### PR TITLE
feat: #1 다마고치 펫 시스템 Phase 3 — Rive 애니메이션

### DIFF
--- a/feature/pet/impl/build.gradle.kts
+++ b/feature/pet/impl/build.gradle.kts
@@ -18,5 +18,6 @@ dependencies {
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.compose.navigation)
     implementation(libs.hilt.navigation.compose)
+    implementation(libs.rive.android)
     implementation(libs.kotlinx.coroutines.android)
 }

--- a/feature/pet/impl/src/main/java/me/pecos/memozy/feature/pet/rive/RiveEggView.kt
+++ b/feature/pet/impl/src/main/java/me/pecos/memozy/feature/pet/rive/RiveEggView.kt
@@ -1,0 +1,79 @@
+package me.pecos.memozy.feature.pet.rive
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.viewinterop.AndroidView
+import app.rive.runtime.kotlin.RiveAnimationView
+import app.rive.runtime.kotlin.core.Rive
+
+/**
+ * Rive wrapper for egg hatching animation.
+ *
+ * State Machine: "EggHatch"
+ * Inputs:
+ *   - tapCount (number, 0~3)
+ *   - hatch (trigger)
+ *
+ * If egg.riv doesn't exist, [fallbackContent] is shown.
+ */
+@Composable
+fun RiveEggView(
+    tapCount: Int = 0,
+    modifier: Modifier = Modifier,
+    fallbackContent: @Composable () -> Unit = {}
+) {
+    val context = LocalContext.current
+    val assetExists = remember {
+        hasAssetFile(context, "egg.riv")
+    }
+
+    if (!assetExists) {
+        Box(modifier = modifier) {
+            fallbackContent()
+        }
+        return
+    }
+
+    var riveView by remember { mutableStateOf<RiveAnimationView?>(null) }
+
+    AndroidView(
+        factory = { ctx ->
+            Rive.init(ctx)
+            RiveAnimationView(ctx).apply {
+                try {
+                    val inputStream = ctx.assets.open("egg.riv")
+                    setRiveBytes(
+                        inputStream.readBytes(),
+                        stateMachineName = "EggHatch",
+                        autoplay = true
+                    )
+                    inputStream.close()
+                } catch (_: Exception) { }
+            }.also { riveView = it }
+        },
+        modifier = modifier.fillMaxSize(),
+        update = { _ ->
+            riveView?.let { view ->
+                try {
+                    view.setNumberState("EggHatch", "tapCount", tapCount.toFloat())
+                } catch (_: Exception) { }
+            }
+        },
+        onRelease = { riveView = null }
+    )
+}
+
+private fun hasAssetFile(context: android.content.Context, fileName: String): Boolean {
+    return try {
+        context.assets.open(fileName).use { true }
+    } catch (_: Exception) {
+        false
+    }
+}

