### PR TITLE
feat: #1 다마고치 펫 시스템 Phase 4 — 가챠 연출 + 추억 앨범

### DIFF
--- a/feature/home/impl/src/main/java/me/pecos/memozy/MainActivity.kt
+++ b/feature/home/impl/src/main/java/me/pecos/memozy/MainActivity.kt
@@ -174,6 +174,9 @@ class MainActivity : AppCompatActivity() {
                                 }
                                 petNavigation.registerGraph(
                                     navGraphBuilder = this,
+                                    onNavigateToHistory = {
+                                        navController.navigate(PetRoute.HISTORY)
+                                    },
                                     onBack = { navController.popBackStack() }
                                 )
                                 memoPlainNavigation.registerGraph(

--- a/feature/pet/api/src/main/java/me/pecos/memozy/feature/pet/PetNavigation.kt
+++ b/feature/pet/api/src/main/java/me/pecos/memozy/feature/pet/PetNavigation.kt
@@ -11,6 +11,7 @@ object PetRoute {
 interface PetNavigation {
     fun registerGraph(
         navGraphBuilder: NavGraphBuilder,
+        onNavigateToHistory: () -> Unit,
         onBack: () -> Unit
     )
 }

--- a/feature/pet/impl/src/main/java/me/pecos/memozy/feature/pet/PetNavigationImpl.kt
+++ b/feature/pet/impl/src/main/java/me/pecos/memozy/feature/pet/PetNavigationImpl.kt
@@ -3,6 +3,7 @@ package me.pecos.memozy.feature.pet
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
+import me.pecos.memozy.feature.pet.screen.PetHistoryScreen
 import me.pecos.memozy.feature.pet.screen.PetScreen
 import javax.inject.Inject
 
@@ -10,11 +11,22 @@ class PetNavigationImpl @Inject constructor() : PetNavigation {
 
     override fun registerGraph(
         navGraphBuilder: NavGraphBuilder,
+        onNavigateToHistory: () -> Unit,
         onBack: () -> Unit
     ) {
         navGraphBuilder.composable(PetRoute.PET) {
             val viewModel: PetViewModel = hiltViewModel()
-            PetScreen(viewModel = viewModel)
+            PetScreen(
+                viewModel = viewModel,
+                onNavigateToHistory = onNavigateToHistory
+            )
+        }
+        navGraphBuilder.composable(PetRoute.HISTORY) {
+            val viewModel: PetViewModel = hiltViewModel()
+            PetHistoryScreen(
+                viewModel = viewModel,
+                onBack = onBack
+            )
         }
     }
 }

--- a/feature/pet/impl/src/main/java/me/pecos/memozy/feature/pet/PetViewModel.kt
+++ b/feature/pet/impl/src/main/java/me/pecos/memozy/feature/pet/PetViewModel.kt
@@ -55,8 +55,12 @@ class PetViewModel @Inject constructor(
         viewModelScope.launch {
             _screenState.value = PetScreenState.HATCHING
             petRepository.hatchPet()
-            _screenState.value = PetScreenState.NAMING
+            _screenState.value = PetScreenState.HATCH_RESULT
         }
+    }
+
+    fun proceedToNaming() {
+        _screenState.value = PetScreenState.NAMING
     }
 
     fun namePet(name: String) {
@@ -65,11 +69,29 @@ class PetViewModel @Inject constructor(
         }
     }
 
+    fun startDeparting() {
+        _screenState.value = PetScreenState.DEPARTING
+    }
+
+    fun cancelDeparting() {
+        _screenState.value = PetScreenState.ACTIVE
+    }
+
+    fun rerollPet() {
+        viewModelScope.launch {
+            petRepository.rerollPet()
+            _screenState.value = PetScreenState.HATCH_RESULT
+        }
+    }
+
     fun interactWithPet() {
         viewModelScope.launch {
             petRepository.interactWithPet()
         }
     }
+
+    val petHistory = petRepository.getPetHistory()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
 
     fun getSpeciesName(speciesId: String): String {
         return PetSpeciesCatalog.getById(speciesId)?.id?.replace("_", " ")

--- a/feature/pet/impl/src/main/java/me/pecos/memozy/feature/pet/model/PetUiState.kt
+++ b/feature/pet/impl/src/main/java/me/pecos/memozy/feature/pet/model/PetUiState.kt
@@ -22,8 +22,10 @@ enum class PetScreenState {
     LOADING,
     NO_PET,
     HATCHING,
+    HATCH_RESULT,
     NAMING,
-    ACTIVE
+    ACTIVE,
+    DEPARTING
 }
 
 enum class TimeOfDay {

--- a/feature/pet/impl/src/main/java/me/pecos/memozy/feature/pet/screen/DepartContent.kt
+++ b/feature/pet/impl/src/main/java/me/pecos/memozy/feature/pet/screen/DepartContent.kt
@@ -1,0 +1,157 @@
+package me.pecos.memozy.feature.pet.screen
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import me.pecos.memozy.feature.pet.PetViewModel
+import me.pecos.memozy.feature.pet.model.PetUiState
+import me.pecos.memozy.presentation.theme.LocalAppColors
+
+/**
+ * Departure confirmation screen.
+ * Shows pet stats and asks user to confirm sending the pet away.
+ */
+@Composable
+fun DepartContent(
+    pet: PetUiState,
+    viewModel: PetViewModel,
+    onConfirmDepart: () -> Unit,
+    onCancel: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val colors = LocalAppColors.current
+    val daysTogether = viewModel.getDaysTogether(pet)
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(horizontal = 24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Text(
+            text = "${pet.name} is leaving...",
+            color = colors.textTitle,
+            fontSize = 22.sp,
+            fontWeight = FontWeight.Bold,
+            textAlign = TextAlign.Center
+        )
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        // Pet waving goodbye
+        Text(
+            text = "\uD83D\uDC4B",
+            fontSize = 72.sp
+        )
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        // Stats card
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(20.dp))
+                .background(colors.cardBackground)
+                .padding(20.dp)
+        ) {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                StatRow("Days Together", "D+$daysTogether")
+                StatRow("Level Reached", "Lv.${pet.level}")
+                StatRow("Species", viewModel.getSpeciesName(pet.speciesId))
+                StatRow("Rarity", viewModel.getRarityStars(pet.rarity))
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                // Last words
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clip(RoundedCornerShape(12.dp))
+                        .background(colors.chipBackground)
+                        .padding(12.dp)
+                ) {
+                    Text(
+                        text = "\uD83D\uDCAC \"Thanks for everything... Take care of the next one!\"",
+                        color = colors.chipText,
+                        fontSize = 13.sp,
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                }
+            }
+        }
+
+        Spacer(modifier = Modifier.height(32.dp))
+
+        // Buttons
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            OutlinedButton(
+                onClick = onCancel,
+                modifier = Modifier.weight(1f)
+            ) {
+                Text("Stay Together")
+            }
+            Button(
+                onClick = onConfirmDepart,
+                modifier = Modifier.weight(1f),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = Color(0xFFE57373)
+                )
+            ) {
+                Text("Say Goodbye", color = Color.White)
+            }
+        }
+    }
+}
+
+@Composable
+private fun StatRow(label: String, value: String) {
+    val colors = LocalAppColors.current
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp),
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Text(
+            text = label,
+            color = colors.textSecondary,
+            fontSize = 14.sp
+        )
+        Text(
+            text = value,
+            color = colors.textTitle,
+            fontSize = 14.sp,
+            fontWeight = FontWeight.Medium
+        )
+    }
+}

