### PR TITLE
feat: #1 펫 시스템 다국어 대응 (한/영/일)

### DIFF
--- a/feature/core/resource/src/main/res/values-en/strings.xml
+++ b/feature/core/resource/src/main/res/values-en/strings.xml
@@ -74,4 +74,37 @@
     <string name="donation_error_title">Payment Error</string>
     <string name="donation_error_message">Something went wrong during payment.\nPlease try again.</string>
     <string name="donation_loading">Connecting…</string>
+
+    <!-- Pet -->
+    <string name="pet_tab">Pet</string>
+    <string name="pet_tap_egg">Tap the egg!</string>
+    <string name="pet_keep_tapping">Keep tapping! (%d/3)</string>
+    <string name="pet_who_inside">Who\'s waiting inside?</string>
+    <string name="pet_new_friend">New Friend!</string>
+    <string name="pet_name_prompt">Give your new friend a name!</string>
+    <string name="pet_name_placeholder">Enter a name…</string>
+    <string name="pet_name_confirm">Confirm</string>
+    <string name="pet_tap_to_name">Tap to name your pet!</string>
+    <string name="pet_profile">Profile</string>
+    <string name="pet_memories">Memories</string>
+    <string name="pet_reroll">Reroll</string>
+    <string name="pet_species">Species</string>
+    <string name="pet_personality">Personality</string>
+    <string name="pet_favorite">Favorite</string>
+    <string name="pet_dislike">Dislike</string>
+    <string name="pet_level">Level</string>
+    <string name="pet_mood">Mood</string>
+    <string name="pet_days_together">Days Together</string>
+    <string name="pet_departing">%s is leaving…</string>
+    <string name="pet_days_together_stat">Days Together</string>
+    <string name="pet_level_reached">Level Reached</string>
+    <string name="pet_last_words">Thanks for everything… Take care of the next one!</string>
+    <string name="pet_stay_together">Stay Together</string>
+    <string name="pet_say_goodbye">Say Goodbye</string>
+    <string name="pet_memories_empty">No memories yet.\nYour departed friends will be remembered here.</string>
+    <string name="pet_departed_date">Departed: %s</string>
+    <string name="pet_morning">Good morning~ *stretches*</string>
+    <string name="pet_daytime">Let\'s write some memos!</string>
+    <string name="pet_evening">Getting sleepy~ *yawn*</string>
+    <string name="pet_night">Zzz…</string>
 </resources>

--- a/feature/core/resource/src/main/res/values-ja/strings.xml
+++ b/feature/core/resource/src/main/res/values-ja/strings.xml
@@ -74,4 +74,37 @@
     <string name="donation_error_title">決済エラー</string>
     <string name="donation_error_message">決済処理中に問題が発生しました。\nもう一度お試しください。</string>
     <string name="donation_loading">接続中…</string>
+
+    <!-- Pet -->
+    <string name="pet_tab">ペット</string>
+    <string name="pet_tap_egg">たまごをタップ！</string>
+    <string name="pet_keep_tapping">もっとタップ！ (%d/3)</string>
+    <string name="pet_who_inside">中で誰が待っているかな？</string>
+    <string name="pet_new_friend">新しい友達！</string>
+    <string name="pet_name_prompt">新しい友達に名前をつけよう！</string>
+    <string name="pet_name_placeholder">名前を入力…</string>
+    <string name="pet_name_confirm">確認</string>
+    <string name="pet_tap_to_name">タップして名前をつけよう！</string>
+    <string name="pet_profile">プロフィール</string>
+    <string name="pet_memories">思い出アルバム</string>
+    <string name="pet_reroll">リロール</string>
+    <string name="pet_species">種族</string>
+    <string name="pet_personality">性格</string>
+    <string name="pet_favorite">好きなもの</string>
+    <string name="pet_dislike">嫌いなもの</string>
+    <string name="pet_level">レベル</string>
+    <string name="pet_mood">気分</string>
+    <string name="pet_days_together">一緒の日々</string>
+    <string name="pet_departing">%sが旅立とうとしています…</string>
+    <string name="pet_days_together_stat">一緒にいた日数</string>
+    <string name="pet_level_reached">到達レベル</string>
+    <string name="pet_last_words">お世話してくれてありがとう…次の子もよろしくね！</string>
+    <string name="pet_stay_together">一緒にいる</string>
+    <string name="pet_say_goodbye">見送る</string>
+    <string name="pet_memories_empty">まだ思い出がありません。\n旅立った友達がここに記録されます。</string>
+    <string name="pet_departed_date">旅立ち: %s</string>
+    <string name="pet_morning">おはよう～ *のび*</string>
+    <string name="pet_daytime">メモを書きに行こう！</string>
+    <string name="pet_evening">眠くなってきた～ *あくび*</string>
+    <string name="pet_night">Zzz…</string>
 </resources>

