### PR TITLE
Fix: #72 보안 강화 — URL 하드코딩 제거, 로깅 축소, minify 활성화

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -17,7 +17,8 @@ android {
     }
     buildTypes {
         release {
-            isMinifyEnabled = false
+            isMinifyEnabled = true
+            isShrinkResources = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,7 +10,7 @@
 
     <application
         android:name=".MemozyApplication"
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"

--- a/datasource/remote/ai/api/src/main/java/me/pecos/memozy/data/datasource/remote/ai/AIApiService.kt
+++ b/datasource/remote/ai/api/src/main/java/me/pecos/memozy/data/datasource/remote/ai/AIApiService.kt
@@ -6,5 +6,5 @@ interface AIApiService {
     suspend fun generateContent(prompt: String): String
     suspend fun generateContentWithVideo(prompt: String, videoUrl: String): String
     fun generateContentStream(prompt: String): Flow<String>
-    suspend fun transcribeAudio(audioBase64: String, mimeType: String): String
+    suspend fun transcribeAudio(audioBase64: String, mimeType: String, durationSeconds: Long = 0): String
 }

--- a/datasource/remote/ai/impl/build.gradle.kts
+++ b/datasource/remote/ai/impl/build.gradle.kts
@@ -21,6 +21,7 @@ android {
 
     defaultConfig {
         buildConfigField("String", "SUPABASE_URL", "\"${localProperties.getProperty("supabase.url", "")}\"")
+        buildConfigField("String", "APP_SECRET_KEY", "\"${localProperties.getProperty("app.secret.key", "")}\"")
     }
 }
 

--- a/datasource/remote/ai/impl/build.gradle.kts
+++ b/datasource/remote/ai/impl/build.gradle.kts
@@ -20,7 +20,7 @@ android {
     }
 
     defaultConfig {
-        buildConfigField("String", "SUPABASE_URL", "\"${localProperties.getProperty("supabase.url", "https://pwgddlqaasmgjbyhadsf.supabase.co")}\"")
+        buildConfigField("String", "SUPABASE_URL", "\"${localProperties.getProperty("supabase.url", "")}\"")
     }
 }
 

--- a/datasource/remote/ai/impl/src/main/java/me/pecos/memozy/data/datasource/remote/ai/AIApiServiceImpl.kt
+++ b/datasource/remote/ai/impl/src/main/java/me/pecos/memozy/data/datasource/remote/ai/AIApiServiceImpl.kt
@@ -103,7 +103,13 @@ class AIApiServiceImpl @Inject constructor(
         }
     }
 
-    override suspend fun transcribeAudio(audioBase64: String, mimeType: String): String {
+    override suspend fun transcribeAudio(audioBase64: String, mimeType: String, durationSeconds: Long): String {
+        val prompt = if (durationSeconds >= 60) {
+            "이 오디오를 한국어로 받아쓰기해줘. 30초 간격으로 타임스탬프를 포함해서 [MM:SS] 형식으로 구분해줘. 타임스탬프와 텍스트만 출력하고 다른 설명은 하지 마."
+        } else {
+            "이 오디오를 한국어로 받아쓰기해줘. 텍스트만 출력하고 다른 설명은 하지 마."
+        }
+
         val request = GeminiRequest(
             contents = listOf(
                 GeminiContent(
@@ -114,7 +120,7 @@ class AIApiServiceImpl @Inject constructor(
                                 data = audioBase64,
                             )
                         ),
-                        GeminiPart(text = "이 오디오를 한국어로 받아쓰기해줘. 텍스트만 출력하고 다른 설명은 하지 마."),
+                        GeminiPart(text = prompt),
                     )
                 )
             )

--- a/datasource/remote/ai/impl/src/main/java/me/pecos/memozy/data/datasource/remote/ai/di/AINetworkModule.kt
+++ b/datasource/remote/ai/impl/src/main/java/me/pecos/memozy/data/datasource/remote/ai/di/AINetworkModule.kt
@@ -11,6 +11,7 @@ import io.ktor.client.plugins.HttpResponseValidator
 import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.defaultRequest
+import io.ktor.client.request.header
 import io.ktor.client.plugins.logging.LogLevel
 import io.ktor.client.plugins.logging.Logging
 import io.ktor.client.statement.bodyAsText
@@ -72,6 +73,7 @@ abstract class AINetworkModule {
 
             defaultRequest {
                 url("${BuildConfig.SUPABASE_URL}/functions/v1/")
+                header("x-app-key", BuildConfig.APP_SECRET_KEY)
             }
 
             HttpResponseValidator {

--- a/datasource/remote/ai/impl/src/main/java/me/pecos/memozy/data/datasource/remote/ai/di/AINetworkModule.kt
+++ b/datasource/remote/ai/impl/src/main/java/me/pecos/memozy/data/datasource/remote/ai/di/AINetworkModule.kt
@@ -61,7 +61,7 @@ abstract class AINetworkModule {
             }
 
             install(Logging) {
-                level = LogLevel.BODY
+                level = if (BuildConfig.DEBUG) LogLevel.HEADERS else LogLevel.NONE
             }
 
             install(HttpTimeout) {

--- a/feature/home/impl/src/main/java/me/pecos/memozy/MainActivity.kt
+++ b/feature/home/impl/src/main/java/me/pecos/memozy/MainActivity.kt
@@ -134,7 +134,7 @@ class MainActivity : AppCompatActivity() {
                         // ACTION_SEND 공유 수신 처리
                         val sharedText = remember {
                             if (intent?.action == Intent.ACTION_SEND && intent.type == "text/plain") {
-                                intent.getStringExtra(Intent.EXTRA_TEXT)
+                                intent.getStringExtra(Intent.EXTRA_TEXT)?.take(4096)
                             } else null
                         }
                         LaunchedEffect(sharedText) {

--- a/feature/memo-plain/impl/src/main/java/me/pecos/memozy/feature/memoplain/impl/MemoPlainNavigationImpl.kt
+++ b/feature/memo-plain/impl/src/main/java/me/pecos/memozy/feature/memoplain/impl/MemoPlainNavigationImpl.kt
@@ -248,7 +248,23 @@ class MemoPlainNavigationImpl @Inject constructor(
             var isTranscribing by remember { mutableStateOf(false) }
             var transcriptionResult by remember { mutableStateOf<String?>(null) }
             var transcriptionError by remember { mutableStateOf<String?>(null) }
+            // 에러/결과 메시지 3초 후 자동 해제
+            LaunchedEffect(transcriptionError) {
+                if (transcriptionError != null) {
+                    kotlinx.coroutines.delay(3000)
+                    transcriptionError = null
+                }
+            }
+            LaunchedEffect(transcriptionResult) {
+                if (transcriptionResult != null) {
+                    // 본문에 삽입된 후 상태 초기화 (MemoScreen에서 LaunchedEffect로 삽입)
+                    kotlinx.coroutines.delay(500)
+                    transcriptionResult = null
+                }
+            }
+
             var mediaRecorder by remember { mutableStateOf<MediaRecorder?>(null) }
+            var recordingStartTime by remember { mutableStateOf(0L) }
             val audioFile = remember(context) { java.io.File(context.cacheDir, "recording.m4a") }
 
             val permissionLauncher = rememberLauncherForActivityResult(
@@ -274,6 +290,7 @@ class MemoPlainNavigationImpl @Inject constructor(
                             start()
                         }
                         mediaRecorder = recorder
+                        recordingStartTime = System.currentTimeMillis()
                         isRecording = true
                         transcriptionError = null
                     } catch (e: Exception) {
@@ -308,6 +325,7 @@ class MemoPlainNavigationImpl @Inject constructor(
                             start()
                         }
                         mediaRecorder = recorder
+                        recordingStartTime = System.currentTimeMillis()
                         isRecording = true
                         transcriptionError = null
                     } catch (e: Exception) {
@@ -322,6 +340,7 @@ class MemoPlainNavigationImpl @Inject constructor(
                 try {
                     mediaRecorder?.apply { stop(); release() }
                 } catch (_: Exception) { }
+                val durationSeconds = (System.currentTimeMillis() - recordingStartTime) / 1000
                 mediaRecorder = null
                 isRecording = false
 
@@ -336,7 +355,7 @@ class MemoPlainNavigationImpl @Inject constructor(
                     try {
                         val audioBytes = audioFile.readBytes()
                         val base64 = Base64.encodeToString(audioBytes, Base64.NO_WRAP)
-                        val result = aiApiService.transcribeAudio(base64, "audio/mp4")
+                        val result = aiApiService.transcribeAudio(base64, "audio/mp4", durationSeconds)
                         // Gemini가 프롬프트를 그대로 반환하는 경우 필터링
                         if (result.contains("받아쓰기") || result.contains("텍스트만 출력") || result.isBlank()) {
                             transcriptionError = "음성이 감지되지 않았어요. 다시 시도해주세요."
@@ -436,7 +455,7 @@ class MemoPlainNavigationImpl @Inject constructor(
                                     "요청이 너무 많아요. 잠시 후 다시 시도해주세요."
                                 e.message?.contains("timeout") == true || e.message?.contains("Timeout") == true ->
                                     "응답 시간이 초과됐어요. 더 짧은 영상을 시도해주세요."
-                                else -> e.message ?: "요약 실패"
+                                else -> "요약 중 오류가 발생했어요. 다시 시도해주세요."
                             }
                             inlineSummaryState = SummaryState.Error(errorMsg)
                         }

--- a/supabase/functions/_shared/auth.ts
+++ b/supabase/functions/_shared/auth.ts
@@ -1,0 +1,12 @@
+const APP_SECRET = Deno.env.get("APP_SECRET_KEY");
+
+export function verifyAppAuth(req: Request): Response | null {
+  const apiKey = req.headers.get("x-app-key");
+  if (!apiKey || apiKey !== APP_SECRET) {
+    return new Response(
+      JSON.stringify({ error: "Unauthorized" }),
+      { status: 401, headers: { "Content-Type": "application/json" } },
+    );
+  }
+  return null; // auth passed
+}

--- a/supabase/functions/gemini-generate/index.ts
+++ b/supabase/functions/gemini-generate/index.ts
@@ -1,4 +1,5 @@
 import "@supabase/functions-js/edge-runtime.d.ts";
+import { verifyAppAuth } from "../_shared/auth.ts";
 
 const GEMINI_API_KEY = Deno.env.get("GEMINI_API_KEY")!;
 const GEMINI_MODEL = Deno.env.get("GEMINI_MODEL") ?? "gemini-2.5-flash";
@@ -8,6 +9,9 @@ Deno.serve(async (req) => {
   if (req.method !== "POST") {
     return new Response("Method Not Allowed", { status: 405 });
   }
+
+  const authError = verifyAppAuth(req);
+  if (authError) return authError;
 
   try {
     const body = await req.json();

--- a/supabase/functions/gemini-stream/index.ts
+++ b/supabase/functions/gemini-stream/index.ts
@@ -1,4 +1,5 @@
 import "@supabase/functions-js/edge-runtime.d.ts";
+import { verifyAppAuth } from "../_shared/auth.ts";
 
 const GEMINI_API_KEY = Deno.env.get("GEMINI_API_KEY")!;
 const GEMINI_MODEL = Deno.env.get("GEMINI_MODEL") ?? "gemini-2.5-flash";
@@ -8,6 +9,9 @@ Deno.serve(async (req) => {
   if (req.method !== "POST") {
     return new Response("Method Not Allowed", { status: 405 });
   }
+
+  const authError = verifyAppAuth(req);
+  if (authError) return authError;
 
   try {
     const body = await req.json();

--- a/supabase/functions/youtube-captions/index.ts
+++ b/supabase/functions/youtube-captions/index.ts
@@ -1,4 +1,5 @@
 import "@supabase/functions-js/edge-runtime.d.ts";
+import { verifyAppAuth } from "../_shared/auth.ts";
 
 const SUPADATA_API_KEY = Deno.env.get("SUPADATA_API_KEY")!;
 
@@ -6,6 +7,9 @@ Deno.serve(async (req) => {
   if (req.method !== "GET") {
     return new Response("Method Not Allowed", { status: 405 });
   }
+
+  const authError = verifyAppAuth(req);
+  if (authError) return authError;
 
   try {
     const reqUrl = new URL(req.url);

--- a/supabase/functions/youtube-title/index.ts
+++ b/supabase/functions/youtube-title/index.ts
@@ -1,9 +1,13 @@
 import "@supabase/functions-js/edge-runtime.d.ts";
+import { verifyAppAuth } from "../_shared/auth.ts";
 
 Deno.serve(async (req) => {
   if (req.method !== "GET") {
     return new Response("Method Not Allowed", { status: 405 });
   }
+
+  const authError = verifyAppAuth(req);
+  if (authError) return authError;
 
   try {
     const url = new URL(req.url);


### PR DESCRIPTION
## Summary

### 보안 강화
- Supabase Edge Functions `x-app-key` 인증 추가 (4개 함수 모두)
- Android HttpClient에 인증 헤더 자동 포함
- `allowBackup="false"` 설정 (ADB 데이터 추출 차단)
- Supabase URL 하드코딩 기본값 제거
- Ktor 로깅: 디버그 HEADERS / 릴리스 NONE
- Release 빌드 minify + shrinkResources 활성화
- 에러 메시지 내부 정보 노출 차단
- ACTION_SEND 입력 길이 4096자 제한

### 기능 개선
- 녹음 1분 이상 시 타임스탬프 포함 STT (`[MM:SS]` 형식)
- 녹음 에러/결과 메시지 3초 후 자동 해제

## Test plan
- [x] 인증 없이 Edge Function 호출 → 401
- [x] 인증 포함 호출 → 200
- [x] 앱에서 유튜브 요약/녹음 STT 정상 동작
- [x] 1분+ 녹음 타임스탬프 확인
- [x] 에러 메시지 자동 해제
- [x] 전체 앱 빌드 성공

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)