### PR TITLE
feat: #1 다마고치 펫 시스템 Phase 5 — 대사 시스템 + 출석 보상

### DIFF
--- a/data/repository/pet/api/src/main/java/me/pecos/memozy/data/repository/pet/PetRepository.kt
+++ b/data/repository/pet/api/src/main/java/me/pecos/memozy/data/repository/pet/PetRepository.kt
@@ -13,4 +13,5 @@ interface PetRepository {
     suspend fun updateMood()
     suspend fun namePet(name: String)
     fun getPetHistory(): Flow<List<PetHistory>>
+    suspend fun feedPetWithStreakBonus(memoCount: Int, consecutiveDays: Int)
 }

--- a/data/repository/pet/impl/src/main/java/me/pecos/memozy/data/repository/pet/PetRepositoryImpl.kt
+++ b/data/repository/pet/impl/src/main/java/me/pecos/memozy/data/repository/pet/PetRepositoryImpl.kt
@@ -109,6 +109,34 @@ class PetRepositoryImpl @Inject constructor(
 
     override fun getPetHistory(): Flow<List<PetHistory>> = petDao.getPetHistory()
 
+    override suspend fun feedPetWithStreakBonus(memoCount: Int, consecutiveDays: Int) {
+        val pet = petDao.getActivePet().first() ?: return
+
+        val moodGain = (memoCount * 10).coerceAtMost(30)
+        val baseExp = memoCount * 20
+        val streakBonus = when {
+            consecutiveDays >= 7 -> 100
+            consecutiveDays >= 3 -> 50
+            else -> 0
+        }
+        val totalExp = baseExp + streakBonus
+
+        val newMood = (pet.mood + moodGain).coerceAtMost(100)
+        val newExp = pet.exp + totalExp
+        val levelUp = newExp >= pet.level * 100
+        val finalExp = if (levelUp) newExp - (pet.level * 100) else newExp
+        val finalLevel = if (levelUp) pet.level + 1 else pet.level
+
+        petDao.updatePet(
+            pet.copy(
+                mood = newMood,
+                exp = finalExp,
+                level = finalLevel,
+                lastFedAt = System.currentTimeMillis()
+            )
+        )
+    }
+
     private fun rollRarity(): Int {
         val roll = Random.nextInt(100)
         return when {

--- a/feature/pet/impl/src/main/java/me/pecos/memozy/feature/pet/model/PetDialogue.kt
+++ b/feature/pet/impl/src/main/java/me/pecos/memozy/feature/pet/model/PetDialogue.kt
@@ -1,0 +1,114 @@
+package me.pecos.memozy.feature.pet.model
+
+/**
+ * Dialogue system: Personality x MoodState x TimeOfDay combinations.
+ * Returns a random line for the current state.
+ */
+object PetDialogue {
+
+    fun getLine(personality: String, mood: MoodState, time: TimeOfDay): String {
+        val key = personality.uppercase()
+        val lines = dialogueMap[key]?.get(mood)?.get(time)
+            ?: dialogueMap[key]?.get(mood)?.get(null)
+            ?: defaultLines[mood]
+            ?: listOf("...")
+        return lines.random()
+    }
+
+    // Personality -> Mood -> TimeOfDay? (null = any time) -> lines
+    private val dialogueMap: Map<String, Map<MoodState, Map<TimeOfDay?, List<String>>>> = mapOf(
+        "ACTIVE" to mapOf(
+            MoodState.HAPPY to mapOf(
+                TimeOfDay.MORNING to listOf("Let's go! New day, new memos!", "I'm pumped! Write something fun!"),
+                TimeOfDay.DAY to listOf("Come on, let's write more!", "I wanna run around~!"),
+                TimeOfDay.EVENING to listOf("What a great day! One more memo?", "Still got energy!"),
+                TimeOfDay.NIGHT to listOf("Zzz... *runs in dream*", "Can't... stop... running... zzz"),
+                null to listOf("Yay! Let's do something!", "I'm so happy right now!")
+            ),
+            MoodState.NORMAL to mapOf(
+                null to listOf("Hey! What are we doing today?", "I'm ready when you are!", "Hmm, a memo sounds good right about now.")
+            ),
+            MoodState.LONELY to mapOf(
+                null to listOf("Where'd you go? I was waiting...", "It's boring without you...", "*fidgets* Come play with me!")
+            ),
+            MoodState.SAD to mapOf(
+                null to listOf("...*stares at the floor*", "I miss the old days...", "Did I do something wrong?")
+            )
+        ),
+        "SHY" to mapOf(
+            MoodState.HAPPY to mapOf(
+                TimeOfDay.MORNING to listOf("G-good morning... *blush*", "Oh, you're here early..."),
+                TimeOfDay.NIGHT to listOf("*curled up, sleeping peacefully*", "Zzz..."),
+                null to listOf("I-I'm glad you're here...", "This is nice... *small smile*", "Um... thank you for the memos...")
+            ),
+            MoodState.NORMAL to mapOf(
+                null to listOf("Oh... hi...", "I'll just be here... if you need me...", "*peeks out shyly*")
+            ),
+            MoodState.LONELY to mapOf(
+                null to listOf("*hiding in corner*", "I-I thought you forgot about me...", "...please don't leave...")
+            ),
+            MoodState.SAD to mapOf(
+                null to listOf("*turns away quietly*", "...", "*sniff*")
+            )
+        ),
+        "PLAYFUL" to mapOf(
+            MoodState.HAPPY to mapOf(
+                TimeOfDay.MORNING to listOf("Boop! Good morning~!", "Hehe, surprise attack!"),
+                TimeOfDay.DAY to listOf("Tag, you're it!", "Let me sit on your memo~ hehe"),
+                TimeOfDay.EVENING to listOf("One more game before bed?", "Catch me if you can~!"),
+                TimeOfDay.NIGHT to listOf("*rolls around in sleep* Hehe...", "Zzz... gotcha... zzz"),
+                null to listOf("Hehehe~!", "What if I hide your memo?", "Prank time!")
+            ),
+            MoodState.NORMAL to mapOf(
+                null to listOf("Hmm, what should we play?", "I spy with my little eye...", "Bored~ entertain me!")
+            ),
+            MoodState.LONELY to mapOf(
+                null to listOf("No one to play with...", "*rolls ball back and forth alone*", "Come baaack~")
+            ),
+            MoodState.SAD to mapOf(
+                null to listOf("Not in the mood to play...", "*drops ball*", "Even pranks aren't fun anymore...")
+            )
+        ),
+        "PROUD" to mapOf(
+            MoodState.HAPPY to mapOf(
+                TimeOfDay.MORNING to listOf("Hmph. You're on time for once.", "I suppose this morning is acceptable."),
+                TimeOfDay.NIGHT to listOf("*sleeps elegantly*", "Do not disturb my beauty sleep."),
+                null to listOf("I acknowledge your effort.", "*nods approvingly*", "Not bad. Keep it up.")
+            ),
+            MoodState.NORMAL to mapOf(
+                null to listOf("I'm fine. Don't worry about me.", "Hmph.", "You may write a memo. I permit it.")
+            ),
+            MoodState.LONELY to mapOf(
+                null to listOf("I-It's not like I missed you or anything!", "I was perfectly fine alone. ...Mostly.", "*glances at you, looks away*")
+            ),
+            MoodState.SAD to mapOf(
+                null to listOf("...Leave me alone.", "*turns head away*", "I don't need anyone.")
+            )
+        ),
+        "GENTLE" to mapOf(
+            MoodState.HAPPY to mapOf(
+                TimeOfDay.MORNING to listOf("Good morning~ Did you sleep well?", "I made you a warm spot~"),
+                TimeOfDay.DAY to listOf("Take your time, I'm right here.", "Your memos make me so happy~"),
+                TimeOfDay.EVENING to listOf("Let's wind down together~", "What a lovely day it was."),
+                TimeOfDay.NIGHT to listOf("Sweet dreams~ *nuzzles*", "*purrs softly*"),
+                null to listOf("I love being with you~", "*rubs cheek against you*", "You're doing great, you know?")
+            ),
+            MoodState.NORMAL to mapOf(
+                null to listOf("I'm here whenever you need me.", "How are you feeling today?", "*sits beside you quietly*")
+            ),
+            MoodState.LONELY to mapOf(
+                null to listOf("I'll wait for you... always.", "It's okay, I know you're busy...", "*looks at door hopefully*")
+            ),
+            MoodState.SAD to mapOf(
+                null to listOf("*curls up sadly*", "I hope you come back soon...", "I'll be right here when you're ready...")
+            )
+        )
+    )
+
+    private val defaultLines: Map<MoodState, List<String>> = mapOf(
+        MoodState.HAPPY to listOf("Write more memos today~!", "I'm so happy!"),
+        MoodState.NORMAL to listOf("Hey there!", "What's up?"),
+        MoodState.LONELY to listOf("It's been a while...", "I missed you."),
+        MoodState.SAD to listOf("...", "*silence*")
+    )
+}

--- a/feature/pet/impl/src/main/java/me/pecos/memozy/feature/pet/screen/PetMainContent.kt
+++ b/feature/pet/impl/src/main/java/me/pecos/memozy/feature/pet/screen/PetMainContent.kt
@@ -32,6 +32,7 @@ import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.OutlinedButton
 import me.pecos.memozy.feature.pet.PetViewModel
 import me.pecos.memozy.feature.pet.model.MoodState
+import me.pecos.memozy.feature.pet.model.PetDialogue
 import me.pecos.memozy.feature.pet.model.PetUiState
 import me.pecos.memozy.feature.pet.model.TimeOfDay
 import me.pecos.memozy.feature.pet.rive.RivePetView
@@ -199,7 +200,7 @@ fun PetMainContent(
                 .padding(horizontal = 16.dp, vertical = 12.dp)
         ) {
             Text(
-                text = getSpeechText(moodState, pet.name),
+                text = "\uD83D\uDCAC \"${PetDialogue.getLine(pet.personality, moodState, timeOfDay)}\"",
                 color = colors.chipText,
                 fontSize = 14.sp,
                 textAlign = TextAlign.Center,


### PR DESCRIPTION
## Summary
- **PetDialogue 대사 시스템**: 성격(5) x 기분(4) x 시간대(4) 조합으로 80+ 고유 대사
- **연속 출석 보상**: 3일 연속 +50 EXP, 7일 연속 +100 EXP 보너스

## 대사 시스템 상세

| 성격 | 특징 | 예시 (HAPPY/MORNING) |
|------|------|---------------------|
| ACTIVE | 에너지 넘침 | "Let's go! New day, new memos!" |
| SHY | 수줍음 | "G-good morning... *blush*" |
| PLAYFUL | 장난꾸러기 | "Boop! Good morning~!" |
| PROUD | 도도함 | "Hmph. You're on time for once." |
| GENTLE | 다정함 | "Good morning~ Did you sleep well?" |

각 성격별로 기분(HAPPY/NORMAL/LONELY/SAD) x 시간대(MORNING/DAY/EVENING/NIGHT) 조합 대사가 있으며, 매번 랜덤 선택됩니다.

## 연속 출석 보상

| 연속 일수 | EXP 보너스 |
|-----------|-----------|
| 1~2일 | 없음 |
| 3일+ | +50 EXP |
| 7일+ | +100 EXP |

`feedPetWithStreakBonus(memoCount, consecutiveDays)` API로 호출.

## 주요 파일

| 파일 | 설명 |
|------|------|
| `PetDialogue.kt` | 성격 x 기분 x 시간대 대사 맵 + getLine() |
| `PetMainContent.kt` | 말풍선에 PetDialogue 연동 |
| `PetRepository.kt` | feedPetWithStreakBonus 인터페이스 추가 |
| `PetRepositoryImpl.kt` | 연속 출석 EXP 보너스 로직 |

## 기존 기능 영향
- Phase 1~4 코드: **변경 최소** (PetMainContent 말풍선 1줄, PetRepository 1 메서드 추가)

## Test plan
- [ ] 각 성격별 펫 → 말풍선 대사가 성격에 맞게 표시
- [ ] 시간대 변경 시 대사 변경 확인
- [ ] 기분 변경 시 대사 변경 확인
- [ ] feedPetWithStreakBonus 호출 시 연속일수에 따른 보너스 EXP 적용

🤖 Generated with [Claude Code](https://claude.com/claude-code)