--- a/feature/core/resource/src/main/res/values/strings.xml
+++ b/feature/core/resource/src/main/res/values/strings.xml
@@ -73,4 +73,37 @@
     <string name="donation_error_title">결제 오류</string>
     <string name="donation_error_message">결제 처리 중 문제가 발생했습니다.\n다시 시도해 주세요.</string>
     <string name="donation_loading">연결 중…</string>
+
+    <!-- Pet -->
+    <string name="pet_tab">펫</string>
+    <string name="pet_tap_egg">알을 탭하세요!</string>
+    <string name="pet_keep_tapping">계속 탭! (%d/3)</string>
+    <string name="pet_who_inside">누가 기다리고 있을까?</string>
+    <string name="pet_new_friend">새 친구!</string>
+    <string name="pet_name_prompt">새 친구에게 이름을 지어주세요!</string>
+    <string name="pet_name_placeholder">이름 입력…</string>
+    <string name="pet_name_confirm">확인</string>
+    <string name="pet_tap_to_name">탭해서 이름 짓기!</string>
+    <string name="pet_profile">프로필</string>
+    <string name="pet_memories">추억 앨범</string>
+    <string name="pet_reroll">리롤</string>
+    <string name="pet_species">종족</string>
+    <string name="pet_personality">성격</string>
+    <string name="pet_favorite">좋아하는 것</string>
+    <string name="pet_dislike">싫어하는 것</string>
+    <string name="pet_level">레벨</string>
+    <string name="pet_mood">기분</string>
+    <string name="pet_days_together">함께한 날</string>
+    <string name="pet_departing">%s이(가) 떠나려 합니다…</string>
+    <string name="pet_days_together_stat">함께한 일수</string>
+    <string name="pet_level_reached">도달 레벨</string>
+    <string name="pet_last_words">돌봐줘서 고마웠어… 다음 아이도 잘 부탁해!</string>
+    <string name="pet_stay_together">함께하기</string>
+    <string name="pet_say_goodbye">보내기</string>
+    <string name="pet_memories_empty">아직 추억이 없어요.\n떠난 친구들이 여기에 기록됩니다.</string>
+    <string name="pet_departed_date">떠난 날: %s</string>
+    <string name="pet_morning">좋은 아침~ *기지개*</string>
+    <string name="pet_daytime">메모 쓰러 가자!</string>
+    <string name="pet_evening">슬슬 졸려~ *하품*</string>
+    <string name="pet_night">Zzz…</string>
 </resources>

--- a/feature/pet/impl/src/main/java/me/pecos/memozy/feature/pet/screen/DepartContent.kt
+++ b/feature/pet/impl/src/main/java/me/pecos/memozy/feature/pet/screen/DepartContent.kt
@@ -25,6 +25,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.res.stringResource
+import me.pecos.memozy.feature.core.resource.R
 import me.pecos.memozy.feature.pet.PetViewModel
 import me.pecos.memozy.feature.pet.model.PetUiState
 import me.pecos.memozy.presentation.theme.LocalAppColors
