### PR TITLE
Add: #38 메모 핀 고정 + 자동저장 중복 방지

### DIFF
--- a/datasource/local/memo/api/src/main/java/me/pecos/memozy/data/datasource/local/MemoDao.kt
+++ b/datasource/local/memo/api/src/main/java/me/pecos/memozy/data/datasource/local/MemoDao.kt
@@ -9,7 +9,7 @@ import me.pecos.memozy.data.datasource.local.entity.Memo
 
 @Dao
 interface MemoDao {
-    @Query("SELECT * FROM memo ORDER BY id DESC")
+    @Query("SELECT * FROM memo ORDER BY isPinned DESC, id DESC")
     fun getAllMemos(): Flow<List<Memo>>
 
     @Insert

--- a/datasource/local/memo/api/src/main/java/me/pecos/memozy/data/datasource/local/entity/Memo.kt
+++ b/datasource/local/memo/api/src/main/java/me/pecos/memozy/data/datasource/local/entity/Memo.kt
@@ -13,5 +13,6 @@ data class Memo(
     val content: String,
     val createdAt: Long = System.currentTimeMillis(),
     val updatedAt: Long = System.currentTimeMillis(),
-    val format: MemoFormat = MemoFormat.PLAIN
+    val format: MemoFormat = MemoFormat.PLAIN,
+    val isPinned: Boolean = false
 )

--- a/datasource/local/memo/impl/src/main/java/me/pecos/memozy/data/datasource/local/MemoDatabase.kt
+++ b/datasource/local/memo/impl/src/main/java/me/pecos/memozy/data/datasource/local/MemoDatabase.kt
@@ -129,6 +129,12 @@ val MIGRATION_5_6 = object : Migration(5, 6) {
     }
 }
 