--- a/feature/pet/impl/src/main/java/me/pecos/memozy/feature/pet/rive/RiveMiniPetView.kt
+++ b/feature/pet/impl/src/main/java/me/pecos/memozy/feature/pet/rive/RiveMiniPetView.kt
@@ -1,0 +1,68 @@
+package me.pecos.memozy.feature.pet.rive
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.viewinterop.AndroidView
+import app.rive.runtime.kotlin.RiveAnimationView
+import app.rive.runtime.kotlin.core.Rive
+
+/**
+ * Mini Rive pet for bottom navigation bar.
+ * Shows a small version of the pet character.
+ * Falls back to emoji if no .riv asset.
+ */
+@Composable
+fun RiveMiniPetView(
+    riveAssetName: String,
+    modifier: Modifier = Modifier
+) {
+    val context = LocalContext.current
+    val assetExists = remember(riveAssetName) {
+        try {
+            context.assets.open(riveAssetName).use { true }
+        } catch (_: Exception) { false }
+    }
+
+    if (!assetExists) {
+        // Emoji fallback — small pet face
+        Box(
+            modifier = modifier.size(24.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(text = "\uD83D\uDC3E", fontSize = 16.sp)
+        }
+        return
+    }
+
+    var riveView by remember { mutableStateOf<RiveAnimationView?>(null) }
+
+    AndroidView(
+        factory = { ctx ->
+            Rive.init(ctx)
+            RiveAnimationView(ctx).apply {
+                try {
+                    val inputStream = ctx.assets.open(riveAssetName)
+                    setRiveBytes(
+                        inputStream.readBytes(),
+                        stateMachineName = "PetBehavior",
+                        autoplay = true
+                    )
+                    inputStream.close()
+                } catch (_: Exception) { }
+            }.also { riveView = it }
+        },
+        modifier = modifier.size(24.dp),
+        onRelease = { riveView = null }
+    )
+}

--- a/feature/pet/impl/src/main/java/me/pecos/memozy/feature/pet/rive/RivePetView.kt
+++ b/feature/pet/impl/src/main/java/me/pecos/memozy/feature/pet/rive/RivePetView.kt
@@ -1,0 +1,107 @@
+package me.pecos.memozy.feature.pet.rive
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.viewinterop.AndroidView
+import app.rive.runtime.kotlin.RiveAnimationView
+import app.rive.runtime.kotlin.core.Rive
+
+/**
+ * Compose wrapper for Rive pet animation.
+ *
+ * State Machine: "PetBehavior"
+ * Inputs:
+ *   - mood (number, 0~100)
+ *   - timeOfDay (number, 0=morning, 1=day, 2=evening, 3=night)
+ *   - isTouching (boolean)
+ *   - memoSaved (trigger)
+ *   - levelUp (trigger)
+ *
+ * If the .riv asset doesn't exist, [fallbackContent] is shown.
+ * To enable Rive: drop the .riv file into assets/ folder.
+ */
+@Composable
+fun RivePetView(
+    riveAssetName: String,
+    stateMachineName: String = "PetBehavior",
+    mood: Int = 70,
+    timeOfDay: Int = 1,
+    isTouching: Boolean = false,
+    modifier: Modifier = Modifier,
+    fallbackContent: @Composable () -> Unit = {}
+) {
+    val context = LocalContext.current
+    val assetExists = remember(riveAssetName) {
+        hasAssetFile(context, riveAssetName)
+    }
+
+    if (!assetExists) {
+        Box(modifier = modifier) {
+            fallbackContent()
+        }
+        return
+    }
+
+    var riveView by remember { mutableStateOf<RiveAnimationView?>(null) }
+
+    AndroidView(
+        factory = { ctx ->
+            Rive.init(ctx)
+            RiveAnimationView(ctx).apply {
+                try {
+                    val inputStream = ctx.assets.open(riveAssetName)
+                    setRiveBytes(
+                        inputStream.readBytes(),
+                        stateMachineName = stateMachineName,
+                        autoplay = true
+                    )
+                    inputStream.close()
+                } catch (_: Exception) { }
+            }.also { riveView = it }
+        },
+        modifier = modifier.fillMaxSize(),
+        onRelease = { view ->
+            riveView = null
+        }
+    )
+
+    // Reactively update state machine inputs
+    LaunchedEffect(mood) {
+        riveView?.setNumberState(stateMachineName, "mood", mood.toFloat())
+    }
+    LaunchedEffect(timeOfDay) {
+        riveView?.setNumberState(stateMachineName, "timeOfDay", timeOfDay.toFloat())
+    }
+    LaunchedEffect(isTouching) {
+        riveView?.setBooleanState(stateMachineName, "isTouching", isTouching)
+    }
+}
+
+/**
+ * Fire a one-shot trigger on the state machine.
+ */
+fun RiveAnimationView.firePetTrigger(
+    triggerName: String,
+    stateMachineName: String = "PetBehavior"
+) {
+    try {
+        fireState(stateMachineName, triggerName)
+    } catch (_: Exception) { }
+}
+
+private fun hasAssetFile(context: android.content.Context, fileName: String): Boolean {
+    return try {
+        context.assets.open(fileName).use { true }
+    } catch (_: Exception) {
+        false
+    }
+}

--- a/feature/pet/impl/src/main/java/me/pecos/memozy/feature/pet/screen/GachaContent.kt
+++ b/feature/pet/impl/src/main/java/me/pecos/memozy/feature/pet/screen/GachaContent.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import me.pecos.memozy.feature.pet.rive.RiveEggView
 import me.pecos.memozy.presentation.theme.LocalAppColors
 
 @Composable
@@ -113,9 +114,21 @@ fun GachaContent(
                 },
             contentAlignment = Alignment.Center
         ) {
-            Text(
-                text = if (tapCount < 3) "\uD83E\uDD5A" else "\uD83D\uDCA5",
-                fontSize = 72.sp
+            // Rive egg animation with emoji fallback
+            RiveEggView(
+                tapCount = tapCount,
+                modifier = Modifier.fillMaxSize(),
+                fallbackContent = {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(
+                            text = if (tapCount < 3) "\uD83E\uDD5A" else "\uD83D\uDCA5",
+                            fontSize = 72.sp
+                        )
+                    }
+                }
             )
         }
 

--- a/feature/pet/impl/src/main/java/me/pecos/memozy/feature/pet/screen/PetMainContent.kt
+++ b/feature/pet/impl/src/main/java/me/pecos/memozy/feature/pet/screen/PetMainContent.kt
@@ -34,6 +34,7 @@ import me.pecos.memozy.feature.pet.PetViewModel
 import me.pecos.memozy.feature.pet.model.MoodState
 import me.pecos.memozy.feature.pet.model.PetUiState
 import me.pecos.memozy.feature.pet.model.TimeOfDay
+import me.pecos.memozy.feature.pet.rive.RivePetView
 import me.pecos.memozy.presentation.theme.LocalAppColors
 
 @Composable