@@ -52,7 +54,7 @@ fun DepartContent(
         verticalArrangement = Arrangement.Center
     ) {
         Text(
-            text = "${pet.name} is leaving...",
+            text = stringResource(R.string.pet_departing, pet.name),
             color = colors.textTitle,
             fontSize = 22.sp,
             fontWeight = FontWeight.Bold,
@@ -81,9 +83,9 @@ fun DepartContent(
                 horizontalAlignment = Alignment.CenterHorizontally,
                 modifier = Modifier.fillMaxWidth()
             ) {
-                StatRow("Days Together", "D+$daysTogether")
-                StatRow("Level Reached", "Lv.${pet.level}")
-                StatRow("Species", viewModel.getSpeciesName(pet.speciesId))
+                StatRow(stringResource(R.string.pet_days_together_stat), "D+$daysTogether")
+                StatRow(stringResource(R.string.pet_level_reached), "Lv.${pet.level}")
+                StatRow(stringResource(R.string.pet_species), viewModel.getSpeciesName(pet.speciesId))
                 StatRow("Rarity", viewModel.getRarityStars(pet.rarity))
 
                 Spacer(modifier = Modifier.height(16.dp))
@@ -97,7 +99,7 @@ fun DepartContent(
                         .padding(12.dp)
                 ) {
                     Text(
-                        text = "\uD83D\uDCAC \"Thanks for everything... Take care of the next one!\"",
+                        text = "\uD83D\uDCAC \"${stringResource(R.string.pet_last_words)}\"",
                         color = colors.chipText,
                         fontSize = 13.sp,
                         textAlign = TextAlign.Center,
@@ -118,7 +120,7 @@ fun DepartContent(
                 onClick = onCancel,
                 modifier = Modifier.weight(1f)
             ) {
-                Text("Stay Together")
+                Text(stringResource(R.string.pet_stay_together))
             }
             Button(
                 onClick = onConfirmDepart,
@@ -127,7 +129,7 @@ fun DepartContent(
                     containerColor = Color(0xFFE57373)
                 )
             ) {
-                Text("Say Goodbye", color = Color.White)
+                Text(stringResource(R.string.pet_say_goodbye), color = Color.White)
             }
         }
     }

--- a/feature/pet/impl/src/main/java/me/pecos/memozy/feature/pet/screen/GachaContent.kt
+++ b/feature/pet/impl/src/main/java/me/pecos/memozy/feature/pet/screen/GachaContent.kt
@@ -34,6 +34,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import androidx.compose.ui.res.stringResource
+import me.pecos.memozy.feature.core.resource.R
 import me.pecos.memozy.feature.pet.rive.RiveEggView
 import me.pecos.memozy.presentation.theme.LocalAppColors
 
@@ -54,7 +56,7 @@ fun GachaContent(
         verticalArrangement = Arrangement.Center
     ) {
         Text(
-            text = if (tapCount == 0) "Tap the egg!" else "Keep tapping! (${tapCount}/3)",
+            text = if (tapCount == 0) stringResource(R.string.pet_tap_egg) else stringResource(R.string.pet_keep_tapping, tapCount),
             color = colors.textTitle,
             fontSize = 18.sp,
             fontWeight = FontWeight.SemiBold
@@ -135,7 +137,7 @@ fun GachaContent(
         Spacer(modifier = Modifier.height(24.dp))
 
         Text(
-            text = "Who's waiting inside?",
+            text = stringResource(R.string.pet_who_inside),
             color = colors.textSecondary,
             fontSize = 14.sp,
             textAlign = TextAlign.Center

--- a/feature/pet/impl/src/main/java/me/pecos/memozy/feature/pet/screen/HatchResultContent.kt
+++ b/feature/pet/impl/src/main/java/me/pecos/memozy/feature/pet/screen/HatchResultContent.kt
@@ -32,6 +32,8 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import kotlinx.coroutines.delay
+import androidx.compose.ui.res.stringResource
+import me.pecos.memozy.feature.core.resource.R
 import me.pecos.memozy.feature.pet.model.PetUiState
 import me.pecos.memozy.presentation.theme.LocalAppColors
 
@@ -105,7 +107,7 @@ fun HatchResultContent(
                     modifier = Modifier.fillMaxWidth()
                 ) {
                     Text(
-                        text = "New Friend!",
+                        text = stringResource(R.string.pet_new_friend),
                         color = colors.textTitle,
                         fontSize = 20.sp,
                         fontWeight = FontWeight.Bold
@@ -131,15 +133,15 @@ fun HatchResultContent(
                         modifier = Modifier.fillMaxWidth(),
                         horizontalArrangement = Arrangement.SpaceEvenly
                     ) {
-                        InfoChip(label = "Personality", value = pet.personality.lowercase()
+                        InfoChip(label = stringResource(R.string.pet_personality), value = pet.personality.lowercase()
                             .replaceFirstChar { it.uppercase() })
-                        InfoChip(label = "Favorite", value = "#${pet.favoriteCategoryId}")
+                        InfoChip(label = stringResource(R.string.pet_favorite), value = "#${pet.favoriteCategoryId}")
                     }
 
                     Spacer(modifier = Modifier.height(20.dp))
 
                     Text(
-                        text = "Tap to name your pet!",
+                        text = stringResource(R.string.pet_tap_to_name),
                         color = colors.chipText,
                         fontSize = 14.sp,
                         fontWeight = FontWeight.Medium,

--- a/feature/pet/impl/src/main/java/me/pecos/memozy/feature/pet/screen/NamePetContent.kt
+++ b/feature/pet/impl/src/main/java/me/pecos/memozy/feature/pet/screen/NamePetContent.kt
@@ -21,6 +21,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.material3.Button
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.ui.res.stringResource
+import me.pecos.memozy.feature.core.resource.R
 import me.pecos.memozy.presentation.theme.LocalAppColors
 
 @Composable
@@ -64,7 +66,7 @@ fun NamePetContent(
         Spacer(modifier = Modifier.height(32.dp))
 
         Text(
-            text = "Give your new friend a name!",
+            text = stringResource(R.string.pet_name_prompt),
             color = colors.textBody,
             fontSize = 16.sp,
             textAlign = TextAlign.Center
@@ -75,7 +77,7 @@ fun NamePetContent(
         OutlinedTextField(
             value = name,
             onValueChange = { if (it.length <= 12) name = it },
-            placeholder = { Text("Enter a name...") },
+            placeholder = { Text(stringResource(R.string.pet_name_placeholder)) },
             singleLine = true,
             modifier = Modifier.fillMaxWidth()
         )
@@ -87,7 +89,7 @@ fun NamePetContent(
             enabled = name.isNotBlank(),
             modifier = Modifier.fillMaxWidth()
         ) {
-            Text("Confirm")
+            Text(stringResource(R.string.pet_name_confirm))
         }
     }
 }

--- a/feature/pet/impl/src/main/java/me/pecos/memozy/feature/pet/screen/PetHistoryScreen.kt
+++ b/feature/pet/impl/src/main/java/me/pecos/memozy/feature/pet/screen/PetHistoryScreen.kt
@@ -33,6 +33,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.res.stringResource
+import me.pecos.memozy.feature.core.resource.R
 import me.pecos.memozy.data.datasource.local.pet.entity.PetHistory
 import me.pecos.memozy.feature.pet.PetViewModel
 import me.pecos.memozy.presentation.theme.LocalAppColors
@@ -58,7 +60,7 @@ fun PetHistoryScreen(
         TopAppBar(
             title = {
                 Text(
-                    text = "Memories",
+                    text = stringResource(R.string.pet_memories),
                     color = colors.topbarTitle,
                     fontWeight = FontWeight.Bold
                 )
@@ -91,7 +93,7 @@ fun PetHistoryScreen(
                     )
                     Spacer(modifier = Modifier.height(16.dp))
                     Text(
-                        text = "No memories yet.\nYour departed friends will be remembered here.",
+                        text = stringResource(R.string.pet_memories_empty),
                         color = colors.textSecondary,
                         fontSize = 14.sp,
                         textAlign = TextAlign.Center

--- a/feature/pet/impl/src/main/java/me/pecos/memozy/feature/pet/screen/PetMainContent.kt
+++ b/feature/pet/impl/src/main/java/me/pecos/memozy/feature/pet/screen/PetMainContent.kt
@@ -31,6 +31,8 @@ import androidx.compose.foundation.border
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.OutlinedButton
 import me.pecos.memozy.feature.pet.PetViewModel
+import androidx.compose.ui.res.stringResource
+import me.pecos.memozy.feature.core.resource.R
 import me.pecos.memozy.feature.pet.model.MoodState
 import me.pecos.memozy.feature.pet.model.PetDialogue
 import me.pecos.memozy.feature.pet.model.PetUiState
@@ -219,19 +221,19 @@ fun PetMainContent(
                 onClick = { showProfile = true },
                 modifier = Modifier.weight(1f)
             ) {
-                Text("Profile")
+                Text(stringResource(R.string.pet_profile))
             }
             OutlinedButton(
                 onClick = onNavigateToHistory,
                 modifier = Modifier.weight(1f)
             ) {
-                Text("Memories")
+                Text(stringResource(R.string.pet_memories))
             }
             OutlinedButton(
                 onClick = { viewModel.startDeparting() },
                 modifier = Modifier.weight(1f)
             ) {
-                Text("Reroll")
+                Text(stringResource(R.string.pet_reroll))
             }
         }
     }

--- a/feature/pet/impl/src/main/java/me/pecos/memozy/feature/pet/screen/PetProfileSheet.kt
+++ b/feature/pet/impl/src/main/java/me/pecos/memozy/feature/pet/screen/PetProfileSheet.kt
@@ -16,6 +16,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.res.stringResource
+import me.pecos.memozy.feature.core.resource.R
 import me.pecos.memozy.feature.pet.PetViewModel
 import me.pecos.memozy.feature.pet.model.PetUiState
 import me.pecos.memozy.presentation.theme.LocalAppColors
@@ -52,13 +54,13 @@ fun PetProfileSheet(
 
             Spacer(modifier = Modifier.height(20.dp))
 
-            ProfileRow("Species", viewModel.getSpeciesName(pet.speciesId))
-            ProfileRow("Personality", pet.personality.lowercase().replaceFirstChar { it.uppercase() })
-            ProfileRow("Favorite", "Category #${pet.favoriteCategoryId}")
-            ProfileRow("Dislike", pet.dislike.replace("_", " "))
-            ProfileRow("Level", "Lv.${pet.level}")
-            ProfileRow("Mood", "${pet.mood}/100")
-            ProfileRow("Days Together", "D+${viewModel.getDaysTogether(pet)}")
+            ProfileRow(stringResource(R.string.pet_species), viewModel.getSpeciesName(pet.speciesId))
+            ProfileRow(stringResource(R.string.pet_personality), pet.personality.lowercase().replaceFirstChar { it.uppercase() })
+            ProfileRow(stringResource(R.string.pet_favorite), "Category #${pet.favoriteCategoryId}")
+            ProfileRow(stringResource(R.string.pet_dislike), pet.dislike.replace("_", " "))
+            ProfileRow(stringResource(R.string.pet_level), "Lv.${pet.level}")
+            ProfileRow(stringResource(R.string.pet_mood), "${pet.mood}/100")
+            ProfileRow(stringResource(R.string.pet_days_together), "D+${viewModel.getDaysTogether(pet)}")
 
             Spacer(modifier = Modifier.height(24.dp))
         }


### PR DESCRIPTION
## Summary
- 펫 관련 UI 텍스트 **30+ 항목** 다국어 대응 (한국어/영어/일본어)
- 7개 화면의 하드코딩 문자열 → `stringResource(R.string.*)` 교체

## 다국어 문자열 예시

| 키 | 한국어 | English | 日本語 |
|----|--------|---------|--------|
| pet_tap_egg | 알을 탭하세요! | Tap the egg! | たまごをタップ！ |
| pet_name_prompt | 새 친구에게 이름을 지어주세요! | Give your new friend a name! | 新しい友達に名前をつけよう！ |
| pet_say_goodbye | 보내기 | Say Goodbye | 見送る |
| pet_memories_empty | 아직 추억이 없어요 | No memories yet | まだ思い出がありません |

## 수정 파일

| 파일 | 변경 |
|------|------|
| `values/strings.xml` | 한국어 펫 문자열 30+ 추가 |
| `values-en/strings.xml` | 영어 펫 문자열 30+ 추가 |
| `values-ja/strings.xml` | 일본어 펫 문자열 30+ 추가 |
| 7개 Screen 파일 | 하드코딩 → stringResource 교체 |

## 참고
- PetDialogue(대사 시스템)은 코드 기반 유지 — 성격x기분x시간대 조합 구조가 복잡하여 strings.xml 부적합

## Test plan
- [ ] 한국어 설정 → 펫 화면 한국어 표시
- [ ] 영어 설정 → 펫 화면 영어 표시
- [ ] 일본어 설정 → 펫 화면 일본어 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)