### PR TITLE
feat: #1 다마고치 펫 시스템 Phase 2 — 핵심 UI

### DIFF
--- a/feature/home/impl/build.gradle.kts
+++ b/feature/home/impl/build.gradle.kts
@@ -12,6 +12,7 @@ dependencies {
     implementation(projects.feature.home.api)
     implementation(projects.feature.core.resource)
     implementation(projects.feature.memoPlain.api)
+    implementation(projects.feature.pet.api)
     implementation(projects.datasource.local.memo.api)
     implementation(projects.data.repository.memo.api)
     implementation(libs.androidx.lifecycle.runtime.ktx)

--- a/feature/home/impl/src/main/java/me/pecos/memozy/MainActivity.kt
+++ b/feature/home/impl/src/main/java/me/pecos/memozy/MainActivity.kt
@@ -52,6 +52,8 @@ import me.pecos.memozy.data.billing.BillingManager
 import me.pecos.memozy.feature.home.api.HomeRoute
 import me.pecos.memozy.feature.memoplain.api.MemoPlainNavigation
 import me.pecos.memozy.feature.memoplain.api.MemoPlainRoute
+import me.pecos.memozy.feature.pet.PetNavigation
+import me.pecos.memozy.feature.pet.PetRoute
 import me.pecos.memozy.presentation.components.FloatingNavPill
 import me.pecos.memozy.presentation.screen.donation.DonationScreen
 import me.pecos.memozy.presentation.screen.home.HomeScreen
@@ -72,6 +74,7 @@ import javax.inject.Inject
 class MainActivity : AppCompatActivity() {
 
     @Inject lateinit var memoPlainNavigation: MemoPlainNavigation
+    @Inject lateinit var petNavigation: PetNavigation
 
     private val billingManager by lazy { BillingManager(this) }
 
@@ -121,7 +124,7 @@ class MainActivity : AppCompatActivity() {
                         val currentRoute by navController.currentBackStackEntryAsState()
                         val showBottomNav = remember(currentRoute) {
                             currentRoute?.destination?.route in listOf(
-                                HomeRoute.MAIN, HomeRoute.SETTINGS
+                                HomeRoute.MAIN, HomeRoute.SETTINGS, PetRoute.PET
                             )
                         }
 
@@ -169,6 +172,10 @@ class MainActivity : AppCompatActivity() {
                                         billingManager = this@MainActivity.billingManager
                                     )
                                 }
+                                petNavigation.registerGraph(
+                                    navGraphBuilder = this,
+                                    onBack = { navController.popBackStack() }
+                                )
                                 memoPlainNavigation.registerGraph(
                                     navGraphBuilder = this,
                                     onNavigateToHome = {

--- a/feature/home/impl/src/main/java/me/pecos/memozy/presentation/components/BottomNavItem.kt
+++ b/feature/home/impl/src/main/java/me/pecos/memozy/presentation/components/BottomNavItem.kt
@@ -2,8 +2,10 @@ package me.pecos.memozy.presentation.components
 
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.ui.graphics.vector.ImageVector
+import me.pecos.memozy.feature.pet.PetRoute
 
 sealed class BottomNavItem(
     val route: String,
@@ -15,6 +17,11 @@ sealed class BottomNavItem(
         label = "Memo",
         icon = Icons.Default.Edit
     )
+    object Pet : BottomNavItem(
+        route = PetRoute.PET,
+        label = "Pet",
+        icon = Icons.Default.Favorite
+    )
     object Settings : BottomNavItem(
         route = "settings",
         label = "Settings",
@@ -22,4 +29,4 @@ sealed class BottomNavItem(
     )
 }
 
-val bottomNavItems = listOf(BottomNavItem.Memo, BottomNavItem.Settings)
+val bottomNavItems = listOf(BottomNavItem.Memo, BottomNavItem.Pet, BottomNavItem.Settings)

--- a/feature/pet/impl/build.gradle.kts
+++ b/feature/pet/impl/build.gradle.kts
@@ -17,5 +17,6 @@ dependencies {
     implementation(projects.data.repository.memo.api)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.compose.navigation)
+    implementation(libs.hilt.navigation.compose)
     implementation(libs.kotlinx.coroutines.android)
 }

--- a/feature/pet/impl/src/main/java/me/pecos/memozy/feature/pet/PetNavigationImpl.kt
+++ b/feature/pet/impl/src/main/java/me/pecos/memozy/feature/pet/PetNavigationImpl.kt
@@ -1,6 +1,9 @@
 package me.pecos.memozy.feature.pet
 
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavGraphBuilder
+import androidx.navigation.compose.composable
+import me.pecos.memozy.feature.pet.screen.PetScreen
 import javax.inject.Inject
 
 class PetNavigationImpl @Inject constructor() : PetNavigation {
@@ -9,6 +12,9 @@ class PetNavigationImpl @Inject constructor() : PetNavigation {
         navGraphBuilder: NavGraphBuilder,
         onBack: () -> Unit
     ) {
-        // Phase 2에서 구현
+        navGraphBuilder.composable(PetRoute.PET) {
+            val viewModel: PetViewModel = hiltViewModel()
+            PetScreen(viewModel = viewModel)
+        }
     }
 }

--- a/feature/pet/impl/src/main/java/me/pecos/memozy/feature/pet/PetViewModel.kt
+++ b/feature/pet/impl/src/main/java/me/pecos/memozy/feature/pet/PetViewModel.kt
@@ -1,0 +1,124 @@
+package me.pecos.memozy.feature.pet
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import me.pecos.memozy.data.datasource.local.pet.PetSpeciesCatalog
+import me.pecos.memozy.data.datasource.local.pet.entity.Pet
+import me.pecos.memozy.data.repository.pet.PetRepository
+import me.pecos.memozy.feature.pet.model.MoodState
+import me.pecos.memozy.feature.pet.model.PetScreenState
+import me.pecos.memozy.feature.pet.model.PetUiState
+import me.pecos.memozy.feature.pet.model.TimeOfDay
+import java.util.Calendar
+import javax.inject.Inject
+
+@HiltViewModel
+class PetViewModel @Inject constructor(
+    private val petRepository: PetRepository
+) : ViewModel() {
+
+    private val _screenState = MutableStateFlow(PetScreenState.LOADING)
+    val screenState: StateFlow<PetScreenState> = _screenState
+
+    val activePet = petRepository.getActivePet()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
+
+    val petUiState: StateFlow<PetUiState> = combine(
+        activePet, _screenState
+    ) { pet, _ ->
+        pet?.toUiState() ?: PetUiState()
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), PetUiState())
+
+    init {
+        viewModelScope.launch {
+            activePet.collect { pet ->
+                _screenState.value = when {
+                    pet == null -> PetScreenState.NO_PET
+                    pet.name.isBlank() -> PetScreenState.NAMING
+                    else -> PetScreenState.ACTIVE
+                }
+            }
+        }
+        viewModelScope.launch {
+            petRepository.updateMood()
+        }
+    }
+
+    fun hatchPet() {
+        viewModelScope.launch {
+            _screenState.value = PetScreenState.HATCHING
+            petRepository.hatchPet()
+            _screenState.value = PetScreenState.NAMING
+        }
+    }
+
+    fun namePet(name: String) {
+        viewModelScope.launch {
+            petRepository.namePet(name)
+        }
+    }
+
+    fun interactWithPet() {
+        viewModelScope.launch {
+            petRepository.interactWithPet()
+        }
+    }
+
+    fun getSpeciesName(speciesId: String): String {
+        return PetSpeciesCatalog.getById(speciesId)?.id?.replace("_", " ")
+            ?.replaceFirstChar { it.uppercase() } ?: speciesId
+    }
+
+    fun getTimeOfDay(): TimeOfDay {
+        val hour = Calendar.getInstance().get(Calendar.HOUR_OF_DAY)
+        return when {
+            hour in 6..8 -> TimeOfDay.MORNING
+            hour in 9..17 -> TimeOfDay.DAY
+            hour in 18..21 -> TimeOfDay.EVENING
+            else -> TimeOfDay.NIGHT
+        }
+    }
+
+    fun getMoodState(mood: Int): MoodState = MoodState.fromMood(mood)
+
+    fun getExpProgress(pet: PetUiState): Float {
+        val needed = pet.level * 100
+        return if (needed > 0) pet.exp.toFloat() / needed else 0f
+    }
+
+    fun getExpText(pet: PetUiState): String {
+        return "${pet.exp} / ${pet.level * 100}"
+    }
+
+    fun getDaysTogether(pet: PetUiState): Int {
+        if (pet.birthday == 0L) return 0
+        return ((System.currentTimeMillis() - pet.birthday) / 86_400_000L).toInt()
+    }
+
+    fun getRarityStars(rarity: Int): String = "\u2605".repeat(rarity) + "\u2606".repeat(5 - rarity)
+}
+
+private fun Pet.toUiState() = PetUiState(
+    id = id,
+    speciesId = speciesId,
+    name = name,
+    personality = personality,
+    favoriteCategoryId = favoriteCategoryId,
+    dislike = dislike,
+    catchphrase = catchphrase,
+    rarity = rarity,
+    mood = mood,
+    exp = exp,
+    level = level,
+    lastFedAt = lastFedAt,
+    lastInteractionAt = lastInteractionAt,
+    birthday = birthday,
+    isActive = isActive
+)

--- a/feature/pet/impl/src/main/java/me/pecos/memozy/feature/pet/model/PetUiState.kt
+++ b/feature/pet/impl/src/main/java/me/pecos/memozy/feature/pet/model/PetUiState.kt
@@ -1,0 +1,50 @@
+package me.pecos.memozy.feature.pet.model
+
+data class PetUiState(
+    val id: Int = 0,
+    val speciesId: String = "",
+    val name: String = "",
+    val personality: String = "",
+    val favoriteCategoryId: Int = 0,
+    val dislike: String = "",
+    val catchphrase: String = "",
+    val rarity: Int = 1,
+    val mood: Int = 70,
+    val exp: Int = 0,
+    val level: Int = 1,
+    val lastFedAt: Long = 0L,
+    val lastInteractionAt: Long = 0L,
+    val birthday: Long = 0L,
+    val isActive: Boolean = true
+)
+
+enum class PetScreenState {
+    LOADING,
+    NO_PET,
+    HATCHING,
+    NAMING,
+    ACTIVE
+}
+
+enum class TimeOfDay {
+    MORNING,   // 06~09
+    DAY,       // 09~18
+    EVENING,   // 18~22
+    NIGHT      // 22~06
+}
+
+enum class MoodState(val label: String) {
+    HAPPY("happy"),
+    NORMAL("normal"),
+    LONELY("lonely"),
+    SAD("sad");
+
+    companion object {
+        fun fromMood(mood: Int): MoodState = when {
+            mood >= 80 -> HAPPY
+            mood >= 50 -> NORMAL
+            mood >= 20 -> LONELY
+            else -> SAD
+        }
+    }
+}

--- a/feature/pet/impl/src/main/java/me/pecos/memozy/feature/pet/screen/GachaContent.kt
+++ b/feature/pet/impl/src/main/java/me/pecos/memozy/feature/pet/screen/GachaContent.kt
@@ -1,0 +1,131 @@
+package me.pecos.memozy.feature.pet.screen
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import me.pecos.memozy.presentation.theme.LocalAppColors
+
+@Composable
+fun GachaContent(
+    onHatch: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val colors = LocalAppColors.current
+    val scope = rememberCoroutineScope()
+    var tapCount by remember { mutableIntStateOf(0) }
+    val shakeOffset = remember { Animatable(0f) }
+    val scaleAnim = remember { Animatable(1f) }
+
+    Column(
+        modifier = modifier.fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Text(
+            text = if (tapCount == 0) "Tap the egg!" else "Keep tapping! (${tapCount}/3)",
+            color = colors.textTitle,
+            fontSize = 18.sp,
+            fontWeight = FontWeight.SemiBold
+        )
+
+        Spacer(modifier = Modifier.height(32.dp))
+
+        Box(
+            modifier = Modifier
+                .size(160.dp)
+                .offset { IntOffset(shakeOffset.value.toInt(), 0) }
+                .scale(scaleAnim.value)
+                .clip(RoundedCornerShape(32.dp))
+                .background(colors.cardBackground)
+                .clickable(
+                    interactionSource = remember { MutableInteractionSource() },
+                    indication = null
+                ) {
+                    scope.launch {
+                        val newCount = tapCount + 1
+                        tapCount = newCount
+
+                        // Shake animation
+                        launch {
+                            shakeOffset.animateTo(
+                                targetValue = 20f,
+                                animationSpec = tween(50)
+                            )
+                            shakeOffset.animateTo(
+                                targetValue = -20f,
+                                animationSpec = tween(50)
+                            )
+                            shakeOffset.animateTo(
+                                targetValue = 10f,
+                                animationSpec = tween(50)
+                            )
+                            shakeOffset.animateTo(
+                                targetValue = 0f,
+                                animationSpec = spring(stiffness = Spring.StiffnessHigh)
+                            )
+                        }
+
+                        if (newCount >= 3) {
+                            // Hatch: scale up then callback
+                            delay(200)
+                            scaleAnim.animateTo(
+                                targetValue = 1.3f,
+                                animationSpec = tween(200)
+                            )
+                            scaleAnim.animateTo(
+                                targetValue = 0f,
+                                animationSpec = tween(150)
+                            )
+                            onHatch()
+                        }
+                    }
+                },
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = if (tapCount < 3) "\uD83E\uDD5A" else "\uD83D\uDCA5",
+                fontSize = 72.sp
+            )
+        }
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        Text(
+            text = "Who's waiting inside?",
+            color = colors.textSecondary,
+            fontSize = 14.sp,
+            textAlign = TextAlign.Center
+        )
+    }
+}

--- a/feature/pet/impl/src/main/java/me/pecos/memozy/feature/pet/screen/NamePetContent.kt
+++ b/feature/pet/impl/src/main/java/me/pecos/memozy/feature/pet/screen/NamePetContent.kt
@@ -1,0 +1,93 @@
+package me.pecos.memozy.feature.pet.screen
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.material3.Button
+import androidx.compose.material3.OutlinedTextField
+import me.pecos.memozy.presentation.theme.LocalAppColors
+
+@Composable
+fun NamePetContent(
+    speciesName: String,
+    rarity: Int,
+    rarityStars: String,
+    onConfirm: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val colors = LocalAppColors.current
+    var name by remember { mutableStateOf("") }
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(horizontal = 24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Text(
+            text = "\uD83C\uDF89",
+            fontSize = 64.sp
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Text(
+            text = speciesName,
+            color = colors.textTitle,
+            fontSize = 24.sp,
+            fontWeight = FontWeight.Bold
+        )
+
+        Text(
+            text = rarityStars,
+            color = colors.textSecondary,
+            fontSize = 20.sp
+        )
+
+        Spacer(modifier = Modifier.height(32.dp))
+
+        Text(
+            text = "Give your new friend a name!",
+            color = colors.textBody,
+            fontSize = 16.sp,
+            textAlign = TextAlign.Center
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        OutlinedTextField(
+            value = name,
+            onValueChange = { if (it.length <= 12) name = it },
+            placeholder = { Text("Enter a name...") },
+            singleLine = true,
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        Button(
+            onClick = { if (name.isNotBlank()) onConfirm(name.trim()) },
+            enabled = name.isNotBlank(),
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text("Confirm")
+        }
+    }
+}

--- a/feature/pet/impl/src/main/java/me/pecos/memozy/feature/pet/screen/PetMainContent.kt
+++ b/feature/pet/impl/src/main/java/me/pecos/memozy/feature/pet/screen/PetMainContent.kt
@@ -1,0 +1,249 @@
+package me.pecos.memozy.feature.pet.screen
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.foundation.border
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.OutlinedButton
+import me.pecos.memozy.feature.pet.PetViewModel
+import me.pecos.memozy.feature.pet.model.MoodState
+import me.pecos.memozy.feature.pet.model.PetUiState
+import me.pecos.memozy.feature.pet.model.TimeOfDay
+import me.pecos.memozy.presentation.theme.LocalAppColors
+
+@Composable
+fun PetMainContent(
+    pet: PetUiState,
+    viewModel: PetViewModel,
+    modifier: Modifier = Modifier
+) {
+    val colors = LocalAppColors.current
+    val moodState = viewModel.getMoodState(pet.mood)
+    val timeOfDay = viewModel.getTimeOfDay()
+    var showProfile by remember { mutableStateOf(false) }
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(horizontal = 16.dp, vertical = 16.dp)
+    ) {
+        // Top: Name + Level + Rarity
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column {
+                Text(
+                    text = "Lv.${pet.level} ${pet.name}",
+                    color = colors.textTitle,
+                    fontSize = 22.sp,
+                    fontWeight = FontWeight.Bold
+                )
+                Text(
+                    text = viewModel.getRarityStars(pet.rarity),
+                    color = colors.textSecondary,
+                    fontSize = 16.sp
+                )
+            }
+            Text(
+                text = "D+${viewModel.getDaysTogether(pet)}",
+                color = colors.textSecondary,
+                fontSize = 14.sp
+            )
+        }
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        // EXP Bar
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = "EXP",
+                color = colors.textSecondary,
+                fontSize = 12.sp,
+                fontWeight = FontWeight.Medium
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            LinearProgressIndicator(
+                progress = { viewModel.getExpProgress(pet) },
+                modifier = Modifier
+                    .weight(1f)
+                    .height(8.dp)
+                    .clip(RoundedCornerShape(4.dp)),
+                trackColor = colors.cardBorder,
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                text = viewModel.getExpText(pet),
+                color = colors.textSecondary,
+                fontSize = 12.sp
+            )
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        // Mood Bar
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = getMoodEmoji(moodState),
+                fontSize = 14.sp
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            LinearProgressIndicator(
+                progress = { pet.mood / 100f },
+                modifier = Modifier
+                    .weight(1f)
+                    .height(8.dp)
+                    .clip(RoundedCornerShape(4.dp)),
+                trackColor = colors.cardBorder,
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                text = "${pet.mood}/100",
+                color = colors.textSecondary,
+                fontSize = 12.sp
+            )
+        }
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        // Character Area (Placeholder for Phase 3 Rive)
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f)
+                .clip(RoundedCornerShape(24.dp))
+                .background(colors.cardBackground)
+                .clickable(
+                    interactionSource = remember { MutableInteractionSource() },
+                    indication = null
+                ) {
+                    viewModel.interactWithPet()
+                },
+            contentAlignment = Alignment.Center
+        ) {
+            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                Text(
+                    text = getPetEmoji(moodState, timeOfDay),
+                    fontSize = 80.sp
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = getTimeGreeting(timeOfDay),
+                    color = colors.textSecondary,
+                    fontSize = 12.sp
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // Speech Bubble
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(16.dp))
+                .background(colors.chipBackground)
+                .padding(horizontal = 16.dp, vertical = 12.dp)
+        ) {
+            Text(
+                text = getSpeechText(moodState, pet.name),
+                color = colors.chipText,
+                fontSize = 14.sp,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // Bottom Buttons
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            OutlinedButton(
+                onClick = { showProfile = true },
+                modifier = Modifier.weight(1f)
+            ) {
+                Text("Profile")
+            }
+            OutlinedButton(
+                onClick = { /* Phase 4: History */ },
+                modifier = Modifier.weight(1f)
+            ) {
+                Text("Memories")
+            }
+        }
+    }
+
+    if (showProfile) {
+        PetProfileSheet(
+            pet = pet,
+            viewModel = viewModel,
+            onDismiss = { showProfile = false }
+        )
+    }
+}
+
+private fun getMoodEmoji(mood: MoodState): String = when (mood) {
+    MoodState.HAPPY -> "\u2764\uFE0F"
+    MoodState.NORMAL -> "\uD83D\uDE0A"
+    MoodState.LONELY -> "\uD83D\uDE14"
+    MoodState.SAD -> "\uD83D\uDE22"
+}
+
+private fun getPetEmoji(mood: MoodState, time: TimeOfDay): String {
+    if (time == TimeOfDay.NIGHT) return "\uD83D\uDE34"
+    return when (mood) {
+        MoodState.HAPPY -> "\uD83D\uDE3B"
+        MoodState.NORMAL -> "\uD83D\uDE3A"
+        MoodState.LONELY -> "\uD83D\uDE3E"
+        MoodState.SAD -> "\uD83D\uDE40"
+    }
+}
+
+private fun getTimeGreeting(time: TimeOfDay): String = when (time) {
+    TimeOfDay.MORNING -> "Good morning~ *stretches*"
+    TimeOfDay.DAY -> "Let's write some memos!"
+    TimeOfDay.EVENING -> "Getting sleepy~ *yawn*"
+    TimeOfDay.NIGHT -> "Zzz..."
+}
+
+private fun getSpeechText(mood: MoodState, name: String): String = when (mood) {
+    MoodState.HAPPY -> "\uD83D\uDCAC \"Write more memos today~!\""
+    MoodState.NORMAL -> "\uD83D\uDCAC \"Hey there, $name is here!\""
+    MoodState.LONELY -> "\uD83D\uDCAC \"It's been a while... I missed you.\""
+    MoodState.SAD -> "\uD83D\uDCAC \"...\""
+}

--- a/feature/pet/impl/src/main/java/me/pecos/memozy/feature/pet/screen/PetProfileSheet.kt
+++ b/feature/pet/impl/src/main/java/me/pecos/memozy/feature/pet/screen/PetProfileSheet.kt
@@ -1,0 +1,89 @@
+package me.pecos.memozy.feature.pet.screen
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import me.pecos.memozy.feature.pet.PetViewModel
+import me.pecos.memozy.feature.pet.model.PetUiState
+import me.pecos.memozy.presentation.theme.LocalAppColors
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PetProfileSheet(
+    pet: PetUiState,
+    viewModel: PetViewModel,
+    onDismiss: () -> Unit
+) {
+    val colors = LocalAppColors.current
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+        containerColor = colors.cardBackground
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 24.dp, vertical = 16.dp)
+        ) {
+            Text(
+                text = pet.name,
+                color = colors.textTitle,
+                fontSize = 24.sp,
+                fontWeight = FontWeight.Bold
+            )
+            Text(
+                text = viewModel.getRarityStars(pet.rarity),
+                fontSize = 18.sp
+            )
+
+            Spacer(modifier = Modifier.height(20.dp))
+
+            ProfileRow("Species", viewModel.getSpeciesName(pet.speciesId))
+            ProfileRow("Personality", pet.personality.lowercase().replaceFirstChar { it.uppercase() })
+            ProfileRow("Favorite", "Category #${pet.favoriteCategoryId}")
+            ProfileRow("Dislike", pet.dislike.replace("_", " "))
+            ProfileRow("Level", "Lv.${pet.level}")
+            ProfileRow("Mood", "${pet.mood}/100")
+            ProfileRow("Days Together", "D+${viewModel.getDaysTogether(pet)}")
+
+            Spacer(modifier = Modifier.height(24.dp))
+        }
+    }
+}
+
+@Composable
+private fun ProfileRow(label: String, value: String) {
+    val colors = LocalAppColors.current
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 6.dp)
+    ) {
+        Text(
+            text = label,
+            color = colors.textSecondary,
+            fontSize = 14.sp,
+            modifier = Modifier.width(120.dp)
+        )
+        Text(
+            text = value,
+            color = colors.textTitle,
+            fontSize = 14.sp,
+            fontWeight = FontWeight.Medium
+        )
+    }
+}

