### PR TITLE
Add: #80 녹음 메모 고도화 — 오디오 파일 저장 + 재생

### DIFF
--- a/datasource/local/memo/api/src/main/java/me/pecos/memozy/data/datasource/local/entity/Memo.kt
+++ b/datasource/local/memo/api/src/main/java/me/pecos/memozy/data/datasource/local/entity/Memo.kt
@@ -14,5 +14,6 @@ data class Memo(
     val createdAt: Long = System.currentTimeMillis(),
     val updatedAt: Long = System.currentTimeMillis(),
     val format: MemoFormat = MemoFormat.PLAIN,
-    val isPinned: Boolean = false
+    val isPinned: Boolean = false,
+    val audioPath: String? = null
 )

--- a/datasource/local/memo/impl/src/main/java/me/pecos/memozy/data/datasource/local/MemoDatabase.kt
+++ b/datasource/local/memo/impl/src/main/java/me/pecos/memozy/data/datasource/local/MemoDatabase.kt
@@ -135,6 +135,12 @@ val MIGRATION_7_8 = object : Migration(7, 8) {
     }
 }
 
+val MIGRATION_8_9 = object : Migration(8, 9) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        database.execSQL("ALTER TABLE memo ADD COLUMN audioPath TEXT DEFAULT NULL")
+    }
+}
+
 private val PREPOPULATE_CALLBACK = object : RoomDatabase.Callback() {
     override fun onCreate(db: SupportSQLiteDatabase) {
         super.onCreate(db)
@@ -145,7 +151,7 @@ private val PREPOPULATE_CALLBACK = object : RoomDatabase.Callback() {
 @TypeConverters(MemoFormatConverter::class)
 @Database(
     entities = [Memo::class, Category::class, ChatSession::class, ChatMessage::class, YoutubeSummary::class, AiUsage::class],
-    version = 8,
+    version = 9,
     exportSchema = true
 )
 abstract class MemoDatabase : RoomDatabase() {
@@ -167,7 +173,7 @@ abstract class MemoDatabase : RoomDatabase() {
                     MemoDatabase::class.java,
                     "memo_database"
                 )
-                    .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8)
+                    .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9)
                     .addCallback(PREPOPULATE_CALLBACK)
                     .build()
                 INSTANCE = instance

--- a/feature/core/resource/src/main/java/me/pecos/memozy/presentation/screen/home/model/MemoUiState.kt
+++ b/feature/core/resource/src/main/java/me/pecos/memozy/presentation/screen/home/model/MemoUiState.kt
@@ -8,5 +8,6 @@ data class MemoUiState(
     val createdAt: Long = 0L,
     val updatedAt: Long = 0L,
     val format: MemoFormatUi = MemoFormatUi.PLAIN,
-    val isPinned: Boolean = false
+    val isPinned: Boolean = false,
+    val audioPath: String? = null
 )

--- a/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/home/MainViewModel.kt
+++ b/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/home/MainViewModel.kt
@@ -113,7 +113,8 @@ fun MemoUiState.toMemo(): Memo = Memo(
         MemoFormatUi.MARKDOWN -> MemoFormat.MARKDOWN
         MemoFormatUi.PLAIN -> MemoFormat.PLAIN
     },
-    isPinned = this.isPinned
+    isPinned = this.isPinned,
+    audioPath = this.audioPath
 )
 
 fun Memo.toUiState(): MemoUiState = MemoUiState(
@@ -127,5 +128,6 @@ fun Memo.toUiState(): MemoUiState = MemoUiState(
         MemoFormat.MARKDOWN -> MemoFormatUi.MARKDOWN
         MemoFormat.PLAIN -> MemoFormatUi.PLAIN
     },
-    isPinned = this.isPinned
+    isPinned = this.isPinned,
+    audioPath = this.audioPath
 )

--- a/feature/memo-plain/impl/src/main/java/me/pecos/memozy/feature/memoplain/impl/MemoPlainNavigationImpl.kt
+++ b/feature/memo-plain/impl/src/main/java/me/pecos/memozy/feature/memoplain/impl/MemoPlainNavigationImpl.kt
@@ -248,6 +248,7 @@ class MemoPlainNavigationImpl @Inject constructor(
             var isTranscribing by remember { mutableStateOf(false) }
             var transcriptionResult by remember { mutableStateOf<String?>(null) }
             var transcriptionError by remember { mutableStateOf<String?>(null) }
+            var savedAudioPath by remember { mutableStateOf<String?>(null) }
             // 에러/결과 메시지 3초 후 자동 해제
             LaunchedEffect(transcriptionError) {
                 if (transcriptionError != null) {
@@ -360,15 +361,24 @@ class MemoPlainNavigationImpl @Inject constructor(
                         if (result.contains("받아쓰기") || result.contains("텍스트만 출력") || result.isBlank()) {
                             transcriptionError = "음성이 감지되지 않았어요. 다시 시도해주세요."
                             transcriptionResult = null
+                            audioFile.delete()
                         } else {
+                            // 오디오 파일을 영구 저장소로 이동
+                            val audioDir = java.io.File(context.filesDir, "audio")
+                            if (!audioDir.exists()) audioDir.mkdirs()
+                            val permanentFile = java.io.File(audioDir, "recording_${System.currentTimeMillis()}.m4a")
+                            audioFile.copyTo(permanentFile, overwrite = true)
+                            audioFile.delete()
+                            savedAudioPath = permanentFile.absolutePath
+
                             transcriptionResult = result
                             transcriptionError = null
                         }
                     } catch (e: Exception) {
                         transcriptionError = "음성 변환에 실패했어요."
+                        audioFile.delete()
                     } finally {
                         isTranscribing = false
-                        audioFile.delete()
                     }
                 }
             }
@@ -382,10 +392,11 @@ class MemoPlainNavigationImpl @Inject constructor(
                 onAutoSave = { memo ->
                     @OptIn(kotlinx.coroutines.DelicateCoroutinesApi::class)
                     GlobalScope.launch {
+                        val memoWithAudio = memo.copy(audioPath = savedAudioPath ?: memo.audioPath)
                         if (savedMemoId > 0) {
-                            repository.updateMemo(memo.copy(id = savedMemoId).toEntity())
-                        } else if (memo.name.isNotBlank() || memo.content.isNotBlank()) {
-                            val newId = repository.addMemo(memo.toEntity())
+                            repository.updateMemo(memoWithAudio.copy(id = savedMemoId).toEntity())
+                        } else if (memoWithAudio.name.isNotBlank() || memoWithAudio.content.isNotBlank()) {
+                            val newId = repository.addMemo(memoWithAudio.toEntity())
                             savedMemoId = newId.toInt()
                         }
                     }
@@ -400,6 +411,7 @@ class MemoPlainNavigationImpl @Inject constructor(
                 isTranscribing = isTranscribing,
                 transcriptionResult = transcriptionResult,
                 transcriptionError = transcriptionError,
+                audioPath = savedAudioPath,
                 onYoutubeDetected = { videoId ->
                     scope.launch {
                         val title = captionService.fetchTitle(videoId)
@@ -463,13 +475,13 @@ class MemoPlainNavigationImpl @Inject constructor(
                 },
                 onSave = { memo ->
                     scope.launch {
+                        val memoWithAudio = memo.copy(audioPath = savedAudioPath ?: memo.audioPath)
                         if (savedMemoId > 0) {
-                            // 자동저장으로 이미 생성된 메모 → update
-                            repository.updateMemo(memo.copy(id = savedMemoId).toEntity())
+                            repository.updateMemo(memoWithAudio.copy(id = savedMemoId).toEntity())
                         } else if (memoId > 0 && existingMemo != null) {
-                            repository.updateMemo(memo.toEntity())
+                            repository.updateMemo(memoWithAudio.toEntity())
                         } else {
-                            repository.addMemo(memo.toEntity())
+                            repository.addMemo(memoWithAudio.toEntity())
                         }
                         onNavigateToHome()
                     }
@@ -488,7 +500,8 @@ class MemoPlainNavigationImpl @Inject constructor(
         id = id,
         name = name,
         categoryId = categoryId,
-        content = content
+        content = content,
+        audioPath = audioPath
     )
 
     private suspend fun summarizeVideo(

--- a/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/MemoScreen.kt
+++ b/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/MemoScreen.kt
@@ -29,6 +29,8 @@ import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Mic
+import androidx.compose.material.icons.filled.Pause
+import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Stop
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material.icons.filled.SmartDisplay
@@ -135,6 +137,7 @@ fun MemoScreen(
     isTranscribing: Boolean = false,
     transcriptionResult: String? = null,
     transcriptionError: String? = null,
+    audioPath: String? = null,
     existingMemo: MemoUiState = MemoUiState(0, "", 1, "")
 ) {
     val isNewMemo = existingMemo.id <= 0
@@ -346,6 +349,66 @@ fun MemoScreen(
                 }
 
                 Spacer(modifier = Modifier.height(16.dp))
+
+                // 오디오 재생 바 (녹음 파일이 있는 메모)
+                val effectiveAudioPath = audioPath ?: existingMemo.audioPath
+                if (effectiveAudioPath != null && java.io.File(effectiveAudioPath).exists()) {
+                    var isPlaying by remember { mutableStateOf(false) }
+                    val mediaPlayer = remember {
+                        android.media.MediaPlayer().apply {
+                            setDataSource(effectiveAudioPath)
+                            prepare()
+                            setOnCompletionListener { isPlaying = false }
+                        }
+                    }
+
+                    DisposableEffect(Unit) {
+                        onDispose {
+                            mediaPlayer.release()
+                        }
+                    }
+
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clip(RoundedCornerShape(10.dp))
+                            .background(colors.chipBackground.copy(alpha = 0.5f))
+                            .padding(horizontal = 12.dp, vertical = 10.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Box(
+                            modifier = Modifier
+                                .size(36.dp)
+                                .clip(CircleShape)
+                                .background(colors.chipText)
+                                .clickable {
+                                    if (isPlaying) {
+                                        mediaPlayer.pause()
+                                        isPlaying = false
+                                    } else {
+                                        mediaPlayer.start()
+                                        isPlaying = true
+                                    }
+                                },
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Icon(
+                                imageVector = if (isPlaying) Icons.Default.Pause else Icons.Default.PlayArrow,
+                                contentDescription = null,
+                                tint = Color.White,
+                                modifier = Modifier.size(20.dp)
+                            )
+                        }
+                        Spacer(modifier = Modifier.width(10.dp))
+                        Text(
+                            text = "🎙️ 녹음 파일",
+                            fontSize = 14.sp,
+                            color = colors.textBody,
+                            fontWeight = FontWeight.SemiBold
+                        )
+                    }
+                    Spacer(modifier = Modifier.height(12.dp))
+                }
 
                 // 녹음 상태 인라인 표시 (녹음 중/변환 중일 때만)
                 if (isRecording || isTranscribing || transcriptionError != null) {


### PR DESCRIPTION
## Summary
- Memo Entity에 `audioPath: String?` 필드 추가 (Room Migration 8→9)
- 녹음 STT 성공 시 오디오 파일을 `filesDir/audio/`에 영구 보관
- 메모 저장/자동저장 시 audioPath 포함
- 메모 화면에 오디오 재생/일시정지 버튼 UI (MediaPlayer)

## Test plan
- [x] 녹음 → STT → 오디오 파일 영구 저장 확인
- [x] 메모 재열기 시 재생 버튼 표시
- [x] 재생/일시정지 정상 동작
- [x] DB Migration 정상 (version 8→9)
- [x] 전체 앱 빌드 성공

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)