### PR TITLE
Add: #61 유튜브 요약 일일 5회 무료 제한

### DIFF
--- a/datasource/local/memo/api/src/main/java/me/pecos/memozy/data/datasource/local/AiUsageDao.kt
+++ b/datasource/local/memo/api/src/main/java/me/pecos/memozy/data/datasource/local/AiUsageDao.kt
@@ -1,0 +1,16 @@
+package me.pecos.memozy.data.datasource.local
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.Query
+import me.pecos.memozy.data.datasource.local.entity.AiUsage
+
+@Dao
+interface AiUsageDao {
+
+    @Insert
+    suspend fun insert(usage: AiUsage)
+
+    @Query("SELECT COUNT(*) FROM ai_usage WHERE feature = :feature AND usedAt >= :startOfDay")
+    suspend fun getCountSince(feature: String, startOfDay: Long): Int
+}

--- a/datasource/local/memo/api/src/main/java/me/pecos/memozy/data/datasource/local/entity/AiUsage.kt
+++ b/datasource/local/memo/api/src/main/java/me/pecos/memozy/data/datasource/local/entity/AiUsage.kt
@@ -1,0 +1,12 @@
+package me.pecos.memozy.data.datasource.local.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "ai_usage")
+data class AiUsage(
+    @PrimaryKey(autoGenerate = true)
+    val id: Long = 0,
+    val feature: String,
+    val usedAt: Long = System.currentTimeMillis()
+)

--- a/datasource/local/memo/impl/schemas/me.pecos.memozy.data.datasource.local.MemoDatabase/7.json
+++ b/datasource/local/memo/impl/schemas/me.pecos.memozy.data.datasource.local.MemoDatabase/7.json
@@ -1,0 +1,270 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 7,
+    "identityHash": "3ec44fa10950c020901398b6030cc24e",
+    "entities": [
+      {
+        "tableName": "memo",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `categoryId` INTEGER NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `format` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "categoryId",
+            "columnName": "categoryId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "format",
+            "columnName": "format",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "category",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "chat_session",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `title` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `category` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "chat_message",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sessionId` INTEGER NOT NULL, `role` TEXT NOT NULL, `content` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, `metadata` TEXT, FOREIGN KEY(`sessionId`) REFERENCES `chat_session`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadata",
+            "columnName": "metadata",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_chat_message_sessionId",
+            "unique": false,
+            "columnNames": [
+              "sessionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chat_message_sessionId` ON `${TABLE_NAME}` (`sessionId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "chat_session",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sessionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "youtube_summary",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`videoId` TEXT NOT NULL, `url` TEXT NOT NULL, `summary` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`videoId`))",
+        "fields": [
+          {
+            "fieldPath": "videoId",
+            "columnName": "videoId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "summary",
+            "columnName": "summary",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "videoId"
+          ]
+        }
+      },
+      {
+        "tableName": "ai_usage",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `feature` TEXT NOT NULL, `usedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "feature",
+            "columnName": "feature",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "usedAt",
+            "columnName": "usedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '3ec44fa10950c020901398b6030cc24e')"
+    ]
+  }
+}

--- a/datasource/local/memo/impl/src/main/java/me/pecos/memozy/data/datasource/local/MemoDatabase.kt
+++ b/datasource/local/memo/impl/src/main/java/me/pecos/memozy/data/datasource/local/MemoDatabase.kt
@@ -9,6 +9,7 @@ import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 import me.pecos.memozy.data.datasource.local.entity.Category
 import me.pecos.memozy.data.datasource.local.entity.Memo
+import me.pecos.memozy.data.datasource.local.entity.AiUsage
 import me.pecos.memozy.data.datasource.local.entity.YoutubeSummary
 import me.pecos.memozy.data.datasource.local.converter.MemoFormatConverter
 import me.pecos.memozy.data.datasource.local.chat.ChatMessageDao
@@ -103,6 +104,18 @@ val MIGRATION_4_5 = object : Migration(4, 5) {
     }
 }
 
