### PR TITLE
Add: #54 메모 내 유튜브 링크 감지 + 요약 메뉴

### DIFF
--- a/feature/memo-plain/impl/src/main/java/me/pecos/memozy/feature/memoplain/impl/MemoPlainNavigationImpl.kt
+++ b/feature/memo-plain/impl/src/main/java/me/pecos/memozy/feature/memoplain/impl/MemoPlainNavigationImpl.kt
@@ -164,26 +164,6 @@ class MemoPlainNavigationImpl @Inject constructor(
                 .collectAsState(initial = emptyList())
             val existingMemo = memos.firstOrNull { it.id == memoId }
 
-            // YouTube 요약 로딩 중
-            if (youtubeUrl != null && summaryState is SummaryState.Loading) {
-                val colors = LocalAppColors.current
-                Box(
-                    modifier = Modifier.fillMaxSize(),
-                    contentAlignment = Alignment.Center
-                ) {
-                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                        CircularProgressIndicator()
-                        Spacer(modifier = Modifier.height(16.dp))
-                        Text(
-                            text = "유튜브 영상을 요약하고 있어요...",
-                            fontSize = 14.sp,
-                            color = colors.textSecondary
-                        )
-                    }
-                }
-                return@composable
-            }
-
             // 요약 에러 시 원본 URL만 프리필
             val finalMemo = sharedMemo
                 ?: if (youtubeUrl != null && summaryState is SummaryState.Error) {
@@ -192,9 +172,68 @@ class MemoPlainNavigationImpl @Inject constructor(
                     existingMemo ?: MemoUiState(0, "", 1, "")
                 }
 
+            // 요약 상태 통합 (ACTION_SEND + 메모 내 링크 감지)
+            var inlineSummaryState by remember { mutableStateOf<SummaryState>(SummaryState.Idle) }
+            // ACTION_SEND 요약 결과를 inlineSummaryState에 반영
+            LaunchedEffect(summaryState) {
+                if (summaryState !is SummaryState.Idle) {
+                    inlineSummaryState = summaryState
+                }
+            }
+
             MemoScreen(
                 existingMemo = finalMemo,
                 onBack = onBack,
+                isSummarizing = inlineSummaryState is SummaryState.Loading,
+                summaryResult = (inlineSummaryState as? SummaryState.Success)?.text,
+                onYoutubeSummarize = { url ->
+                    scope.launch {
+                        inlineSummaryState = SummaryState.Loading
+                        try {
+                            val summary = aiApiService.generateContentWithVideo(
+                                prompt = """
+                                |이 유튜브 영상을 한국어로 상세하게 요약해줘. 아래 형식을 정확히 따라줘:
+                                |
+                                |📋 한줄 요약
+                                |영상의 핵심을 한 문장으로 요약
+                                |
+                                |📌 핵심 키워드
+                                |#키워드1 #키워드2 #키워드3 #키워드4 #키워드5
+                                |
+                                |⏰ 타임라인별 상세 요약
+                                |각 주제/구간별로 나눠서 아래처럼 정리해줘:
+                                |
+                                |[00:00] 섹션 제목
+                                |- 상세 설명 (2~3문장)
+                                |- 중요한 내용이나 인사이트
+                                |
+                                |[다음 구간] 섹션 제목
+                                |- 상세 설명
+                                |- 중요한 내용이나 인사이트
+                                |
+                                |(영상 흐름에 따라 모든 구간을 빠짐없이 정리)
+                                |
+                                |💡 핵심 인사이트
+                                |- 영상에서 얻을 수 있는 주요 인사이트를 정리
+                                """.trimMargin(),
+                                videoUrl = url,
+                            )
+                            inlineSummaryState = SummaryState.Success(summary)
+                        } catch (e: Exception) {
+                            val errorMsg = when {
+                                e.message?.contains("token count exceeds") == true ||
+                                e.message?.contains("INVALID_ARGUMENT") == true ->
+                                    "영상이 너무 길어 요약할 수 없어요. 약 30분 이하 영상을 시도해주세요."
+                                e.message?.contains("Rate limit") == true ->
+                                    "요청이 너무 많아요. 잠시 후 다시 시도해주세요."
+                                e.message?.contains("timeout") == true || e.message?.contains("Timeout") == true ->
+                                    "응답 시간이 초과됐어요. 더 짧은 영상을 시도해주세요."
+                                else -> e.message ?: "요약 실패"
+                            }
+                            inlineSummaryState = SummaryState.Error(errorMsg)
+                        }
+                    }
+                },
                 onSave = { memo ->
                     scope.launch {
                         if (memoId > 0 && existingMemo != null) {

--- a/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/MemoScreen.kt
+++ b/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/MemoScreen.kt
@@ -1,6 +1,7 @@
 package me.pecos.memozy.presentation.screen.memo
 
 import android.content.Intent
+import android.net.Uri
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -13,6 +14,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -27,11 +29,22 @@ import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Share
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.input.OffsetMapping
+import androidx.compose.ui.text.input.TransformedText
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.text.style.LineHeightStyle
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.withStyle
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -61,12 +74,38 @@ import me.pecos.memozy.feature.core.resource.CATEGORY_RES_IDS
 import me.pecos.memozy.feature.core.resource.R
 import me.pecos.memozy.presentation.theme.LocalAppColors
 
-@OptIn(ExperimentalLayoutApi::class)
+private val YOUTUBE_URL_REGEX = Regex(
+    """(?:https?://)?(?:www\.)?(?:youtube\.com/watch\?v=|youtu\.be/|youtube\.com/shorts/)[\w\-]+(?:[&?][\w\-=]*)*"""
+)
+
+private class UrlHighlightTransformation : VisualTransformation {
+    override fun filter(text: AnnotatedString): TransformedText {
+        val annotated = buildAnnotatedString {
+            append(text)
+            YOUTUBE_URL_REGEX.findAll(text.text).forEach { match ->
+                addStyle(
+                    SpanStyle(
+                        color = Color(0xFF2196F3),
+                        textDecoration = TextDecoration.Underline
+                    ),
+                    start = match.range.first,
+                    end = match.range.last + 1
+                )
+            }
+        }
+        return TransformedText(annotated, OffsetMapping.Identity)
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class, ExperimentalMaterial3Api::class)
 @Composable
 fun MemoScreen(
     onSave: (MemoUiState) -> Unit,
     onBack: () -> Unit = {},
     onDelete: ((Int) -> Unit)? = null,
+    onYoutubeSummarize: ((url: String) -> Unit)? = null,
+    isSummarizing: Boolean = false,
+    summaryResult: String? = null,
     existingMemo: MemoUiState = MemoUiState(0, "", 1, "")
 ) {
     val isNewMemo = existingMemo.id <= 0
@@ -99,6 +138,9 @@ fun MemoScreen(
         initialized = true
     }
     val hasChanges = nameText != existingMemo.name || bodyText != existingMemo.content || categoryIndex != (existingMemo.categoryId - 1).coerceIn(0, CATEGORY_RES_IDS.size - 1)
+
+    // 요약 결과 표시 상태
+    var showSummary by remember { mutableStateOf(false) }
 
     val enabled = nameText.isNotBlank() && bodyText.isNotBlank()
     val colors = LocalAppColors.current  // ← CompositionLocal에서 현재 테마 색상 가져옴
@@ -188,18 +230,32 @@ fun MemoScreen(
 
                 Spacer(modifier = Modifier.height(16.dp))
 
-                // 내용
+                // 내용 — YouTube 링크 감지
+                var selectedYoutubeUrl by remember { mutableStateOf<String?>(null) }
+                val sheetState = rememberModalBottomSheetState()
+
+                val urlHighlight = remember { UrlHighlightTransformation() }
+
                 BasicTextField(
                     value = bodyText,
-                    onValueChange = { bodyText = it },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .heightIn(min = 150.dp),
+                    onValueChange = { newText ->
+                        bodyText = newText
+                    },
+                    visualTransformation = urlHighlight,
                     textStyle = TextStyle(
                         fontSize = 15.sp,
                         lineHeight = 24.sp,
-                        color = colors.textBody
+                        color = colors.textBody,
+                        lineHeightStyle = LineHeightStyle(
+                            alignment = LineHeightStyle.Alignment.Center,
+                            trim = LineHeightStyle.Trim.None
+                        )
                     ),
-                    modifier = Modifier.fillMaxWidth(),
                     decorationBox = { innerTextField ->
-                        Box {
+                        Box(modifier = Modifier.heightIn(min = 150.dp)) {
                             if (bodyText.isEmpty()) {
                                 Text(
                                     text = stringResource(R.string.memo_content_placeholder),
@@ -211,6 +267,189 @@ fun MemoScreen(
                         }
                     }
                 )
+
+                // 감지된 유튜브 URL 칩 표시
+                val detectedYoutubeUrl = remember(bodyText) {
+                    YOUTUBE_URL_REGEX.find(bodyText)?.value
+                }
+
+                if (detectedYoutubeUrl != null) {
+                    Spacer(modifier = Modifier.height(12.dp))
+                    Column {
+                        // 링크 칩
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clip(RoundedCornerShape(10.dp))
+                                .background(colors.chipBackground.copy(alpha = 0.5f))
+                                .clickable { selectedYoutubeUrl = detectedYoutubeUrl }
+                                .padding(horizontal = 12.dp, vertical = 10.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Text(text = "▶", fontSize = 14.sp)
+                            Spacer(modifier = Modifier.width(8.dp))
+                            Text(
+                                text = detectedYoutubeUrl,
+                                fontSize = 13.sp,
+                                color = Color(0xFF2196F3),
+                                maxLines = 1,
+                                modifier = Modifier.weight(1f),
+                                style = TextStyle(textDecoration = TextDecoration.Underline)
+                            )
+                            if (onYoutubeSummarize != null && !isSummarizing && summaryResult == null) {
+                                Spacer(modifier = Modifier.width(8.dp))
+                                Text(
+                                    text = "🤖 요약",
+                                    fontSize = 12.sp,
+                                    color = colors.chipText,
+                                    fontWeight = FontWeight.SemiBold,
+                                    modifier = Modifier
+                                        .clip(RoundedCornerShape(6.dp))
+                                        .background(colors.chipBackground)
+                                        .clickable { onYoutubeSummarize(detectedYoutubeUrl) }
+                                        .padding(horizontal = 8.dp, vertical = 4.dp)
+                                )
+                            }
+                        }
+
+                        // 로딩 중 — 칩 아래 작게 표시
+                        if (isSummarizing) {
+                            Spacer(modifier = Modifier.height(8.dp))
+                            Row(
+                                modifier = Modifier.padding(start = 4.dp),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                androidx.compose.material3.CircularProgressIndicator(
+                                    modifier = Modifier.size(14.dp),
+                                    strokeWidth = 2.dp,
+                                    color = colors.textSecondary
+                                )
+                                Spacer(modifier = Modifier.width(8.dp))
+                                Text(
+                                    text = "요약 중...",
+                                    fontSize = 12.sp,
+                                    color = colors.textSecondary
+                                )
+                            }
+                        }
+
+                        // 요약 완료 — "요약 보기" 버튼
+                        if (summaryResult != null) {
+                            Spacer(modifier = Modifier.height(8.dp))
+                            Text(
+                                text = if (showSummary) "▼ 요약 접기" else "▶ 요약 보기",
+                                fontSize = 13.sp,
+                                color = colors.chipText,
+                                fontWeight = FontWeight.SemiBold,
+                                modifier = Modifier
+                                    .clip(RoundedCornerShape(8.dp))
+                                    .background(colors.chipBackground)
+                                    .clickable { showSummary = !showSummary }
+                                    .padding(horizontal = 12.dp, vertical = 8.dp)
+                            )
+                            if (showSummary) {
+                                Spacer(modifier = Modifier.height(8.dp))
+                                Text(
+                                    text = summaryResult,
+                                    fontSize = 14.sp,
+                                    lineHeight = 22.sp,
+                                    color = colors.textBody,
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .clip(RoundedCornerShape(10.dp))
+                                        .background(colors.chipBackground.copy(alpha = 0.3f))
+                                        .padding(12.dp)
+                                )
+                            }
+                        }
+                    }
+                }
+
+                // YouTube 링크 바텀시트
+                if (selectedYoutubeUrl != null) {
+                    ModalBottomSheet(
+                        onDismissRequest = { selectedYoutubeUrl = null },
+                        sheetState = sheetState,
+                        containerColor = colors.cardBackground
+                    ) {
+                        val url = selectedYoutubeUrl!!
+                        Column(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 24.dp, vertical = 8.dp)
+                                .padding(bottom = 24.dp)
+                        ) {
+                            Text(
+                                text = "YouTube 링크",
+                                fontSize = 18.sp,
+                                fontWeight = FontWeight.Bold,
+                                color = colors.textTitle
+                            )
+                            Spacer(modifier = Modifier.height(4.dp))
+                            Text(
+                                text = url,
+                                fontSize = 13.sp,
+                                color = colors.textSecondary,
+                                maxLines = 1
+                            )
+                            Spacer(modifier = Modifier.height(20.dp))
+
+                            // 📋 링크 복사
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .clip(RoundedCornerShape(12.dp))
+                                    .clickable {
+                                        clipboardManager.setText(AnnotatedString(url))
+                                        selectedYoutubeUrl = null
+                                    }
+                                    .padding(vertical = 14.dp, horizontal = 4.dp),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Text("📋", fontSize = 20.sp)
+                                Spacer(modifier = Modifier.width(12.dp))
+                                Text("링크 복사", fontSize = 16.sp, color = colors.textBody)
+                            }
+
+                            // 🌐 브라우저에서 열기
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .clip(RoundedCornerShape(12.dp))
+                                    .clickable {
+                                        val fullUrl = if (url.startsWith("http")) url else "https://$url"
+                                        context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(fullUrl)))
+                                        selectedYoutubeUrl = null
+                                    }
+                                    .padding(vertical = 14.dp, horizontal = 4.dp),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Text("🌐", fontSize = 20.sp)
+                                Spacer(modifier = Modifier.width(12.dp))
+                                Text("브라우저에서 열기", fontSize = 16.sp, color = colors.textBody)
+                            }
+
+                            // 🤖 AI 요약하기
+                            if (onYoutubeSummarize != null) {
+                                Row(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .clip(RoundedCornerShape(12.dp))
+                                        .clickable {
+                                            onYoutubeSummarize(url)
+                                            selectedYoutubeUrl = null
+                                        }
+                                        .padding(vertical = 14.dp, horizontal = 4.dp),
+                                    verticalAlignment = Alignment.CenterVertically
+                                ) {
+                                    Text("🤖", fontSize = 20.sp)
+                                    Spacer(modifier = Modifier.width(12.dp))
+                                    Text("AI 요약하기", fontSize = 16.sp, color = colors.textBody)
+                                }
+                            }
+                        }
+                    }
+                }
 
                 Spacer(modifier = Modifier.height(20.dp))
 


### PR DESCRIPTION
## Summary
- 메모 본문에 유튜브 링크 붙여넣기 시 자동 감지 + 인라인 요약 UX
- 전체화면 로딩 제거 → 메모 편집 중에도 요약 가능

## 변경 내역

### MemoScreen.kt
- **URL 하이라이트**: `VisualTransformation`으로 유튜브 URL 파란색+밑줄 실시간 표시
- **링크 칩**: 본문 아래 ▶ 유튜브 URL + 🤖 요약 버튼
- **바텀시트**: 링크 칩 탭 시 복사/접속/AI 요약 메뉴
- **인라인 로딩**: 칩 아래 작은 스피너 ("요약 중...")
- **요약 보기**: 완료 시 "▶ 요약 보기" 버튼 → 펼침/접힘
- **메모 내용 영역**: `heightIn(min = 150.dp)`로 최소 높이 보장

### MemoPlainNavigationImpl.kt
- 전체화면 로딩 UI 제거 (편집 차단 없음)
- ACTION_SEND 요약 + 인라인 요약 상태 통합

## Test plan
- [ ] 메모에 유튜브 URL 붙여넣기 → 파란색 하이라이트 확인
- [ ] 링크 칩의 🤖 요약 버튼 탭 → 요약 시작 + 메모 편집 가능
- [ ] 요약 완료 → "요약 보기" 버튼 → 펼침/접힘 확인
- [ ] 링크 칩 탭 → 바텀시트 (복사/접속/요약) 동작 확인
- [ ] 유튜브 앱에서 공유 → 기존 ACTION_SEND 플로우 정상 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)