### PR TITLE
Add: #36 화면 전환 / 카드 애니메이션

### DIFF
--- a/feature/home/impl/src/main/java/me/pecos/memozy/MainActivity.kt
+++ b/feature/home/impl/src/main/java/me/pecos/memozy/MainActivity.kt
@@ -5,6 +5,10 @@ import android.content.Intent
 import android.content.res.Configuration
 import android.os.Bundle
 import androidx.activity.compose.setContent
+import androidx.compose.animation.AnimatedContentTransitionScope
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.background
@@ -160,7 +164,19 @@ class MainActivity : AppCompatActivity() {
                             NavHost(
                                 navController = navController,
                                 startDestination = HomeRoute.MAIN,
-                                modifier = Modifier.fillMaxSize()
+                                modifier = Modifier.fillMaxSize(),
+                                enterTransition = {
+                                    slideIntoContainer(AnimatedContentTransitionScope.SlideDirection.Start, tween(300)) + fadeIn(tween(300))
+                                },
+                                exitTransition = {
+                                    slideOutOfContainer(AnimatedContentTransitionScope.SlideDirection.Start, tween(300)) + fadeOut(tween(300))
+                                },
+                                popEnterTransition = {
+                                    slideIntoContainer(AnimatedContentTransitionScope.SlideDirection.End, tween(300)) + fadeIn(tween(300))
+                                },
+                                popExitTransition = {
+                                    slideOutOfContainer(AnimatedContentTransitionScope.SlideDirection.End, tween(300)) + fadeOut(tween(300))
+                                }
                             ) {
                                 composable(HomeRoute.MAIN) {
                                     HomeScreen(

--- a/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/home/HomeScreen.kt
+++ b/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/home/HomeScreen.kt
@@ -18,11 +18,12 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.gestures.detectHorizontalDragGestures
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.draggable
+import androidx.compose.foundation.gestures.rememberDraggableState
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
-import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.unit.IntOffset
 import kotlin.math.roundToInt
 import androidx.compose.animation.core.animateFloatAsState
@@ -242,6 +243,12 @@ fun HomeScreen(
                 ) {
                     items(filteredList, key = { it.id }) { memo ->
                         val revealWidth = 80f
+                        // 카드 재배치/삭제 애니메이션
+                        val itemModifier = Modifier.animateItem(
+                            fadeInSpec = tween(300),
+                            fadeOutSpec = tween(300),
+                            placementSpec = tween(300)
+                        )
                         val revealPx = with(androidx.compose.ui.platform.LocalDensity.current) { revealWidth.dp.toPx() }
                         // 이 카드가 열려있는지 판단
                         val isOpen = swipedOpenId == memo.id
@@ -253,7 +260,7 @@ fun HomeScreen(
                             label = "swipeOffset"
                         )
 
-                        Box(modifier = Modifier.fillMaxWidth()) {
+                        Box(modifier = itemModifier.fillMaxWidth()) {
                             // 뒤쪽 액션 버튼
                             Row(
                                 modifier = Modifier
@@ -319,26 +326,26 @@ fun HomeScreen(
                             }
 
                             // 앞쪽 카드 (스와이프 이동)
+                            val dragState = rememberDraggableState { delta ->
+                                rawOffset = (rawOffset + delta).coerceIn(-revealPx, revealPx)
+                                swipedOpenId = memo.id
+                            }
                             Box(
                                 modifier = Modifier
                                     .offset { IntOffset(animatedOffset.roundToInt(), 0) }
-                                    .pointerInput(Unit) {
-                                        detectHorizontalDragGestures(
-                                            onDragEnd = {
-                                                val snapped = when {
-                                                    rawOffset > revealPx / 2 -> revealPx
-                                                    rawOffset < -revealPx / 2 -> -revealPx
-                                                    else -> 0f
-                                                }
-                                                rawOffset = snapped
-                                                swipedOpenId = if (snapped != 0f) memo.id else null
-                                            },
-                                            onHorizontalDrag = { _, dragAmount ->
-                                                rawOffset = (rawOffset + dragAmount).coerceIn(-revealPx, revealPx)
-                                                swipedOpenId = memo.id
+                                    .draggable(
+                                        state = dragState,
+                                        orientation = Orientation.Horizontal,
+                                        onDragStopped = {
+                                            val snapped = when {
+                                                rawOffset > revealPx / 2 -> revealPx
+                                                rawOffset < -revealPx / 2 -> -revealPx
+                                                else -> 0f
                                             }
-                                        )
-                                    }
+                                            rawOffset = snapped
+                                            swipedOpenId = if (snapped != 0f) memo.id else null
+                                        }
+                                    )
                                     .clickable {
                                         if (swipedOpenId != null) {
                                             swipedOpenId = null

--- a/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/home/components/MemoCard.kt
+++ b/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/home/components/MemoCard.kt
@@ -10,6 +10,8 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
@@ -59,7 +61,7 @@ fun MemoCardItem(
         elevation = CardDefaults.cardElevation(0.dp),
         colors = CardDefaults.cardColors(containerColor = colors.cardBackground)
     ) {
-        Column(modifier = Modifier.padding(16.dp)) {
+        Column(modifier = Modifier.padding(16.dp).animateContentSize(tween(200))) {
             Row(
                 horizontalArrangement = Arrangement.SpaceBetween,
                 modifier = Modifier.fillMaxWidth()


### PR DESCRIPTION
## Summary
- NavHost 화면 전환 애니메이션 (slideIn/Out + fadeIn/Out, 300ms)
- LazyColumn 카드 `animateItem` — 핀 고정/삭제 시 부드러운 재배치
- MemoCard `animateContentSize` — 내용 변경 시 크기 전환
- 스와이프를 `draggable(Horizontal)`로 변경하여 수직 스크롤과 공존

## Test plan
- [x] 홈 ↔ 메모/설정 화면 전환 부드러움
- [x] 핀 고정/해제 시 카드 재배치 애니메이션
- [x] 메모 삭제 시 카드 페이드아웃
- [x] 수직 스크롤 + 수평 스와이프 공존
- [x] 빌드 성공

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)