--- a/feature/pet/impl/src/main/java/me/pecos/memozy/feature/pet/screen/HatchResultContent.kt
+++ b/feature/pet/impl/src/main/java/me/pecos/memozy/feature/pet/screen/HatchResultContent.kt
@@ -1,0 +1,190 @@
+package me.pecos.memozy.feature.pet.screen
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.slideInVertically
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import kotlinx.coroutines.delay
+import me.pecos.memozy.feature.pet.model.PetUiState
+import me.pecos.memozy.presentation.theme.LocalAppColors
+
+/**
+ * Hatch result screen — shown after egg breaks.
+ * Character appears with fade-in, then profile card slides up.
+ */
+@Composable
+fun HatchResultContent(
+    pet: PetUiState,
+    speciesName: String,
+    rarityStars: String,
+    onContinue: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val colors = LocalAppColors.current
+    var showCharacter by remember { mutableStateOf(false) }
+    var showCard by remember { mutableStateOf(false) }
+
+    LaunchedEffect(Unit) {
+        delay(300)
+        showCharacter = true
+        delay(600)
+        showCard = true
+    }
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(horizontal = 24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        // Character appear with fade
+        AnimatedVisibility(
+            visible = showCharacter,
+            enter = fadeIn(animationSpec = tween(500))
+        ) {
+            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                Text(
+                    text = "\u2728",
+                    fontSize = 32.sp
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = "\uD83D\uDE3A",
+                    fontSize = 96.sp
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        // Profile card slide up
+        AnimatedVisibility(
+            visible = showCard,
+            enter = slideInVertically(
+                initialOffsetY = { it },
+                animationSpec = tween(400)
+            ) + fadeIn(animationSpec = tween(400))
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(20.dp))
+                    .background(colors.cardBackground)
+                    .padding(24.dp)
+            ) {
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text(
+                        text = "New Friend!",
+                        color = colors.textTitle,
+                        fontSize = 20.sp,
+                        fontWeight = FontWeight.Bold
+                    )
+
+                    Spacer(modifier = Modifier.height(12.dp))
+
+                    Text(
+                        text = speciesName,
+                        color = colors.textTitle,
+                        fontSize = 18.sp,
+                        fontWeight = FontWeight.SemiBold
+                    )
+
+                    Text(
+                        text = rarityStars,
+                        fontSize = 20.sp
+                    )
+
+                    Spacer(modifier = Modifier.height(12.dp))
+
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceEvenly
+                    ) {
+                        InfoChip(label = "Personality", value = pet.personality.lowercase()
+                            .replaceFirstChar { it.uppercase() })
+                        InfoChip(label = "Favorite", value = "#${pet.favoriteCategoryId}")
+                    }
+
+                    Spacer(modifier = Modifier.height(20.dp))
+
+                    Text(
+                        text = "Tap to name your pet!",
+                        color = colors.chipText,
+                        fontSize = 14.sp,
+                        fontWeight = FontWeight.Medium,
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier
+                            .clip(RoundedCornerShape(12.dp))
+                            .background(colors.chipBackground)
+                            .padding(horizontal = 20.dp, vertical = 10.dp)
+                            .fillMaxWidth()
+                            .then(
+                                Modifier.clickableNoRipple { onContinue() }
+                            )
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun InfoChip(label: String, value: String) {
+    val colors = LocalAppColors.current
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Text(
+            text = label,
+            color = colors.textSecondary,
+            fontSize = 11.sp
+        )
+        Text(
+            text = value,
+            color = colors.textTitle,
+            fontSize = 14.sp,
+            fontWeight = FontWeight.Medium
+        )
+    }
+}
+
+// Utility: clickable without ripple
+@Composable
+private fun Modifier.clickableNoRipple(onClick: () -> Unit): Modifier {
+    return this.then(
+        Modifier.clickable(
+            interactionSource = remember { androidx.compose.foundation.interaction.MutableInteractionSource() },
+            indication = null,
+            onClick = onClick
+        )
+    )
+}

--- a/feature/pet/impl/src/main/java/me/pecos/memozy/feature/pet/screen/PetHistoryScreen.kt
+++ b/feature/pet/impl/src/main/java/me/pecos/memozy/feature/pet/screen/PetHistoryScreen.kt
@@ -1,0 +1,183 @@
+package me.pecos.memozy.feature.pet.screen
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import me.pecos.memozy.data.datasource.local.pet.entity.PetHistory
+import me.pecos.memozy.feature.pet.PetViewModel
+import me.pecos.memozy.presentation.theme.LocalAppColors
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PetHistoryScreen(
+    viewModel: PetViewModel,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val colors = LocalAppColors.current
+    val history by viewModel.petHistory.collectAsState()
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .background(colors.screenBackground)
+    ) {
+        TopAppBar(
+            title = {
+                Text(
+                    text = "Memories",
+                    color = colors.topbarTitle,
+                    fontWeight = FontWeight.Bold
+                )
+            },
+            navigationIcon = {
+                IconButton(onClick = onBack) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = "Back",
+                        tint = colors.topbarTitle
+                    )
+                }
+            },
+            colors = TopAppBarDefaults.topAppBarColors(
+                containerColor = colors.screenBackground
+            )
+        )
+
+        if (history.isEmpty()) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(32.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Text(
+                        text = "\uD83D\uDCED",
+                        fontSize = 48.sp
+                    )
+                    Spacer(modifier = Modifier.height(16.dp))
+                    Text(
+                        text = "No memories yet.\nYour departed friends will be remembered here.",
+                        color = colors.textSecondary,
+                        fontSize = 14.sp,
+                        textAlign = TextAlign.Center
+                    )
+                }
+            }
+        } else {
+            LazyColumn(
+                contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                items(history) { pet ->
+                    PetHistoryCard(pet = pet, viewModel = viewModel)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun PetHistoryCard(
+    pet: PetHistory,
+    viewModel: PetViewModel
+) {
+    val colors = LocalAppColors.current
+    val dateFormat = SimpleDateFormat("yyyy.MM.dd", Locale.getDefault())
+
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(16.dp))
+            .background(colors.cardBackground)
+            .padding(16.dp)
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            // Pet emoji
+            Text(
+                text = "\uD83D\uDE3A",
+                fontSize = 36.sp
+            )
+
+            Spacer(modifier = Modifier.width(16.dp))
+
+            Column(modifier = Modifier.weight(1f)) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Text(
+                        text = pet.name,
+                        color = colors.textTitle,
+                        fontSize = 16.sp,
+                        fontWeight = FontWeight.Bold
+                    )
+                    Text(
+                        text = viewModel.getRarityStars(pet.rarity),
+                        fontSize = 14.sp
+                    )
+                }
+
+                Text(
+                    text = viewModel.getSpeciesName(pet.speciesId),
+                    color = colors.textSecondary,
+                    fontSize = 13.sp
+                )
+
+                Spacer(modifier = Modifier.height(4.dp))
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Text(
+                        text = "Lv.${pet.level} \u00B7 D+${pet.daysTogether}",
+                        color = colors.textSecondary,
+                        fontSize = 12.sp
+                    )
+                    Text(
+                        text = "Departed ${dateFormat.format(Date(pet.departedAt))}",
+                        color = colors.textSecondary,
+                        fontSize = 11.sp
+                    )
+                }
+            }
+        }
+    }
+}