+val MIGRATION_7_8 = object : Migration(7, 8) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        database.execSQL("ALTER TABLE memo ADD COLUMN isPinned INTEGER NOT NULL DEFAULT 0")
+    }
+}
+
 private val PREPOPULATE_CALLBACK = object : RoomDatabase.Callback() {
     override fun onCreate(db: SupportSQLiteDatabase) {
         super.onCreate(db)
@@ -139,7 +145,7 @@ private val PREPOPULATE_CALLBACK = object : RoomDatabase.Callback() {
 @TypeConverters(MemoFormatConverter::class)
 @Database(
     entities = [Memo::class, Category::class, ChatSession::class, ChatMessage::class, YoutubeSummary::class, AiUsage::class],
-    version = 7,
+    version = 8,
     exportSchema = true
 )
 abstract class MemoDatabase : RoomDatabase() {
@@ -161,7 +167,7 @@ abstract class MemoDatabase : RoomDatabase() {
                     MemoDatabase::class.java,
                     "memo_database"
                 )
-                    .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7)
+                    .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8)
                     .addCallback(PREPOPULATE_CALLBACK)
                     .build()
                 INSTANCE = instance

--- a/feature/core/resource/src/main/java/me/pecos/memozy/presentation/screen/home/model/MemoUiState.kt
+++ b/feature/core/resource/src/main/java/me/pecos/memozy/presentation/screen/home/model/MemoUiState.kt
@@ -7,5 +7,6 @@ data class MemoUiState(
     val content: String,
     val createdAt: Long = 0L,
     val updatedAt: Long = 0L,
-    val format: MemoFormatUi = MemoFormatUi.PLAIN
+    val format: MemoFormatUi = MemoFormatUi.PLAIN,
+    val isPinned: Boolean = false
 )

--- a/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/home/HomeScreen.kt
+++ b/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/home/HomeScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -261,27 +262,27 @@ fun HomeScreen(
                                     .clip(RoundedCornerShape(12.dp)),
                                 horizontalArrangement = Arrangement.SpaceBetween
                             ) {
-                                // 오른쪽 스와이프 → 편집 버튼 (왼쪽에 표시)
+                                // 오른쪽 스와이프 → 핀 토글 (왼쪽에 표시)
                                 Box(
                                     modifier = Modifier
                                         .width(revealWidth.dp)
                                         .fillMaxHeight()
-                                        .background(colors.chipText)
+                                        .background(if (memo.isPinned) colors.textSecondary else Color(0xFFFFA726))
                                         .clickable {
                                             swipedOpenId = null
-                                            onEdit(memo.id)
+                                            viewModel.togglePin(memo)
                                         },
                                     contentAlignment = Alignment.Center
                                 ) {
                                     Column(horizontalAlignment = Alignment.CenterHorizontally) {
                                         Icon(
-                                            Icons.Default.Edit,
+                                            Icons.Default.Star,
                                             contentDescription = null,
                                             tint = Color.White,
                                             modifier = Modifier.size(22.dp)
                                         )
                                         Text(
-                                            text = stringResource(R.string.edit_memo),
+                                            text = if (memo.isPinned) "고정 해제" else "고정",
                                             color = Color.White,
                                             fontSize = 10.sp,
                                             fontWeight = FontWeight.Medium

--- a/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/home/MainViewModel.kt
+++ b/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/home/MainViewModel.kt
@@ -94,6 +94,12 @@ class MainViewModel @Inject constructor(
             repository.updateMemo(memo.toMemo())
         }
     }
+
+    fun togglePin(memo: MemoUiState) {
+        viewModelScope.launch {
+            repository.updateMemo(memo.copy(isPinned = !memo.isPinned).toMemo())
+        }
+    }
 }
 
 fun MemoUiState.toMemo(): Memo = Memo(
@@ -106,7 +112,8 @@ fun MemoUiState.toMemo(): Memo = Memo(
     format = when (this.format) {
         MemoFormatUi.MARKDOWN -> MemoFormat.MARKDOWN
         MemoFormatUi.PLAIN -> MemoFormat.PLAIN
-    }
+    },
+    isPinned = this.isPinned
 )
 
 fun Memo.toUiState(): MemoUiState = MemoUiState(
@@ -119,5 +126,6 @@ fun Memo.toUiState(): MemoUiState = MemoUiState(
     format = when (this.format) {
         MemoFormat.MARKDOWN -> MemoFormatUi.MARKDOWN
         MemoFormat.PLAIN -> MemoFormatUi.PLAIN
-    }
+    },
+    isPinned = this.isPinned
 )

--- a/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/home/components/MemoCard.kt
+++ b/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/home/components/MemoCard.kt
@@ -10,6 +10,11 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material3.Icon
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -17,6 +22,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -58,12 +64,25 @@ fun MemoCardItem(
                 horizontalArrangement = Arrangement.SpaceBetween,
                 modifier = Modifier.fillMaxWidth()
             ) {
-                Text(
-                    text = memo.name,
-                    fontWeight = FontWeight.Bold,
-                    color = colors.textTitle,
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
                     modifier = Modifier.weight(1f)
-                )
+                ) {
+                    if (memo.isPinned) {
+                        Icon(
+                            Icons.Default.Star,
+                            contentDescription = null,
+                            tint = Color(0xFFFFA726),
+                            modifier = Modifier.size(14.dp)
+                        )
+                        Spacer(modifier = Modifier.width(4.dp))
+                    }
+                    Text(
+                        text = memo.name,
+                        fontWeight = FontWeight.Bold,
+                        color = colors.textTitle,
+                    )
+                }
                 Column(horizontalAlignment = Alignment.End) {
                     Text(
                         text = formatMemoTime(memo.createdAt, languageCode),

--- a/feature/memo-plain/impl/src/main/java/me/pecos/memozy/feature/memoplain/impl/MemoPlainNavigationImpl.kt
+++ b/feature/memo-plain/impl/src/main/java/me/pecos/memozy/feature/memoplain/impl/MemoPlainNavigationImpl.kt
@@ -444,7 +444,10 @@ class MemoPlainNavigationImpl @Inject constructor(
                 },
                 onSave = { memo ->
                     scope.launch {
-                        if (memoId > 0 && existingMemo != null) {
+                        if (savedMemoId > 0) {
+                            // 자동저장으로 이미 생성된 메모 → update
+                            repository.updateMemo(memo.copy(id = savedMemoId).toEntity())
+                        } else if (memoId > 0 && existingMemo != null) {
                             repository.updateMemo(memo.toEntity())
                         } else {
                             repository.addMemo(memo.toEntity())


### PR DESCRIPTION
## Summary
- Memo Entity에 `isPinned` 필드 추가 (Room Migration 7→8)
- 핀 고정 메모가 목록 상단에 표시 (`ORDER BY isPinned DESC, id DESC`)
- 스와이프 오른쪽 → ⭐ 고정/해제 토글 버튼
- MemoCard 제목 옆에 핀 아이콘 표시
- 새 메모 "완료" 버튼 클릭 시 자동저장과 중복 생성되는 버그 수정

## Test plan
- [x] 핀 고정/해제 정상 동작
- [x] 고정 메모 목록 상단 표시
- [x] 핀 아이콘 표시
- [x] DB Migration 정상 (version 7→8)
- [x] 새 메모 완료 시 1개만 생성 확인
- [x] 전체 앱 빌드 성공

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)