### PR TITLE
feat: #1 메모 저장 시 펫 feedPet 자동 연동

### DIFF
--- a/feature/memo-plain/impl/build.gradle.kts
+++ b/feature/memo-plain/impl/build.gradle.kts
@@ -13,6 +13,8 @@ dependencies {
     implementation(projects.feature.core.resource)
     implementation(projects.datasource.local.memo.api)
     implementation(projects.data.repository.memo.api)
+    implementation(projects.data.repository.pet.api)
+    implementation(projects.datasource.local.pet.api)
     implementation(libs.montage.android)
     implementation(libs.androidx.compose.navigation)
     implementation(libs.kotlinx.coroutines.android)

--- a/feature/memo-plain/impl/src/main/java/me/pecos/memozy/feature/memoplain/impl/MemoPlainNavigationImpl.kt
+++ b/feature/memo-plain/impl/src/main/java/me/pecos/memozy/feature/memoplain/impl/MemoPlainNavigationImpl.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.launch
 import me.pecos.memozy.data.datasource.local.entity.Memo
 import me.pecos.memozy.data.repository.MemoRepository
 import me.pecos.memozy.data.repository.model.MemoFormat
+import me.pecos.memozy.data.repository.pet.PetRepository
 import me.pecos.memozy.feature.memoplain.api.MemoPlainNavigation
 import me.pecos.memozy.feature.memoplain.api.MemoPlainRoute
 import me.pecos.memozy.presentation.screen.home.model.MemoFormatUi
@@ -18,7 +19,8 @@ import me.pecos.memozy.presentation.screen.memo.MemoScreen
 import javax.inject.Inject
 
 class MemoPlainNavigationImpl @Inject constructor(
-    private val repository: MemoRepository
+    private val repository: MemoRepository,
+    private val petRepository: PetRepository
 ) : MemoPlainNavigation {
 
     override fun registerGraph(
@@ -59,6 +61,10 @@ class MemoPlainNavigationImpl @Inject constructor(
                         } else {
                             repository.addMemo(memo.toEntity())
                         }
+                        // Feed pet when memo is saved
+                        try {
+                            petRepository.feedPet(1)
+                        } catch (_: Exception) { }
                         onNavigateToHome()
                     }
                 }


### PR DESCRIPTION
## Summary
- 메모 저장(신규/수정) 시 펫에게 자동으로 먹이를 줌 (mood +10, exp +20)
- `MemoPlainNavigationImpl`에 `PetRepository` 주입

## 변경 포인트
| 파일 | 변경 |
|------|------|
| `MemoPlainNavigationImpl.kt` | PetRepository 주입 + onSave에서 feedPet(1) 호출 |
| `feature:memo-plain:impl/build.gradle.kts` | pet repository api 의존성 추가 |

## 동작
```
메모 저장 → repository.addMemo/updateMemo → petRepository.feedPet(1)
                                              ├── mood +10 (하루 최대 +30)
                                              └── exp +20
```

## Test plan
- [ ] 메모 신규 저장 → 펫 mood/exp 증가 확인
- [ ] 메모 수정 저장 → 펫 mood/exp 증가 확인
- [ ] 펫이 없는 상태에서 메모 저장 → 크래시 없이 정상 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)