--- a/feature/pet/impl/src/main/java/me/pecos/memozy/feature/pet/screen/PetMainContent.kt
+++ b/feature/pet/impl/src/main/java/me/pecos/memozy/feature/pet/screen/PetMainContent.kt
@@ -41,6 +41,7 @@ import me.pecos.memozy.presentation.theme.LocalAppColors
 fun PetMainContent(
     pet: PetUiState,
     viewModel: PetViewModel,
+    onNavigateToHistory: () -> Unit = {},
     modifier: Modifier = Modifier
 ) {
     val colors = LocalAppColors.current
@@ -220,10 +221,16 @@ fun PetMainContent(
                 Text("Profile")
             }
             OutlinedButton(
-                onClick = { /* Phase 4: History */ },
+                onClick = onNavigateToHistory,
                 modifier = Modifier.weight(1f)
             ) {
                 Text("Memories")
+            }
+            OutlinedButton(
+                onClick = { viewModel.startDeparting() },
+                modifier = Modifier.weight(1f)
+            ) {
+                Text("Reroll")
             }
         }
     }

--- a/feature/pet/impl/src/main/java/me/pecos/memozy/feature/pet/screen/PetScreen.kt
+++ b/feature/pet/impl/src/main/java/me/pecos/memozy/feature/pet/screen/PetScreen.kt
@@ -16,6 +16,7 @@ import me.pecos.memozy.feature.pet.model.PetScreenState
 @Composable
 fun PetScreen(
     viewModel: PetViewModel,
+    onNavigateToHistory: () -> Unit = {},
     modifier: Modifier = Modifier
 ) {
     val screenState by viewModel.screenState.collectAsState()
@@ -42,6 +43,14 @@ fun PetScreen(
                     modifier = Modifier.align(Alignment.Center)
                 )
             }