--- a/feature/pet/impl/src/main/java/me/pecos/memozy/feature/pet/screen/PetScreen.kt
+++ b/feature/pet/impl/src/main/java/me/pecos/memozy/feature/pet/screen/PetScreen.kt
@@ -1,0 +1,61 @@
+package me.pecos.memozy.feature.pet.screen
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import me.pecos.memozy.feature.pet.PetViewModel
+import me.pecos.memozy.feature.pet.model.PetScreenState
+
+@Composable
+fun PetScreen(
+    viewModel: PetViewModel,
+    modifier: Modifier = Modifier
+) {
+    val screenState by viewModel.screenState.collectAsState()
+    val petUiState by viewModel.petUiState.collectAsState()
+
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(bottom = 80.dp)
+    ) {
+        when (screenState) {
+            PetScreenState.LOADING -> {
+                CircularProgressIndicator(
+                    modifier = Modifier.align(Alignment.Center)
+                )
+            }
+            PetScreenState.NO_PET -> {
+                GachaContent(
+                    onHatch = { viewModel.hatchPet() }
+                )
+            }
+            PetScreenState.HATCHING -> {
+                CircularProgressIndicator(
+                    modifier = Modifier.align(Alignment.Center)
+                )
+            }
+            PetScreenState.NAMING -> {
+                NamePetContent(
+                    speciesName = viewModel.getSpeciesName(petUiState.speciesId),
+                    rarity = petUiState.rarity,
+                    rarityStars = viewModel.getRarityStars(petUiState.rarity),
+                    onConfirm = { name -> viewModel.namePet(name) }
+                )
+            }
+            PetScreenState.ACTIVE -> {
+                PetMainContent(
+                    pet = petUiState,
+                    viewModel = viewModel
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- **PetViewModel** (@HiltViewModel): mood/exp/level 계산, 시간대 인식 (아침/낮/저녁/밤)
- **펫 화면 5개** 구현: PetScreen, GachaContent, NamePetContent, PetMainContent, PetProfileSheet
- **하단 네비게이션** 펫 탭 추가: Memo / Pet / Settings (3탭)
- **PetNavigation** graph 등록 + MainActivity 연동

## 화면 흐름

```
펫 탭 클릭
  → 펫 없음? → 알 부화 화면 (탭 3회 → 부화 애니메이션)
  → 이름 짓기 화면 (12자 제한)
  → 펫 메인 화면
      ├── 레벨/이름/등급 ★
      ├── EXP 진행바
      ├── Mood 진행바 (emoji + 수치)
      ├── 캐릭터 영역 (Phase 3 Rive placeholder, 터치 상호작용)
      ├── 말풍선 (mood 상태별 대사)
      └── Profile / Memories 버튼
```

## 주요 파일

| 파일 | 설명 |
|------|------|
| `PetViewModel.kt` | mood 감소 계산, exp/레벨업, 시간대, 터치 상호작용 |
| `PetUiState.kt` | UI 상태 모델 + PetScreenState, TimeOfDay, MoodState enum |
| `PetScreen.kt` | 상태 기반 분기 (LOADING → NO_PET → HATCHING → NAMING → ACTIVE) |
| `GachaContent.kt` | 알 탭 → 흔들림 → scale 애니메이션 → 부화 |
| `NamePetContent.kt` | OutlinedTextField + 확인 버튼 |
| `PetMainContent.kt` | EXP/Mood bar, 캐릭터 placeholder, 말풍선, 프로필/추억 버튼 |
| `PetProfileSheet.kt` | ModalBottomSheet 프로필 카드 |
| `BottomNavItem.kt` | Pet 탭 추가 (Icons.Default.Favorite) |
| `MainActivity.kt` | PetNavigation 주입 + PetRoute 등록 |

## 기존 기능 영향
- HomeScreen / MainViewModel: **변경 없음**
- SettingsScreen: **변경 없음**
- MemoPlain 기능: **변경 없음**
- Phase 1 코드 (Entity, DAO, Repository, Migration): **변경 없음**
- 기존 하단 네비 동작: 유지 (Memo, Settings 탭 그대로)

## Test plan
- [ ] 앱 실행 → 하단에 3개 탭 (Memo / Pet / Settings) 표시 확인
- [ ] Pet 탭 → 알 부화 화면 → 3회 탭 → 부화 애니메이션
- [ ] 이름 짓기 → 입력 후 확인 → 펫 메인 화면 전환
- [ ] 펫 메인: EXP바, Mood바, 캐릭터 영역, 말풍선 표시
- [ ] 캐릭터 터치 → mood +5 반영
- [ ] Profile 버튼 → BottomSheet 프로필 카드
- [ ] 기존 Memo, Settings 탭 정상 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)