### PR TITLE
Add: #66 유튜브 요약 제한 도달 시 경고 메시지 UI

### DIFF
--- a/feature/memo-plain/impl/src/main/java/me/pecos/memozy/feature/memoplain/impl/MemoPlainNavigationImpl.kt
+++ b/feature/memo-plain/impl/src/main/java/me/pecos/memozy/feature/memoplain/impl/MemoPlainNavigationImpl.kt
@@ -252,6 +252,7 @@ class MemoPlainNavigationImpl @Inject constructor(
                 },
                 isSummarizing = inlineSummaryState is SummaryState.Loading,
                 summaryResult = (inlineSummaryState as? SummaryState.Success)?.text,
+                summaryError = (inlineSummaryState as? SummaryState.Error)?.message,
                 youtubeTitle = youtubeTitle,
                 onYoutubeDetected = { videoId ->
                     scope.launch {

--- a/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/MemoScreen.kt
+++ b/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/MemoScreen.kt
@@ -118,6 +118,7 @@ fun MemoScreen(
     onYoutubeDetected: ((videoId: String) -> Unit)? = null,
     isSummarizing: Boolean = false,
     summaryResult: String? = null,
+    summaryError: String? = null,
     youtubeTitle: String? = null,
     existingMemo: MemoUiState = MemoUiState(0, "", 1, "")
 ) {
@@ -423,6 +424,28 @@ fun MemoScreen(
                                         .background(colors.chipBackground)
                                         .clickable { onYoutubeSummarize(detectedYoutubeUrl) }
                                         .padding(horizontal = 8.dp, vertical = 4.dp)
+                                )
+                            }
+                        }
+
+                        // 제한 도달 에러 메시지
+                        if (summaryError != null) {
+                            Spacer(modifier = Modifier.height(8.dp))
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .clip(RoundedCornerShape(8.dp))
+                                    .background(Color(0xFFFFF3E0))
+                                    .padding(12.dp),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Text(text = "⚠️", fontSize = 16.sp)
+                                Spacer(modifier = Modifier.width(8.dp))
+                                Text(
+                                    text = summaryError,
+                                    fontSize = 13.sp,
+                                    color = Color(0xFFE65100),
+                                    lineHeight = 18.sp
                                 )
                             }
                         }


### PR DESCRIPTION
## Summary
- 유튜브 요약 일일 제한(5회) 도달 시 주황색 경고 배너 표시
- `SummaryState.Error`를 MemoScreen에 `summaryError`로 전달
- 요약 버튼 아래에 인라인 경고 메시지 표시

## Test plan
- [x] 제한 도달 시 경고 메시지 정상 표시 확인
- [x] 빌드 성공 확인

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)