+            PetScreenState.HATCH_RESULT -> {
+                HatchResultContent(
+                    pet = petUiState,
+                    speciesName = viewModel.getSpeciesName(petUiState.speciesId),
+                    rarityStars = viewModel.getRarityStars(petUiState.rarity),
+                    onContinue = { viewModel.proceedToNaming() }
+                )
+            }
             PetScreenState.NAMING -> {
                 NamePetContent(
                     speciesName = viewModel.getSpeciesName(petUiState.speciesId),
@@ -53,7 +62,16 @@ fun PetScreen(
             PetScreenState.ACTIVE -> {
                 PetMainContent(
                     pet = petUiState,
-                    viewModel = viewModel
+                    viewModel = viewModel,
+                    onNavigateToHistory = onNavigateToHistory
+                )
+            }
+            PetScreenState.DEPARTING -> {
+                DepartContent(
+                    pet = petUiState,
+                    viewModel = viewModel,
+                    onConfirmDepart = { viewModel.rerollPet() },
+                    onCancel = { viewModel.cancelDeparting() }
                 )
             }
         }


### PR DESCRIPTION
## Summary
- **부화 연출 완성**: 캐릭터 fade-in → 프로필 카드 slide-up → 이름 짓기 전환
- **떠남 연출**: 함께한 일수/레벨/등급 표시 + 마지막 인사 + Stay/Goodbye 선택
- **추억 앨범**: 떠난 펫 목록 (이름, 종족, 레벨, 함께한 일수, 떠난 날짜)
- **리롤 흐름**: Reroll 버튼 → 떠남 확인 → 새 알 부화

## 화면 흐름

```
부화 완료 → HatchResultContent (프로필 카드)
         → NamePetContent (이름 짓기)
         → PetMainContent (메인)
                ├── Profile → BottomSheet
                ├── Memories → PetHistoryScreen
                └── Reroll → DepartContent
                              ├── Say Goodbye → 떠남 + 새 부화
                              └── Stay Together → 취소
```

## 주요 파일

| 파일 | 설명 |
|------|------|
| `HatchResultContent.kt` | 부화 결과 — 캐릭터 등장 + 프로필 카드 애니메이션 |
| `DepartContent.kt` | 떠남 확인 — 통계 + 마지막 인사 + 선택 버튼 |
| `PetHistoryScreen.kt` | 추억 앨범 — TopAppBar + LazyColumn 카드 리스트 |
| `PetViewModel.kt` | rerollPet, startDeparting, cancelDeparting, petHistory 추가 |
| `PetUiState.kt` | HATCH_RESULT, DEPARTING 상태 추가 |
| `PetScreen.kt` | 새 상태들 when 분기 연결 |
| `PetMainContent.kt` | Reroll 버튼 + Memories 네비게이션 |
| `PetNavigation.kt` | onNavigateToHistory 콜백 추가 |

## 기존 기능 영향
- Phase 1~3 코드: **변경 최소** (PetViewModel, PetScreen, PetMainContent 확장만)
- Home/Settings/MemoPlain: **변경 없음** (MainActivity에 history 네비 콜백만 추가)

## Test plan
- [ ] 알 부화 → 프로필 카드 슬라이드업 → 이름 짓기 흐름
- [ ] 리롤: Reroll → 떠남 확인 → Say Goodbye → 새 알 부화
- [ ] 리롤 취소: Stay Together → 기존 펫 유지
- [ ] 추억 앨범: Memories → 떠난 펫 목록 표시
- [ ] 추억 앨범: 빈 상태 → empty state 메시지

🤖 Generated with [Claude Code](https://claude.com/claude-code)