+val MIGRATION_6_7 = object : Migration(6, 7) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        database.execSQL("""
+            CREATE TABLE IF NOT EXISTS `ai_usage` (
+                `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                `feature` TEXT NOT NULL,
+                `usedAt` INTEGER NOT NULL DEFAULT 0
+            )
+        """.trimIndent())
+    }
+}
+
 val MIGRATION_5_6 = object : Migration(5, 6) {
     override fun migrate(database: SupportSQLiteDatabase) {
         database.execSQL("""
@@ -125,8 +138,8 @@ private val PREPOPULATE_CALLBACK = object : RoomDatabase.Callback() {
 
 @TypeConverters(MemoFormatConverter::class)
 @Database(
-    entities = [Memo::class, Category::class, ChatSession::class, ChatMessage::class, YoutubeSummary::class],
-    version = 6,
+    entities = [Memo::class, Category::class, ChatSession::class, ChatMessage::class, YoutubeSummary::class, AiUsage::class],
+    version = 7,
     exportSchema = true
 )
 abstract class MemoDatabase : RoomDatabase() {
@@ -135,6 +148,7 @@ abstract class MemoDatabase : RoomDatabase() {
     abstract fun chatSessionDao(): ChatSessionDao
     abstract fun chatMessageDao(): ChatMessageDao
     abstract fun youtubeSummaryDao(): YoutubeSummaryDao
+    abstract fun aiUsageDao(): AiUsageDao
 
     companion object {
         @Volatile
@@ -147,7 +161,7 @@ abstract class MemoDatabase : RoomDatabase() {
                     MemoDatabase::class.java,
                     "memo_database"
                 )
-                    .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6)
+                    .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7)
                     .addCallback(PREPOPULATE_CALLBACK)
                     .build()
                 INSTANCE = instance

--- a/datasource/local/memo/impl/src/main/java/me/pecos/memozy/data/datasource/local/di/DatabaseModule.kt
+++ b/datasource/local/memo/impl/src/main/java/me/pecos/memozy/data/datasource/local/di/DatabaseModule.kt
@@ -14,6 +14,8 @@ import me.pecos.memozy.data.datasource.local.MIGRATION_2_3
 import me.pecos.memozy.data.datasource.local.MIGRATION_3_4
 import me.pecos.memozy.data.datasource.local.MIGRATION_4_5
 import me.pecos.memozy.data.datasource.local.MIGRATION_5_6
+import me.pecos.memozy.data.datasource.local.MIGRATION_6_7
+import me.pecos.memozy.data.datasource.local.AiUsageDao
 import me.pecos.memozy.data.datasource.local.MemoDao
 import me.pecos.memozy.data.datasource.local.MemoDatabase
 import me.pecos.memozy.data.datasource.local.YoutubeSummaryDao
@@ -33,7 +35,7 @@ object DatabaseModule {
             MemoDatabase::class.java,
             "memo_database"
         )
-            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6)
+            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7)
             .addCallback(object : RoomDatabase.Callback() {
                 override fun onCreate(db: SupportSQLiteDatabase) {
                     super.onCreate(db)
@@ -61,5 +63,10 @@ object DatabaseModule {
     @Provides
     fun provideYoutubeSummaryDao(database: MemoDatabase): YoutubeSummaryDao {
         return database.youtubeSummaryDao()
+    }
+
+    @Provides
+    fun provideAiUsageDao(database: MemoDatabase): AiUsageDao {
+        return database.aiUsageDao()
     }
 }

--- a/feature/memo-plain/impl/src/main/java/me/pecos/memozy/feature/memoplain/impl/MemoPlainNavigationImpl.kt
+++ b/feature/memo-plain/impl/src/main/java/me/pecos/memozy/feature/memoplain/impl/MemoPlainNavigationImpl.kt
@@ -25,9 +25,12 @@ import androidx.navigation.compose.composable
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
+import me.pecos.memozy.data.datasource.local.AiUsageDao
 import me.pecos.memozy.data.datasource.local.YoutubeSummaryDao
+import me.pecos.memozy.data.datasource.local.entity.AiUsage
 import me.pecos.memozy.data.datasource.local.entity.Memo
 import me.pecos.memozy.data.datasource.local.entity.YoutubeSummary
+import java.util.Calendar
 import me.pecos.memozy.data.datasource.remote.ai.AIApiService
 import me.pecos.memozy.data.datasource.remote.ai.YouTubeCaptionService
 import me.pecos.memozy.data.repository.MemoRepository
@@ -44,13 +47,22 @@ class MemoPlainNavigationImpl @Inject constructor(
     private val repository: MemoRepository,
     private val aiApiService: AIApiService,
     private val youtubeSummaryDao: YoutubeSummaryDao,
-    private val captionService: YouTubeCaptionService
+    private val captionService: YouTubeCaptionService,
+    private val aiUsageDao: AiUsageDao
 ) : MemoPlainNavigation {
 
     companion object {
-        private const val PREF_NAME = "memozy_ai_usage"
-        private const val KEY_SUMMARY_COUNT = "youtube_summary_count"
-        private const val FREE_SUMMARY_LIMIT = 100
+        private const val FEATURE_YOUTUBE_SUMMARY = "youtube_summary"
+        private const val DAILY_FREE_LIMIT = 5
+
+        private fun startOfToday(): Long {
+            return Calendar.getInstance().apply {
+                set(Calendar.HOUR_OF_DAY, 0)
+                set(Calendar.MINUTE, 0)
+                set(Calendar.SECOND, 0)
+                set(Calendar.MILLISECOND, 0)
+            }.timeInMillis
+        }
 
         private val YOUTUBE_REGEX = Regex(
             """(?:https?://)?(?:www\.)?(?:youtube\.com/watch\?v=|youtu\.be/|youtube\.com/shorts/)[\w-]+"""
@@ -205,11 +217,12 @@ class MemoPlainNavigationImpl @Inject constructor(
                     existingMemo ?: MemoUiState(0, "", 1, "")
                 }
 
-            // AI 사용량 체크
-            val context = LocalContext.current
-            val aiPrefs = remember { context.getSharedPreferences(PREF_NAME, android.content.Context.MODE_PRIVATE) }
-            val summaryCount = remember { mutableStateOf(aiPrefs.getInt(KEY_SUMMARY_COUNT, 0)) }
-            val canSummarize = summaryCount.value < FREE_SUMMARY_LIMIT
+            // AI 사용량 체크 (일일 5회 제한)
+            var dailyUsageCount by remember { mutableStateOf(0) }
+            LaunchedEffect(Unit) {
+                dailyUsageCount = aiUsageDao.getCountSince(FEATURE_YOUTUBE_SUMMARY, startOfToday())
+            }
+            val canSummarize = dailyUsageCount < DAILY_FREE_LIMIT
 
             // 요약 상태 통합 (ACTION_SEND + 메모 내 링크 감지)
             var inlineSummaryState by remember { mutableStateOf<SummaryState>(SummaryState.Idle) }
@@ -248,8 +261,12 @@ class MemoPlainNavigationImpl @Inject constructor(
                         }
                     }
                 },
-                onYoutubeSummarize = if (canSummarize) { { url ->
+                onYoutubeSummarize = { url ->
                     scope.launch {
+                        if (!canSummarize) {
+                            inlineSummaryState = SummaryState.Error("오늘 무료 요약 횟수를 모두 사용했어요.")
+                            return@launch
+                        }
                         val videoId = extractVideoId(url)
                         // 캐시 조회
                         val cached = videoId?.let { youtubeSummaryDao.getByVideoId(it) }
@@ -280,9 +297,8 @@ class MemoPlainNavigationImpl @Inject constructor(
                             }
                             inlineSummaryState = SummaryState.Success(summary)
                             // 성공 시 사용 횟수 증가
-                            val newCount = summaryCount.value + 1
-                            aiPrefs.edit().putInt(KEY_SUMMARY_COUNT, newCount).apply()
-                            summaryCount.value = newCount
+                            aiUsageDao.insert(AiUsage(feature = FEATURE_YOUTUBE_SUMMARY))
+                            dailyUsageCount++
                         } catch (e: Exception) {
                             val errorMsg = when {
                                 e.message?.contains("token count exceeds") == true ||
@@ -297,7 +313,7 @@ class MemoPlainNavigationImpl @Inject constructor(
                             inlineSummaryState = SummaryState.Error(errorMsg)
                         }
                     }
-                } } else null,
+                },
                 onSave = { memo ->
                     scope.launch {
                         if (memoId > 0 && existingMemo != null) {


### PR DESCRIPTION
## Summary
- SharedPreferences 기반 총량 100회 제한 → Room DB 기반 **일일 5회** 제한으로 교체
- `ai_usage` 테이블 신규 생성 (DB version 7, Migration 6→7)
- 제한 초과 시 "오늘 무료 요약 횟수를 모두 사용했어요." 에러 메시지 표시
- 캐시 히트 시 카운트 차감 안 함 (비용 0이므로)

## Test plan
- [ ] 유튜브 요약 5회 실행 후 6번째에 제한 메시지 확인
- [ ] 캐시된 영상 재요약 시 카운트 미차감 확인
- [ ] 앱 재실행 후 카운트 유지 확인
- [ ] 자정 이후 카운트 리셋 확인
- [ ] DB migration (v6→v7) 정상 동작 확인

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)