@@ -138,7 +139,7 @@ fun PetMainContent(
 
         Spacer(modifier = Modifier.height(24.dp))
 
-        // Character Area (Placeholder for Phase 3 Rive)
+        // Character Area — Rive animation with emoji fallback
         Box(
             modifier = Modifier
                 .fillMaxWidth()
@@ -153,18 +154,37 @@ fun PetMainContent(
                 },
             contentAlignment = Alignment.Center
         ) {
-            Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                Text(
-                    text = getPetEmoji(moodState, timeOfDay),
-                    fontSize = 80.sp
-                )
-                Spacer(modifier = Modifier.height(8.dp))
-                Text(
-                    text = getTimeGreeting(timeOfDay),
-                    color = colors.textSecondary,
-                    fontSize = 12.sp
-                )
-            }
+            RivePetView(
+                riveAssetName = "${pet.speciesId}.riv",
+                mood = pet.mood,
+                timeOfDay = when (timeOfDay) {
+                    TimeOfDay.MORNING -> 0
+                    TimeOfDay.DAY -> 1
+                    TimeOfDay.EVENING -> 2
+                    TimeOfDay.NIGHT -> 3
+                },
+                isTouching = false,
+                modifier = Modifier.fillMaxSize(),
+                fallbackContent = {
+                    // Emoji fallback when .riv file is not available
+                    Column(
+                        modifier = Modifier.fillMaxSize(),
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.Center
+                    ) {
+                        Text(
+                            text = getPetEmoji(moodState, timeOfDay),
+                            fontSize = 80.sp
+                        )
+                        Spacer(modifier = Modifier.height(8.dp))
+                        Text(
+                            text = getTimeGreeting(timeOfDay),
+                            color = colors.textSecondary,
+                            fontSize = 12.sp
+                        )
+                    }
+                }
+            )
         }
 
         Spacer(modifier = Modifier.height(16.dp))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,6 +20,7 @@ hilt = "2.59.2"
 hiltNavigationCompose = "1.2.0"
 navigationCompose = "2.8.9"
 kotlinxCoroutines = "1.10.2"
+riveAndroid = "10.2.0"
 
 [libraries]
 gradlePlugin-android = { module = "com.android.tools.build:gradle", version.ref = "agp" }
@@ -50,6 +51,7 @@ androidx-compose-foundation-layout = { group = "androidx.compose.foundation", na
 androidx-compose-navigation = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose"  }
 kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "kotlinxCoroutines" }
 montage-android = { module = "com.github.wanteddev:montage-android", version.ref = "montageAndroid" }
+rive-android = { group = "app.rive", name = "rive-android", version.ref = "riveAndroid" }
 room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
 room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
 room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }


### PR DESCRIPTION
## Summary
- **Rive Android SDK 10.2.0** 의존성 추가
- **RivePetView** Compose wrapper: 펫 캐릭터 상태 머신 바인딩 (mood, timeOfDay, isTouching, memoSaved, levelUp)
- **RiveEggView** Compose wrapper: 알 부화 애니메이션 (tapCount 입력)
- **RiveMiniPetView**: 하단 네비 미니펫 렌더링 구조
- PetMainContent/GachaContent에 Rive 적용 + **emoji fallback 자동 전환**

## 디자이너 협업 포인트

.riv 파일이 없으면 자동으로 emoji fallback이 표시됩니다. 디자이너는 아래 파일만 `assets/`에 넣으면 됩니다:

| 파일명 | 용도 | State Machine |
|--------|------|---------------|
| `{speciesId}.riv` (예: cloud_fox.riv) | 펫 캐릭터 | PetBehavior: mood(0~100), timeOfDay(0~3), isTouching, memoSaved, levelUp |
| `egg.riv` | 알 부화 연출 | EggHatch: tapCount(0~3), hatch |

## 주요 파일

| 파일 | 설명 |
|------|------|
| `RivePetView.kt` | 메인 캐릭터 wrapper — mood/time/touch 반응형 바인딩 |
| `RiveEggView.kt` | 알 부화 wrapper — tap 카운트 연동 |
| `RiveMiniPetView.kt` | 네비바 미니펫 (24dp) |
| `PetMainContent.kt` | emoji → RivePetView 교체 |
| `GachaContent.kt` | emoji → RiveEggView 교체 |
| `libs.versions.toml` | rive-android = 10.2.0 추가 |

## 기존 기능 영향
- Phase 1, 2 코드: **변경 없음** (PetMainContent, GachaContent만 Rive 교체)
- .riv 없으면 기존 emoji 동작 그대로 유지

## Test plan
- [ ] 앱 빌드 성공 확인
- [ ] .riv 파일 없는 상태에서 emoji fallback 정상 표시
- [ ] (디자이너 에셋 후) .riv 파일 추가 시 Rive 애니메이션 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)