### PR TITLE
Add: #75 메모 서식 툴바 — 굵기, 기울임, 취소선, 색상

### DIFF
--- a/data/repository/memo/api/src/main/java/me/pecos/memozy/data/repository/MemoRepository.kt
+++ b/data/repository/memo/api/src/main/java/me/pecos/memozy/data/repository/MemoRepository.kt
@@ -5,6 +5,7 @@ import me.pecos.memozy.data.datasource.local.entity.Memo
 
 interface MemoRepository {
     fun getMemos(): Flow<List<Memo>>
+    suspend fun getMemoById(id: Int): Memo?
     suspend fun addMemo(memo: Memo): Long
     suspend fun deleteMemo(id: Int)
     suspend fun updateMemo(memo: Memo)

--- a/data/repository/memo/impl/src/main/java/me/pecos/memozy/data/repository/MemoRepositoryImpl.kt
+++ b/data/repository/memo/impl/src/main/java/me/pecos/memozy/data/repository/MemoRepositoryImpl.kt
@@ -9,6 +9,8 @@ class MemoRepositoryImpl @Inject constructor(private val memoDao: MemoDao) : Mem
 
     override fun getMemos(): Flow<List<Memo>> = memoDao.getAllMemos()
 
+    override suspend fun getMemoById(id: Int): Memo? = memoDao.getMemoById(id)
+
     override suspend fun addMemo(memo: Memo): Long {
         return memoDao.insertMemo(memo)
     }

--- a/datasource/local/memo/api/src/main/java/me/pecos/memozy/data/datasource/local/MemoDao.kt
+++ b/datasource/local/memo/api/src/main/java/me/pecos/memozy/data/datasource/local/MemoDao.kt
@@ -18,6 +18,9 @@ interface MemoDao {
     @Update
     suspend fun updateMemo(memo: Memo)
 
+    @Query("SELECT * FROM memo WHERE id = :id")
+    suspend fun getMemoById(id: Int): Memo?
+
     @Query("DELETE FROM memo WHERE id = :id")
     suspend fun deleteMemoById(id: Int)
 

--- a/datasource/local/memo/api/src/main/java/me/pecos/memozy/data/datasource/local/entity/Memo.kt
+++ b/datasource/local/memo/api/src/main/java/me/pecos/memozy/data/datasource/local/entity/Memo.kt
@@ -15,5 +15,6 @@ data class Memo(
     val updatedAt: Long = System.currentTimeMillis(),
     val format: MemoFormat = MemoFormat.PLAIN,
     val isPinned: Boolean = false,
-    val audioPath: String? = null
+    val audioPath: String? = null,
+    val styles: String? = null // JSON: [{start,end,bold,italic,strikethrough,color}]
 )

--- a/datasource/local/memo/impl/src/main/java/me/pecos/memozy/data/datasource/local/MemoDatabase.kt
+++ b/datasource/local/memo/impl/src/main/java/me/pecos/memozy/data/datasource/local/MemoDatabase.kt
@@ -141,6 +141,12 @@ val MIGRATION_8_9 = object : Migration(8, 9) {
     }
 }
 
+val MIGRATION_9_10 = object : Migration(9, 10) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        database.execSQL("ALTER TABLE memo ADD COLUMN styles TEXT DEFAULT NULL")
+    }
+}
+
 private val PREPOPULATE_CALLBACK = object : RoomDatabase.Callback() {
     override fun onCreate(db: SupportSQLiteDatabase) {
         super.onCreate(db)
@@ -151,7 +157,7 @@ private val PREPOPULATE_CALLBACK = object : RoomDatabase.Callback() {
 @TypeConverters(MemoFormatConverter::class)
 @Database(
     entities = [Memo::class, Category::class, ChatSession::class, ChatMessage::class, YoutubeSummary::class, AiUsage::class],
-    version = 9,
+    version = 10,
     exportSchema = true
 )
 abstract class MemoDatabase : RoomDatabase() {
@@ -173,7 +179,7 @@ abstract class MemoDatabase : RoomDatabase() {
                     MemoDatabase::class.java,
                     "memo_database"
                 )
-                    .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9)
+                    .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10)
                     .addCallback(PREPOPULATE_CALLBACK)
                     .build()
                 INSTANCE = instance

--- a/feature/core/resource/src/main/java/me/pecos/memozy/presentation/screen/home/model/MemoUiState.kt
+++ b/feature/core/resource/src/main/java/me/pecos/memozy/presentation/screen/home/model/MemoUiState.kt
@@ -9,5 +9,6 @@ data class MemoUiState(
     val updatedAt: Long = 0L,
     val format: MemoFormatUi = MemoFormatUi.PLAIN,
     val isPinned: Boolean = false,
-    val audioPath: String? = null
+    val audioPath: String? = null,
+    val styles: String? = null
 )

--- a/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/home/MainViewModel.kt
+++ b/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/home/MainViewModel.kt
@@ -114,7 +114,8 @@ fun MemoUiState.toMemo(): Memo = Memo(
         MemoFormatUi.PLAIN -> MemoFormat.PLAIN
     },
     isPinned = this.isPinned,
-    audioPath = this.audioPath
+    audioPath = this.audioPath,
+    styles = this.styles
 )
 
 fun Memo.toUiState(): MemoUiState = MemoUiState(
@@ -129,5 +130,6 @@ fun Memo.toUiState(): MemoUiState = MemoUiState(
         MemoFormat.PLAIN -> MemoFormatUi.PLAIN
     },
     isPinned = this.isPinned,
-    audioPath = this.audioPath
+    audioPath = this.audioPath,
+    styles = this.styles
 )

--- a/feature/memo-plain/impl/build.gradle.kts
+++ b/feature/memo-plain/impl/build.gradle.kts
@@ -19,4 +19,5 @@ dependencies {
     implementation(libs.kotlinx.coroutines.android)
     implementation(libs.androidx.lifecycle.runtime.compose)
     implementation(libs.androidx.compose.material.icons.extended)
+    implementation(libs.richeditor.compose)
 }

--- a/feature/memo-plain/impl/src/main/java/me/pecos/memozy/feature/memoplain/impl/MemoPlainNavigationImpl.kt
+++ b/feature/memo-plain/impl/src/main/java/me/pecos/memozy/feature/memoplain/impl/MemoPlainNavigationImpl.kt
@@ -197,25 +197,34 @@ class MemoPlainNavigationImpl @Inject constructor(
                 }
             }
 
-            val memos by repository.getMemos()
-                .map { list ->
-                    list.map { memo ->
+            // 기존 메모 직접 조회 (suspend, 빠름)
+            var existingMemo by remember { mutableStateOf<MemoUiState?>(null) }
+            var memoLoaded by remember { mutableStateOf(memoId <= 0) }
+            LaunchedEffect(memoId) {
+                if (memoId > 0) {
+                    val memo = repository.getMemoById(memoId)
+                    existingMemo = memo?.let {
                         MemoUiState(
-                            id = memo.id,
-                            name = memo.name,
-                            categoryId = memo.categoryId,
-                            content = memo.content,
-                            createdAt = memo.createdAt,
-                            updatedAt = memo.updatedAt,
-                            format = when (memo.format) {
+                            id = it.id,
+                            name = it.name,
+                            categoryId = it.categoryId,
+                            content = it.content,
+                            createdAt = it.createdAt,
+                            updatedAt = it.updatedAt,
+                            format = when (it.format) {
                                 MemoFormat.MARKDOWN -> MemoFormatUi.MARKDOWN
                                 MemoFormat.PLAIN -> MemoFormatUi.PLAIN
-                            }
+                            },
+                            isPinned = it.isPinned,
+                            audioPath = it.audioPath,
+                            styles = it.styles
                         )
                     }
+                    memoLoaded = true
                 }
-                .collectAsState(initial = emptyList())
-            val existingMemo = memos.firstOrNull { it.id == memoId }
+            }
+
+            if (!memoLoaded) return@composable
 
             // 요약 에러 시 원본 URL만 프리필
             val finalMemo = sharedMemo
@@ -501,7 +510,8 @@ class MemoPlainNavigationImpl @Inject constructor(
         name = name,
         categoryId = categoryId,
         content = content,
-        audioPath = audioPath
+        audioPath = audioPath,
+        styles = styles
     )
 
     private suspend fun summarizeVideo(

--- a/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/MemoScreen.kt
+++ b/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/MemoScreen.kt
@@ -49,8 +49,13 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.input.OffsetMapping
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.input.TransformedText
 import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.material.icons.filled.FormatBold
+import androidx.compose.material.icons.filled.FormatItalic
+import androidx.compose.material.icons.filled.FormatStrikethrough
 import androidx.compose.ui.text.style.LineHeightStyle
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.withStyle
@@ -74,6 +79,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
@@ -98,6 +105,41 @@ import me.pecos.memozy.presentation.theme.LocalAppColors
 private val YOUTUBE_URL_REGEX = Regex(
     """(?:https?://)?(?:www\.)?(?:youtube\.com/watch\?v=|youtu\.be/|youtube\.com/shorts/)[\w\-]+(?:[&?][\w\-=]*)*"""
 )
+
+private class StyleVisualTransformation(
+    private val styles: List<TextSpanStyle>
+) : VisualTransformation {
+    override fun filter(text: AnnotatedString): TransformedText {
+        val result = buildAnnotatedString {
+            append(text)
+            // 사용자 서식 적용
+            for (style in styles) {
+                if (style.start >= text.length || style.end > text.length || style.start >= style.end) continue
+                addStyle(
+                    SpanStyle(
+                        fontWeight = if (style.bold) FontWeight.Bold else null,
+                        fontStyle = if (style.italic) FontStyle.Italic else null,
+                        textDecoration = if (style.strikethrough) TextDecoration.LineThrough else null,
+                        color = style.color?.let {
+                            try { Color(android.graphics.Color.parseColor(it)) } catch (_: Exception) { Color.Unspecified }
+                        } ?: Color.Unspecified
+                    ),
+                    start = style.start,
+                    end = style.end
+                )
+            }
+            // YouTube URL 하이라이트
+            YOUTUBE_URL_REGEX.findAll(text.text).forEach { match ->
+                addStyle(
+                    SpanStyle(color = Color(0xFF2196F3), textDecoration = TextDecoration.Underline),
+                    start = match.range.first,
+                    end = match.range.last + 1
+                )
+            }
+        }
+        return TransformedText(result, OffsetMapping.Identity)
+    }
+}
 
 private class UrlHighlightTransformation : VisualTransformation {
     override fun filter(text: AnnotatedString): TransformedText {
@@ -163,6 +205,7 @@ fun MemoScreen(
         mutableStateOf((existingMemo.categoryId - 1).coerceIn(0, CATEGORY_RES_IDS.size - 1))
     }
     var bodyText by remember { mutableStateOf(existingMemo.content) }
+    val richTextState = com.mohamedrejeb.richeditor.model.rememberRichTextState()
     if (!initialized && existingMemo.id > 0 && existingMemo.name.isNotEmpty()) {
         nameText = existingMemo.name
         categoryIndex = (existingMemo.categoryId - 1).coerceIn(0, CATEGORY_RES_IDS.size - 1)
@@ -200,7 +243,8 @@ fun MemoScreen(
             id = existingMemo.id,
             name = nameText,
             categoryId = categoryIndex + 1,
-            content = bodyText
+            content = bodyText,
+            styles = richTextState.toHtml().takeIf { it.isNotBlank() }
         )
     }
     val canAutoSave = nameText.isNotBlank() || bodyText.isNotBlank()
@@ -292,7 +336,7 @@ fun MemoScreen(
                     color = colors.chipText,
                     modifier = Modifier
                         .clickable {
-                            onSave(MemoUiState(id = existingMemo.id, name = nameText, categoryId = categoryIndex + 1, content = bodyText))
+                            onSave(MemoUiState(id = existingMemo.id, name = nameText, categoryId = categoryIndex + 1, content = bodyText, styles = richTextState.toHtml().takeIf { it.isNotBlank() }))
                         }
                         .padding(horizontal = 8.dp, vertical = 4.dp)
                 )
@@ -343,8 +387,11 @@ fun MemoScreen(
                 // 녹음 결과를 본문에 삽입
                 LaunchedEffect(transcriptionResult) {
                     if (transcriptionResult != null) {
-                        bodyText = if (bodyText.isBlank()) transcriptionResult
-                        else "$bodyText\n\n$transcriptionResult"
+                        val current = richTextState.annotatedString.text
+                        val newText = if (current.isBlank()) transcriptionResult
+                        else "$current\n\n$transcriptionResult"
+                        richTextState.setText(newText)
+                        bodyText = newText
                     }
                 }
 
@@ -445,22 +492,157 @@ fun MemoScreen(
                     }
                 }
 
+                // 초기 내용 로드 (HTML 저장 방식)
+                LaunchedEffect(Unit) {
+                    val savedStyles = existingMemo.styles
+                    if (savedStyles != null) {
+                        richTextState.setHtml(savedStyles)
+                    } else if (bodyText.isNotEmpty()) {
+                        richTextState.setText(bodyText)
+                    }
+                }
+
+                // richTextState → bodyText 동기화
+                LaunchedEffect(richTextState.annotatedString) {
+                    val plainText = richTextState.annotatedString.text
+                    if (plainText != bodyText) {
+                        bodyText = plainText
+                    }
+                }
+
+                // 서식 툴바
+                var showColorPicker by remember { mutableStateOf(false) }
+                var savedColorSelection by remember { mutableStateOf(androidx.compose.ui.text.TextRange.Zero) }
+
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(bottom = 8.dp),
+                    horizontalArrangement = Arrangement.spacedBy(6.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    val activeBg = colors.chipBackground
+                    val activeTint = colors.chipText
+
+                    // Bold
+                    val isBold = richTextState.currentSpanStyle.fontWeight == FontWeight.Bold
+                    Box(
+                        modifier = Modifier
+                            .size(36.dp)
+                            .clip(RoundedCornerShape(8.dp))
+                            .background(if (isBold) activeBg else activeBg.copy(alpha = 0.4f))
+                            .pointerInput(Unit) {
+                                detectTapGestures(onPress = {
+                                    richTextState.toggleSpanStyle(SpanStyle(fontWeight = FontWeight.Bold))
+                                    tryAwaitRelease()
+                                })
+                            },
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Icon(Icons.Default.FormatBold, contentDescription = null, tint = activeTint, modifier = Modifier.size(20.dp))
+                    }
+                    // Italic
+                    val isItalic = richTextState.currentSpanStyle.fontStyle == FontStyle.Italic
+                    Box(
+                        modifier = Modifier
+                            .size(36.dp)
+                            .clip(RoundedCornerShape(8.dp))
+                            .background(if (isItalic) activeBg else activeBg.copy(alpha = 0.4f))
+                            .pointerInput(Unit) {
+                                detectTapGestures(onPress = {
+                                    richTextState.toggleSpanStyle(SpanStyle(fontStyle = FontStyle.Italic))
+                                    tryAwaitRelease()
+                                })
+                            },
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Icon(Icons.Default.FormatItalic, contentDescription = null, tint = activeTint, modifier = Modifier.size(20.dp))
+                    }
+                    // Strikethrough
+                    val isStrike = richTextState.currentSpanStyle.textDecoration == TextDecoration.LineThrough
+                    Box(
+                        modifier = Modifier
+                            .size(36.dp)
+                            .clip(RoundedCornerShape(8.dp))
+                            .background(if (isStrike) activeBg else activeBg.copy(alpha = 0.4f))
+                            .pointerInput(Unit) {
+                                detectTapGestures(onPress = {
+                                    richTextState.toggleSpanStyle(SpanStyle(textDecoration = TextDecoration.LineThrough))
+                                    tryAwaitRelease()
+                                })
+                            },
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Icon(Icons.Default.FormatStrikethrough, contentDescription = null, tint = activeTint, modifier = Modifier.size(20.dp))
+                    }
+                    // 색상 버튼 (탭하면 인라인으로 색상 펼침)
+                    Box(
+                        modifier = Modifier
+                            .size(36.dp)
+                            .clip(RoundedCornerShape(8.dp))
+                            .background(if (showColorPicker) activeBg else activeBg.copy(alpha = 0.4f))
+                            .pointerInput(Unit) {
+                                detectTapGestures(onPress = {
+                                    savedColorSelection = richTextState.selection
+                                    showColorPicker = !showColorPicker
+                                    tryAwaitRelease()
+                                })
+                            },
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                            Text("A", fontSize = 16.sp, fontWeight = FontWeight.Bold, color = activeTint)
+                            Box(modifier = Modifier.width(16.dp).height(3.dp).background(Color(0xFFFF0000), RoundedCornerShape(1.dp)))
+                        }
+                    }
+
+                }
+
+                // 색상 팔레트 — 툴바 아래 별도 Row
+                if (showColorPicker) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(bottom = 8.dp),
+                        horizontalArrangement = Arrangement.spacedBy(10.dp)
+                    ) {
+                        val textColors = listOf(
+                            "#FF0000", "#FF9800", "#FFEB3B", "#4CAF50",
+                            "#2196F3", "#9C27B0", "#795548", "#607D8B"
+                        )
+                        textColors.forEach { hex ->
+                            Box(
+                                modifier = Modifier
+                                    .size(22.dp)
+                                    .clip(CircleShape)
+                                    .background(Color(android.graphics.Color.parseColor(hex)))
+                                    .pointerInput(hex) {
+                                        detectTapGestures(onPress = {
+                                            if (savedColorSelection.start != savedColorSelection.end) {
+                                                richTextState.addSpanStyle(
+                                                    SpanStyle(color = Color(android.graphics.Color.parseColor(hex))),
+                                                    savedColorSelection
+                                                )
+                                            }
+                                            showColorPicker = false
+                                            tryAwaitRelease()
+                                        })
+                                    }
+                            )
+                        }
+                    }
+                }
+
                 // 내용 — YouTube 링크 감지
                 var selectedYoutubeUrl by remember { mutableStateOf<String?>(null) }
                 val sheetState = rememberModalBottomSheetState()
 
-                val urlHighlight = remember { UrlHighlightTransformation() }
-
-                BasicTextField(
-                    value = bodyText,
+                com.mohamedrejeb.richeditor.ui.BasicRichTextEditor(
+                    state = richTextState,
                     modifier = Modifier
                         .fillMaxWidth()
                         .heightIn(min = 150.dp)
                         .focusRequester(bodyFocusRequester),
-                    onValueChange = { newText ->
-                        bodyText = newText
-                    },
-                    visualTransformation = urlHighlight,
                     textStyle = TextStyle(
                         fontSize = 15.sp,
                         lineHeight = 24.sp,
@@ -472,7 +654,7 @@ fun MemoScreen(
                     ),
                     decorationBox = { innerTextField ->
                         Box(modifier = Modifier.heightIn(min = 150.dp)) {
-                            if (bodyText.isEmpty()) {
+                            if (richTextState.annotatedString.text.isEmpty()) {
                                 Text(
                                     text = stringResource(R.string.memo_content_placeholder),
                                     fontSize = 15.sp,

--- a/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/TextStyleModel.kt
+++ b/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/TextStyleModel.kt
@@ -1,0 +1,127 @@
+package me.pecos.memozy.presentation.screen.memo
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
+import org.json.JSONArray
+import org.json.JSONObject
+
+data class TextSpanStyle(
+    val start: Int,
+    val end: Int,
+    val bold: Boolean = false,
+    val italic: Boolean = false,
+    val strikethrough: Boolean = false,
+    val color: String? = null
+)
+
+fun List<TextSpanStyle>.toJson(): String {
+    val arr = JSONArray()
+    for (s in this) {
+        val obj = JSONObject()
+        obj.put("s", s.start)
+        obj.put("e", s.end)
+        if (s.bold) obj.put("b", true)
+        if (s.italic) obj.put("i", true)
+        if (s.strikethrough) obj.put("st", true)
+        if (s.color != null) obj.put("c", s.color)
+        arr.put(obj)
+    }
+    return arr.toString()
+}
+
+fun String?.toTextSpanStyles(): List<TextSpanStyle> {
+    if (this.isNullOrBlank()) return emptyList()
+    return try {
+        val arr = JSONArray(this)
+        (0 until arr.length()).map { idx ->
+            val obj = arr.getJSONObject(idx)
+            TextSpanStyle(
+                start = obj.getInt("s"),
+                end = obj.getInt("e"),
+                bold = obj.optBoolean("b", false),
+                italic = obj.optBoolean("i", false),
+                strikethrough = obj.optBoolean("st", false),
+                color = obj.optString("c", null)
+            )
+        }
+    } catch (_: Exception) {
+        emptyList()
+    }
+}
+
+fun applyStylesToText(text: String, styles: List<TextSpanStyle>): AnnotatedString {
+    return buildAnnotatedString {
+        append(text)
+        for (style in styles) {
+            if (style.start >= text.length || style.end > text.length || style.start >= style.end) continue
+            addStyle(
+                SpanStyle(
+                    fontWeight = if (style.bold) FontWeight.Bold else null,
+                    fontStyle = if (style.italic) FontStyle.Italic else null,
+                    textDecoration = if (style.strikethrough) TextDecoration.LineThrough else null,
+                    color = style.color?.let { parseHexColor(it) } ?: Color.Unspecified
+                ),
+                start = style.start,
+                end = style.end
+            )
+        }
+    }
+}
+
+fun toggleStyle(
+    styles: List<TextSpanStyle>,
+    selectionStart: Int,
+    selectionEnd: Int,
+    bold: Boolean? = null,
+    italic: Boolean? = null,
+    strikethrough: Boolean? = null,
+    color: String? = null
+): List<TextSpanStyle> {
+    if (selectionStart == selectionEnd) return styles
+
+    val result = styles.toMutableList()
+    val overlapping = result.filter { it.start < selectionEnd && it.end > selectionStart }
+
+    val allBold = bold != null && overlapping.isNotEmpty() && overlapping.all { it.bold }
+    val allItalic = italic != null && overlapping.isNotEmpty() && overlapping.all { it.italic }
+    val allStrike = strikethrough != null && overlapping.isNotEmpty() && overlapping.all { it.strikethrough }
+
+    result.removeAll(overlapping.toSet())
+
+    for (existing in overlapping) {
+        if (existing.start < selectionStart) {
+            result.add(existing.copy(end = selectionStart))
+        }
+        if (existing.end > selectionEnd) {
+            result.add(existing.copy(start = selectionEnd))
+        }
+    }
+
+    val newStyle = TextSpanStyle(
+        start = selectionStart,
+        end = selectionEnd,
+        bold = if (bold != null) !allBold else overlapping.firstOrNull()?.bold ?: false,
+        italic = if (italic != null) !allItalic else overlapping.firstOrNull()?.italic ?: false,
+        strikethrough = if (strikethrough != null) !allStrike else overlapping.firstOrNull()?.strikethrough ?: false,
+        color = color ?: overlapping.firstOrNull()?.color
+    )
+
+    if (newStyle.bold || newStyle.italic || newStyle.strikethrough || newStyle.color != null) {
+        result.add(newStyle)
+    }
+
+    return result.sortedBy { it.start }
+}
+
+private fun parseHexColor(hex: String): Color {
+    return try {
+        Color(android.graphics.Color.parseColor(hex))
+    } catch (_: Exception) {
+        Color.Unspecified
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,6 +22,7 @@ navigationCompose = "2.8.9"
 kotlinxCoroutines = "1.10.2"
 ktor = "3.1.3"
 kotlinxSerialization = "1.8.1"
+richeditor = "1.0.0-rc11"
 
 [libraries]
 gradlePlugin-android = { module = "com.android.tools.build:gradle", version.ref = "agp" }
@@ -55,6 +56,7 @@ androidx-compose-foundation-layout = { group = "androidx.compose.foundation", na
 androidx-compose-navigation = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose"  }
 kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "kotlinxCoroutines" }
 montage-android = { module = "com.github.wanteddev:montage-android", version.ref = "montageAndroid" }
+richeditor-compose = { module = "com.mohamedrejeb.richeditor:richeditor-compose", version.ref = "richeditor" }
 room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
 room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
 room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }


### PR DESCRIPTION
## Summary
- compose-richeditor 라이브러리 도입 (`BasicRichTextEditor`)
- 서식 툴바: **B** / *I* / ~~S~~ / 🎨 색상 팔레트 (8색 인라인)
- `pointerInput` + `detectTapGestures`로 포커스/selection 유지
- 색상: A 버튼 탭 시 selection 저장 → 색상 탭 시 `addSpanStyle(range)` 적용
- 서식 데이터 HTML로 DB 저장/복원 (`Memo.styles`, Migration 9→10)
- 메모 수정 화면 `getMemoById` 직접 조회로 진입 딜레이 제거

## Test plan
- [x] Bold / Italic / Strikethrough 텍스트 선택 후 적용
- [x] 색상 선택 후 적용
- [x] 중첩 서식 (Bold + Italic + 색상)
- [x] 저장 후 재열기 시 서식 복원
- [x] 메모 수정 화면 즉시 진입
- [x] 전체 앱 빌드 성공

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)