### PR TITLE
Add: #69 카테고리 → 태그 시스템 전환 + 메모 UX 대폭 개선

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,6 +19,16 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.Memozy"
         android:localeConfig="@xml/locales_config">
+
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
     </application>
 
 </manifest>

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <files-path name="audio" path="audio/" />
+    <cache-path name="cache" path="." />
+</paths>

--- a/datasource/local/memo/api/src/main/java/me/pecos/memozy/data/datasource/local/TagDao.kt
+++ b/datasource/local/memo/api/src/main/java/me/pecos/memozy/data/datasource/local/TagDao.kt
@@ -1,0 +1,52 @@
+package me.pecos.memozy.data.datasource.local
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Update
+import kotlinx.coroutines.flow.Flow
+import me.pecos.memozy.data.datasource.local.entity.MemoTag
+import me.pecos.memozy.data.datasource.local.entity.Tag
+
+@Dao
+interface TagDao {
+    @Query("SELECT * FROM tag ORDER BY name ASC")
+    fun getAllTags(): Flow<List<Tag>>
+
+    @Query("SELECT * FROM tag ORDER BY name ASC")
+    suspend fun getAllTagsOnce(): List<Tag>
+
+    @Insert
+    suspend fun insertTag(tag: Tag): Long
+
+    @Update
+    suspend fun updateTag(tag: Tag)
+
+    @Query("DELETE FROM tag WHERE id = :id")
+    suspend fun deleteTagById(id: Int)
+
+    @Query("SELECT * FROM tag WHERE id = :id")
+    suspend fun getTagById(id: Int): Tag?
+
+    // 메모-태그 관계
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun insertMemoTag(memoTag: MemoTag)
+
+    @Query("DELETE FROM memo_tag WHERE memoId = :memoId AND tagId = :tagId")
+    suspend fun removeMemoTag(memoId: Int, tagId: Int)
+
+    @Query("DELETE FROM memo_tag WHERE memoId = :memoId")
+    suspend fun removeAllTagsForMemo(memoId: Int)
+
+    // 메모에 연결된 태그 조회
+    @Query("SELECT t.* FROM tag t INNER JOIN memo_tag mt ON t.id = mt.tagId WHERE mt.memoId = :memoId ORDER BY t.name ASC")
+    suspend fun getTagsForMemo(memoId: Int): List<Tag>
+
+    @Query("SELECT t.* FROM tag t INNER JOIN memo_tag mt ON t.id = mt.tagId WHERE mt.memoId = :memoId ORDER BY t.name ASC")
+    fun getTagsForMemoFlow(memoId: Int): Flow<List<Tag>>
+
+    // 태그에 연결된 메모 ID 조회
+    @Query("SELECT memoId FROM memo_tag WHERE tagId = :tagId")
+    fun getMemoIdsForTag(tagId: Int): Flow<List<Int>>
+}

--- a/datasource/local/memo/api/src/main/java/me/pecos/memozy/data/datasource/local/entity/Memo.kt
+++ b/datasource/local/memo/api/src/main/java/me/pecos/memozy/data/datasource/local/entity/Memo.kt
@@ -16,5 +16,6 @@ data class Memo(
     val format: MemoFormat = MemoFormat.PLAIN,
     val isPinned: Boolean = false,
     val audioPath: String? = null,
-    val styles: String? = null // JSON: [{start,end,bold,italic,strikethrough,color}]
+    val styles: String? = null, // JSON: [{start,end,bold,italic,strikethrough,color}]
+    val youtubeUrl: String? = null
 )

--- a/datasource/local/memo/api/src/main/java/me/pecos/memozy/data/datasource/local/entity/MemoTag.kt
+++ b/datasource/local/memo/api/src/main/java/me/pecos/memozy/data/datasource/local/entity/MemoTag.kt
@@ -1,0 +1,19 @@
+package me.pecos.memozy.data.datasource.local.entity
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+
+@Entity(
+    tableName = "memo_tag",
+    primaryKeys = ["memoId", "tagId"],
+    foreignKeys = [
+        ForeignKey(entity = Memo::class, parentColumns = ["id"], childColumns = ["memoId"], onDelete = ForeignKey.CASCADE),
+        ForeignKey(entity = Tag::class, parentColumns = ["id"], childColumns = ["tagId"], onDelete = ForeignKey.CASCADE)
+    ],
+    indices = [Index("memoId"), Index("tagId")]
+)
+data class MemoTag(
+    val memoId: Int,
+    val tagId: Int
+)

--- a/datasource/local/memo/api/src/main/java/me/pecos/memozy/data/datasource/local/entity/Tag.kt
+++ b/datasource/local/memo/api/src/main/java/me/pecos/memozy/data/datasource/local/entity/Tag.kt
@@ -1,0 +1,13 @@
+package me.pecos.memozy.data.datasource.local.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "tag")
+data class Tag(
+    @PrimaryKey(autoGenerate = true)
+    val id: Int = 0,
+    val name: String,
+    val emoji: String = "🏷️",
+    val createdAt: Long = System.currentTimeMillis()
+)

--- a/datasource/local/memo/impl/schemas/me.pecos.memozy.data.datasource.local.MemoDatabase/10.json
+++ b/datasource/local/memo/impl/schemas/me.pecos.memozy.data.datasource.local.MemoDatabase/10.json
@@ -1,0 +1,286 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 10,
+    "identityHash": "fd22a205f0053af06343d40f56f6af03",
+    "entities": [
+      {
+        "tableName": "memo",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `categoryId` INTEGER NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `format` TEXT NOT NULL, `isPinned` INTEGER NOT NULL, `audioPath` TEXT, `styles` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "categoryId",
+            "columnName": "categoryId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "format",
+            "columnName": "format",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isPinned",
+            "columnName": "isPinned",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "audioPath",
+            "columnName": "audioPath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "styles",
+            "columnName": "styles",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "category",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "chat_session",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `title` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `category` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "chat_message",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sessionId` INTEGER NOT NULL, `role` TEXT NOT NULL, `content` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, `metadata` TEXT, FOREIGN KEY(`sessionId`) REFERENCES `chat_session`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadata",
+            "columnName": "metadata",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_chat_message_sessionId",
+            "unique": false,
+            "columnNames": [
+              "sessionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chat_message_sessionId` ON `${TABLE_NAME}` (`sessionId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "chat_session",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sessionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "youtube_summary",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`videoId` TEXT NOT NULL, `url` TEXT NOT NULL, `summary` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`videoId`))",
+        "fields": [
+          {
+            "fieldPath": "videoId",
+            "columnName": "videoId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "summary",
+            "columnName": "summary",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "videoId"
+          ]
+        }
+      },
+      {
+        "tableName": "ai_usage",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `feature` TEXT NOT NULL, `usedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "feature",
+            "columnName": "feature",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "usedAt",
+            "columnName": "usedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'fd22a205f0053af06343d40f56f6af03')"
+    ]
+  }
+}

--- a/datasource/local/memo/impl/schemas/me.pecos.memozy.data.datasource.local.MemoDatabase/11.json
+++ b/datasource/local/memo/impl/schemas/me.pecos.memozy.data.datasource.local.MemoDatabase/11.json
@@ -1,0 +1,391 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 11,
+    "identityHash": "1fcf5c81af491f11aa8f5980799cc236",
+    "entities": [
+      {
+        "tableName": "memo",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `categoryId` INTEGER NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `format` TEXT NOT NULL, `isPinned` INTEGER NOT NULL, `audioPath` TEXT, `styles` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "categoryId",
+            "columnName": "categoryId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "format",
+            "columnName": "format",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isPinned",
+            "columnName": "isPinned",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "audioPath",
+            "columnName": "audioPath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "styles",
+            "columnName": "styles",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "category",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "chat_session",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `title` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `category` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "chat_message",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sessionId` INTEGER NOT NULL, `role` TEXT NOT NULL, `content` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, `metadata` TEXT, FOREIGN KEY(`sessionId`) REFERENCES `chat_session`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadata",
+            "columnName": "metadata",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_chat_message_sessionId",
+            "unique": false,
+            "columnNames": [
+              "sessionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chat_message_sessionId` ON `${TABLE_NAME}` (`sessionId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "chat_session",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sessionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "youtube_summary",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`videoId` TEXT NOT NULL, `url` TEXT NOT NULL, `summary` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`videoId`))",
+        "fields": [
+          {
+            "fieldPath": "videoId",
+            "columnName": "videoId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "summary",
+            "columnName": "summary",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "videoId"
+          ]
+        }
+      },
+      {
+        "tableName": "ai_usage",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `feature` TEXT NOT NULL, `usedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "feature",
+            "columnName": "feature",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "usedAt",
+            "columnName": "usedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "tag",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `emoji` TEXT NOT NULL, `createdAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "emoji",
+            "columnName": "emoji",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "memo_tag",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`memoId` INTEGER NOT NULL, `tagId` INTEGER NOT NULL, PRIMARY KEY(`memoId`, `tagId`), FOREIGN KEY(`memoId`) REFERENCES `memo`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`tagId`) REFERENCES `tag`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "memoId",
+            "columnName": "memoId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tagId",
+            "columnName": "tagId",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "memoId",
+            "tagId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_memo_tag_memoId",
+            "unique": false,
+            "columnNames": [
+              "memoId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_memo_tag_memoId` ON `${TABLE_NAME}` (`memoId`)"
+          },
+          {
+            "name": "index_memo_tag_tagId",
+            "unique": false,
+            "columnNames": [
+              "tagId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_memo_tag_tagId` ON `${TABLE_NAME}` (`tagId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "memo",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "memoId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "tag",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "tagId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '1fcf5c81af491f11aa8f5980799cc236')"
+    ]
+  }
+}

--- a/datasource/local/memo/impl/schemas/me.pecos.memozy.data.datasource.local.MemoDatabase/12.json
+++ b/datasource/local/memo/impl/schemas/me.pecos.memozy.data.datasource.local.MemoDatabase/12.json
@@ -1,0 +1,396 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 12,
+    "identityHash": "0d5a8198e88fb2632d04e97e5deac6b0",
+    "entities": [
+      {
+        "tableName": "memo",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `categoryId` INTEGER NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `format` TEXT NOT NULL, `isPinned` INTEGER NOT NULL, `audioPath` TEXT, `styles` TEXT, `youtubeUrl` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "categoryId",
+            "columnName": "categoryId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "format",
+            "columnName": "format",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isPinned",
+            "columnName": "isPinned",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "audioPath",
+            "columnName": "audioPath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "styles",
+            "columnName": "styles",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "youtubeUrl",
+            "columnName": "youtubeUrl",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "category",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "chat_session",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `title` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `category` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "chat_message",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sessionId` INTEGER NOT NULL, `role` TEXT NOT NULL, `content` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, `metadata` TEXT, FOREIGN KEY(`sessionId`) REFERENCES `chat_session`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadata",
+            "columnName": "metadata",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_chat_message_sessionId",
+            "unique": false,
+            "columnNames": [
+              "sessionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chat_message_sessionId` ON `${TABLE_NAME}` (`sessionId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "chat_session",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sessionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "youtube_summary",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`videoId` TEXT NOT NULL, `url` TEXT NOT NULL, `summary` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`videoId`))",
+        "fields": [
+          {
+            "fieldPath": "videoId",
+            "columnName": "videoId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "summary",
+            "columnName": "summary",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "videoId"
+          ]
+        }
+      },
+      {
+        "tableName": "ai_usage",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `feature` TEXT NOT NULL, `usedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "feature",
+            "columnName": "feature",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "usedAt",
+            "columnName": "usedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "tag",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `emoji` TEXT NOT NULL, `createdAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "emoji",
+            "columnName": "emoji",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "memo_tag",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`memoId` INTEGER NOT NULL, `tagId` INTEGER NOT NULL, PRIMARY KEY(`memoId`, `tagId`), FOREIGN KEY(`memoId`) REFERENCES `memo`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`tagId`) REFERENCES `tag`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "memoId",
+            "columnName": "memoId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tagId",
+            "columnName": "tagId",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "memoId",
+            "tagId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_memo_tag_memoId",
+            "unique": false,
+            "columnNames": [
+              "memoId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_memo_tag_memoId` ON `${TABLE_NAME}` (`memoId`)"
+          },
+          {
+            "name": "index_memo_tag_tagId",
+            "unique": false,
+            "columnNames": [
+              "tagId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_memo_tag_tagId` ON `${TABLE_NAME}` (`tagId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "memo",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "memoId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "tag",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "tagId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '0d5a8198e88fb2632d04e97e5deac6b0')"
+    ]
+  }
+}

--- a/datasource/local/memo/impl/schemas/me.pecos.memozy.data.datasource.local.MemoDatabase/8.json
+++ b/datasource/local/memo/impl/schemas/me.pecos.memozy.data.datasource.local.MemoDatabase/8.json
@@ -1,0 +1,276 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 8,
+    "identityHash": "31fefba0a6bcf951904f335c12390949",
+    "entities": [
+      {
+        "tableName": "memo",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `categoryId` INTEGER NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `format` TEXT NOT NULL, `isPinned` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "categoryId",
+            "columnName": "categoryId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "format",
+            "columnName": "format",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isPinned",
+            "columnName": "isPinned",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "category",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "chat_session",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `title` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `category` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "chat_message",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sessionId` INTEGER NOT NULL, `role` TEXT NOT NULL, `content` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, `metadata` TEXT, FOREIGN KEY(`sessionId`) REFERENCES `chat_session`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadata",
+            "columnName": "metadata",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_chat_message_sessionId",
+            "unique": false,
+            "columnNames": [
+              "sessionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chat_message_sessionId` ON `${TABLE_NAME}` (`sessionId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "chat_session",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sessionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "youtube_summary",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`videoId` TEXT NOT NULL, `url` TEXT NOT NULL, `summary` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`videoId`))",
+        "fields": [
+          {
+            "fieldPath": "videoId",
+            "columnName": "videoId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "summary",
+            "columnName": "summary",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "videoId"
+          ]
+        }
+      },
+      {
+        "tableName": "ai_usage",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `feature` TEXT NOT NULL, `usedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "feature",
+            "columnName": "feature",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "usedAt",
+            "columnName": "usedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '31fefba0a6bcf951904f335c12390949')"
+    ]
+  }
+}

--- a/datasource/local/memo/impl/schemas/me.pecos.memozy.data.datasource.local.MemoDatabase/9.json
+++ b/datasource/local/memo/impl/schemas/me.pecos.memozy.data.datasource.local.MemoDatabase/9.json
@@ -1,0 +1,281 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 9,
+    "identityHash": "6a15a3a7e82c33f675e6235644a70a3a",
+    "entities": [
+      {
+        "tableName": "memo",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `categoryId` INTEGER NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `format` TEXT NOT NULL, `isPinned` INTEGER NOT NULL, `audioPath` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "categoryId",
+            "columnName": "categoryId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "format",
+            "columnName": "format",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isPinned",
+            "columnName": "isPinned",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "audioPath",
+            "columnName": "audioPath",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "category",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "chat_session",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `title` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `category` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "chat_message",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sessionId` INTEGER NOT NULL, `role` TEXT NOT NULL, `content` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, `metadata` TEXT, FOREIGN KEY(`sessionId`) REFERENCES `chat_session`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadata",
+            "columnName": "metadata",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_chat_message_sessionId",
+            "unique": false,
+            "columnNames": [
+              "sessionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chat_message_sessionId` ON `${TABLE_NAME}` (`sessionId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "chat_session",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sessionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "youtube_summary",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`videoId` TEXT NOT NULL, `url` TEXT NOT NULL, `summary` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`videoId`))",
+        "fields": [
+          {
+            "fieldPath": "videoId",
+            "columnName": "videoId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "summary",
+            "columnName": "summary",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "videoId"
+          ]
+        }
+      },
+      {
+        "tableName": "ai_usage",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `feature` TEXT NOT NULL, `usedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "feature",
+            "columnName": "feature",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "usedAt",
+            "columnName": "usedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '6a15a3a7e82c33f675e6235644a70a3a')"
+    ]
+  }
+}

--- a/datasource/local/memo/impl/src/main/java/me/pecos/memozy/data/datasource/local/MemoDatabase.kt
+++ b/datasource/local/memo/impl/src/main/java/me/pecos/memozy/data/datasource/local/MemoDatabase.kt
@@ -10,6 +10,8 @@ import androidx.sqlite.db.SupportSQLiteDatabase
 import me.pecos.memozy.data.datasource.local.entity.Category
 import me.pecos.memozy.data.datasource.local.entity.Memo
 import me.pecos.memozy.data.datasource.local.entity.AiUsage
+import me.pecos.memozy.data.datasource.local.entity.MemoTag
+import me.pecos.memozy.data.datasource.local.entity.Tag
 import me.pecos.memozy.data.datasource.local.entity.YoutubeSummary
 import me.pecos.memozy.data.datasource.local.converter.MemoFormatConverter
 import me.pecos.memozy.data.datasource.local.chat.ChatMessageDao
@@ -147,6 +149,60 @@ val MIGRATION_9_10 = object : Migration(9, 10) {
     }
 }
 
+val MIGRATION_10_11 = object : Migration(10, 11) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        // 1. tag 테이블 생성
+        database.execSQL("""
+            CREATE TABLE IF NOT EXISTS `tag` (
+                `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                `name` TEXT NOT NULL,
+                `emoji` TEXT NOT NULL DEFAULT '🏷️',
+                `createdAt` INTEGER NOT NULL DEFAULT 0
+            )
+        """.trimIndent())
+
+        // 2. memo_tag 중간 테이블 생성
+        database.execSQL("""
+            CREATE TABLE IF NOT EXISTS `memo_tag` (
+                `memoId` INTEGER NOT NULL,
+                `tagId` INTEGER NOT NULL,
+                PRIMARY KEY(`memoId`, `tagId`),
+                FOREIGN KEY(`memoId`) REFERENCES `memo`(`id`) ON DELETE CASCADE,
+                FOREIGN KEY(`tagId`) REFERENCES `tag`(`id`) ON DELETE CASCADE
+            )
+        """.trimIndent())
+        database.execSQL("CREATE INDEX IF NOT EXISTS `index_memo_tag_memoId` ON `memo_tag` (`memoId`)")
+        database.execSQL("CREATE INDEX IF NOT EXISTS `index_memo_tag_tagId` ON `memo_tag` (`tagId`)")
+
+        // 3. 기존 카테고리를 태그로 마이그레이션
+        val categoryEmojis = mapOf(
+            1 to "📝", 2 to "💼", 3 to "💡", 4 to "✅", 5 to "📚",
+            6 to "📅", 7 to "💰", 8 to "🏃", 9 to "🏥", 10 to "✈️", 11 to "🛒"
+        )
+        val cursor = database.query("SELECT DISTINCT categoryId FROM memo WHERE categoryId BETWEEN 1 AND 11")
+        while (cursor.moveToNext()) {
+            val catId = cursor.getInt(0)
+            val emoji = categoryEmojis[catId] ?: "🏷️"
+            // 카테고리 이름 조회
+            val nameCursor = database.query("SELECT name FROM category WHERE id = $catId")
+            val name = if (nameCursor.moveToFirst()) nameCursor.getString(0) else "태그$catId"
+            nameCursor.close()
+            // 태그 삽입 (같은 ID 사용)
+            database.execSQL("INSERT OR IGNORE INTO `tag` (`id`, `name`, `emoji`, `createdAt`) VALUES ($catId, '$name', '$emoji', ${System.currentTimeMillis()})")
+        }
+        cursor.close()
+
+        // 4. 기존 memo.categoryId → memo_tag 연결
+        database.execSQL("INSERT OR IGNORE INTO `memo_tag` (`memoId`, `tagId`) SELECT `id`, `categoryId` FROM `memo` WHERE `categoryId` BETWEEN 1 AND 11")
+    }
+}
+
+val MIGRATION_11_12 = object : Migration(11, 12) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        database.execSQL("ALTER TABLE memo ADD COLUMN youtubeUrl TEXT DEFAULT NULL")
+    }
+}
+
 private val PREPOPULATE_CALLBACK = object : RoomDatabase.Callback() {
     override fun onCreate(db: SupportSQLiteDatabase) {
         super.onCreate(db)
@@ -156,8 +212,8 @@ private val PREPOPULATE_CALLBACK = object : RoomDatabase.Callback() {
 
 @TypeConverters(MemoFormatConverter::class)
 @Database(
-    entities = [Memo::class, Category::class, ChatSession::class, ChatMessage::class, YoutubeSummary::class, AiUsage::class],
-    version = 10,
+    entities = [Memo::class, Category::class, ChatSession::class, ChatMessage::class, YoutubeSummary::class, AiUsage::class, Tag::class, MemoTag::class],
+    version = 12,
     exportSchema = true
 )
 abstract class MemoDatabase : RoomDatabase() {
@@ -167,6 +223,7 @@ abstract class MemoDatabase : RoomDatabase() {
     abstract fun chatMessageDao(): ChatMessageDao
     abstract fun youtubeSummaryDao(): YoutubeSummaryDao
     abstract fun aiUsageDao(): AiUsageDao
+    abstract fun tagDao(): TagDao
 
     companion object {
         @Volatile
@@ -179,7 +236,7 @@ abstract class MemoDatabase : RoomDatabase() {
                     MemoDatabase::class.java,
                     "memo_database"
                 )
-                    .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10)
+                    .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12)
                     .addCallback(PREPOPULATE_CALLBACK)
                     .build()
                 INSTANCE = instance

--- a/datasource/local/memo/impl/src/main/java/me/pecos/memozy/data/datasource/local/di/DatabaseModule.kt
+++ b/datasource/local/memo/impl/src/main/java/me/pecos/memozy/data/datasource/local/di/DatabaseModule.kt
@@ -15,9 +15,14 @@ import me.pecos.memozy.data.datasource.local.MIGRATION_3_4
 import me.pecos.memozy.data.datasource.local.MIGRATION_4_5
 import me.pecos.memozy.data.datasource.local.MIGRATION_5_6
 import me.pecos.memozy.data.datasource.local.MIGRATION_6_7
+import me.pecos.memozy.data.datasource.local.MIGRATION_7_8
+import me.pecos.memozy.data.datasource.local.MIGRATION_8_9
+import me.pecos.memozy.data.datasource.local.MIGRATION_9_10
+import me.pecos.memozy.data.datasource.local.MIGRATION_10_11
 import me.pecos.memozy.data.datasource.local.AiUsageDao
 import me.pecos.memozy.data.datasource.local.MemoDao
 import me.pecos.memozy.data.datasource.local.MemoDatabase
+import me.pecos.memozy.data.datasource.local.TagDao
 import me.pecos.memozy.data.datasource.local.YoutubeSummaryDao
 import me.pecos.memozy.data.datasource.local.chat.ChatMessageDao
 import me.pecos.memozy.data.datasource.local.chat.ChatSessionDao
@@ -68,5 +73,10 @@ object DatabaseModule {
     @Provides
     fun provideAiUsageDao(database: MemoDatabase): AiUsageDao {
         return database.aiUsageDao()
+    }
+
+    @Provides
+    fun provideTagDao(database: MemoDatabase): TagDao {
+        return database.tagDao()
     }
 }

--- a/datasource/remote/ai/impl/src/main/java/me/pecos/memozy/data/datasource/remote/ai/AIApiServiceImpl.kt
+++ b/datasource/remote/ai/impl/src/main/java/me/pecos/memozy/data/datasource/remote/ai/AIApiServiceImpl.kt
@@ -104,11 +104,7 @@ class AIApiServiceImpl @Inject constructor(
     }
 
     override suspend fun transcribeAudio(audioBase64: String, mimeType: String, durationSeconds: Long): String {
-        val prompt = if (durationSeconds >= 60) {
-            "이 오디오를 한국어로 받아쓰기해줘. 30초 간격으로 타임스탬프를 포함해서 [MM:SS] 형식으로 구분해줘. 타임스탬프와 텍스트만 출력하고 다른 설명은 하지 마."
-        } else {
-            "이 오디오를 한국어로 받아쓰기해줘. 텍스트만 출력하고 다른 설명은 하지 마."
-        }
+        val prompt = "이 오디오를 한국어로 받아쓰기해줘. 텍스트만 출력하고 다른 설명은 하지 마."
 
         val request = GeminiRequest(
             contents = listOf(

--- a/feature/core/resource/src/main/java/me/pecos/memozy/presentation/screen/home/model/MemoUiState.kt
+++ b/feature/core/resource/src/main/java/me/pecos/memozy/presentation/screen/home/model/MemoUiState.kt
@@ -10,5 +10,13 @@ data class MemoUiState(
     val format: MemoFormatUi = MemoFormatUi.PLAIN,
     val isPinned: Boolean = false,
     val audioPath: String? = null,
-    val styles: String? = null
+    val styles: String? = null,
+    val youtubeUrl: String? = null,
+    val tags: List<TagUiState> = emptyList()
+)
+
+data class TagUiState(
+    val id: Int,
+    val name: String,
+    val emoji: String = "🏷️"
 )

--- a/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/home/HomeScreen.kt
+++ b/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/home/HomeScreen.kt
@@ -45,6 +45,7 @@ import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
@@ -84,72 +85,28 @@ fun HomeScreen(
     viewModel: MainViewModel
 ) {
     val colors = LocalAppColors.current
-    val selectedCategoryIndex by viewModel.selectedCategoryIndex.collectAsState()
+    val selectedTagId by viewModel.selectedTagId.collectAsState()
     val searchQuery by viewModel.searchQuery.collectAsState()
     val sortOrder by viewModel.sortOrder.collectAsState()
     val filteredList by viewModel.filteredList.collectAsState()
+    val allTags by viewModel.allTags.collectAsState()
+    val memoTags by viewModel.memoTags.collectAsState()
+    // 하위호환
+    val selectedCategoryIndex = selectedTagId
+
+    // 메모 태그 로드
+    LaunchedEffect(filteredList) {
+        viewModel.loadMemoTags(filteredList.map { it.id })
+    }
+
     // 스와이프 열린 카드 추적 — null이면 모두 닫힌 상태
     var swipedOpenId by remember { mutableStateOf<Int?>(null) }
     val listState = remember(sortOrder) { LazyListState() }
-    var showFilterDialog by remember { mutableStateOf(false) }
-    var tempCategoryIndex by remember(showFilterDialog, selectedCategoryIndex) { mutableIntStateOf(selectedCategoryIndex) }
+    // 태그 추가 다이얼로그
+    var showAddTagDialog by remember { mutableStateOf(false) }
 
-    val categoryLabels = CATEGORY_RES_IDS.mapIndexed { index, resId ->
-        "${CATEGORY_EMOJIS[index]} ${stringResource(resId)}"
-    }
-    val allLabel = "🗂️ ${stringResource(R.string.category_all)}"
-    val currentLabel = if (selectedCategoryIndex == -1) allLabel else categoryLabels[selectedCategoryIndex]
-
-    // ── 카테고리 필터 Popup ────────────────────────────────────────────────────
-    if (showFilterDialog) {
-        AppPopup(
-            onDismissRequest = { showFilterDialog = false },
-            title = stringResource(R.string.category_settings),
-            navigation = PopupNavigation.EMPHASIZED,
-            size = PopupSize.LARGE,
-            actionArea = PopupActionArea.NEUTRAL,
-            primaryButtonText = stringResource(R.string.save),
-            onPrimaryClick = {
-                viewModel.setSelectedCategory(tempCategoryIndex)
-                showFilterDialog = false
-            },
-            secondaryButtonText = stringResource(R.string.cancel),
-            onSecondaryClick = { showFilterDialog = false }
-        ) {
-            FlowRow(
-                maxItemsInEachRow = 3,
-                horizontalArrangement = Arrangement.spacedBy(6.dp),
-                verticalArrangement = Arrangement.spacedBy(6.dp),
-                modifier = Modifier.fillMaxWidth()
-            ) {
-                val orderedIndices = listOf(-1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
-                orderedIndices.forEach { index ->
-                    val label = if (index == -1) allLabel else categoryLabels[index]
-                    val selected = tempCategoryIndex == index
-                    Box(
-                        modifier = Modifier
-                            .weight(1f)
-                            .fillMaxWidth()
-                            .clip(RoundedCornerShape(12.dp))
-                            .background(if (selected) colors.chipBackground else Color.Transparent)
-                            .border(
-                                1.dp,
-                                if (selected) colors.chipText else colors.cardBorder,
-                                RoundedCornerShape(12.dp)
-                            )
-                            .clickable { tempCategoryIndex = index }
-                            .padding(horizontal = 4.dp, vertical = 8.dp),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        Text(
-                            text = label, maxLines = 1, fontSize = 11.sp,
-                            color = if (selected) colors.chipText else colors.textSecondary
-                        )
-                    }
-                }
-            }
-        }
-    }
+    // 자동 뷰 필터 타입
+    // -1 = 전체, -2 = 일반메모, -3 = 유튜브, -4 = 녹음, 양수 = 사용자 태그 ID
 
     // containerColor 명시 → MaterialTheme.colorScheme.surface 무시
     Scaffold(containerColor = colors.screenBackground) { innerPadding ->
@@ -189,31 +146,72 @@ fun HomeScreen(
                     )
                 }
 
-                // 카테고리 필터 + 정렬 버튼
+                // 태그 필터 (드롭다운) + 정렬 버튼
+                var showFilterMenu by remember { mutableStateOf(false) }
+                val autoViews = listOf(
+                    -1 to "전체",
+                    -2 to "메모",
+                    -3 to "유튜브",
+                    -4 to "녹음"
+                )
+                val currentLabel = autoViews.firstOrNull { it.first == selectedTagId }?.second
+                    ?: allTags.firstOrNull { it.id == selectedTagId }?.name
+                    ?: "전체"
+
                 Row(
                     modifier = Modifier.padding(start = 16.dp),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    Row(
-                        modifier = Modifier
-                            .border(1.5.dp, colors.cardBorder, RoundedCornerShape(12.dp))
-                            .clickable { showFilterDialog = true }
-                            .padding(horizontal = 14.dp, vertical = 6.dp),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Text(
-                            text = currentLabel,
-                            fontSize = 13.sp,
-                            fontWeight = FontWeight.Medium,
-                            color = colors.textSecondary
-                        )
-                        Spacer(modifier = Modifier.width(4.dp))
-                        Icon(
-                            imageVector = Icons.Default.KeyboardArrowDown,
-                            contentDescription = null,
-                            tint = colors.textSecondary,
-                            modifier = Modifier.size(16.dp)
-                        )
+                    Box {
+                        Row(
+                            modifier = Modifier
+                                .border(1.5.dp, colors.cardBorder, RoundedCornerShape(12.dp))
+                                .clickable { showFilterMenu = true }
+                                .padding(horizontal = 14.dp, vertical = 6.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Text(
+                                text = currentLabel,
+                                fontSize = 13.sp,
+                                fontWeight = FontWeight.Medium,
+                                color = colors.textSecondary
+                            )
+                            Spacer(modifier = Modifier.width(4.dp))
+                            Icon(
+                                imageVector = Icons.Default.KeyboardArrowDown,
+                                contentDescription = null,
+                                tint = colors.textSecondary,
+                                modifier = Modifier.size(16.dp)
+                            )
+                        }
+                        androidx.compose.material3.DropdownMenu(
+                            expanded = showFilterMenu,
+                            onDismissRequest = { showFilterMenu = false }
+                        ) {
+                            // 자동 뷰
+                            autoViews.forEach { (id, label) ->
+                                androidx.compose.material3.DropdownMenuItem(
+                                    text = { Text(label, fontWeight = if (selectedTagId == id) FontWeight.Bold else FontWeight.Normal) },
+                                    onClick = { viewModel.setSelectedTag(id); showFilterMenu = false }
+                                )
+                            }
+                            if (allTags.isNotEmpty()) {
+                                androidx.compose.material3.HorizontalDivider()
+                                // 사용자 태그
+                                allTags.forEach { tag ->
+                                    androidx.compose.material3.DropdownMenuItem(
+                                        text = { Text(tag.name, fontWeight = if (selectedTagId == tag.id) FontWeight.Bold else FontWeight.Normal) },
+                                        onClick = { viewModel.setSelectedTag(tag.id); showFilterMenu = false }
+                                    )
+                                }
+                            }
+                            androidx.compose.material3.HorizontalDivider()
+                            // 태그 추가
+                            androidx.compose.material3.DropdownMenuItem(
+                                text = { Text("+ 태그 추가", color = colors.chipText) },
+                                onClick = { showFilterMenu = false; showAddTagDialog = true }
+                            )
+                        }
                     }
                     Spacer(modifier = Modifier.width(8.dp))
                     Row(
@@ -354,7 +352,7 @@ fun HomeScreen(
                                         }
                                     }
                             ) {
-                                MemoCardItem(memo = memo)
+                                MemoCardItem(memo = memo, tags = memoTags[memo.id] ?: emptyList())
                             }
                         }
                     }
@@ -385,6 +383,39 @@ fun HomeScreen(
                 }
             }
         }
+    }
+
+    // 태그 추가 다이얼로그
+    if (showAddTagDialog) {
+        var tagName by remember { mutableStateOf("") }
+        androidx.compose.material3.AlertDialog(
+            onDismissRequest = { showAddTagDialog = false },
+            title = { Text("태그 추가", fontWeight = FontWeight.Bold) },
+            text = {
+                androidx.compose.material3.OutlinedTextField(
+                    value = tagName,
+                    onValueChange = { tagName = it },
+                    placeholder = { Text("태그 이름") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            },
+            confirmButton = {
+                androidx.compose.material3.TextButton(
+                    onClick = {
+                        if (tagName.isNotBlank()) {
+                            viewModel.createTag(tagName.trim())
+                            showAddTagDialog = false
+                        }
+                    }
+                ) { Text("추가") }
+            },
+            dismissButton = {
+                androidx.compose.material3.TextButton(
+                    onClick = { showAddTagDialog = false }
+                ) { Text("취소") }
+            }
+        )
     }
 }
 

--- a/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/home/MainViewModel.kt
+++ b/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/home/MainViewModel.kt
@@ -16,14 +16,23 @@ import me.pecos.memozy.data.repository.model.MemoFormat
 import me.pecos.memozy.presentation.screen.home.model.MemoFormatUi
 import me.pecos.memozy.presentation.screen.home.model.MemoUiState
 import me.pecos.memozy.presentation.screen.home.model.SortOrder
+import me.pecos.memozy.data.datasource.local.TagDao
 import me.pecos.memozy.data.datasource.local.entity.Memo
+import me.pecos.memozy.data.datasource.local.entity.Tag
 import me.pecos.memozy.data.repository.MemoRepository
+import me.pecos.memozy.presentation.screen.home.model.TagUiState
 import javax.inject.Inject
 
 @HiltViewModel
 class MainViewModel @Inject constructor(
-    private val repository: MemoRepository
+    private val repository: MemoRepository,
+    private val tagDao: TagDao
 ) : ViewModel() {
+
+    // 전체 태그 목록
+    val allTags = tagDao.getAllTags()
+        .map { list -> list.map { TagUiState(it.id, it.name, it.emoji) } }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
 
     val uiState = repository.getMemos()
         .map { list -> list.map { it.toUiState() } }
@@ -43,12 +52,32 @@ class MainViewModel @Inject constructor(
         }
     }
 
-    // -1 = 전체, 0~7 = 카테고리 인덱스
-    private val _selectedCategoryIndex = MutableStateFlow(-1)
-    val selectedCategoryIndex: StateFlow<Int> = _selectedCategoryIndex
+    // -1 = 전체, 0+ = 태그 ID
+    private val _selectedTagId = MutableStateFlow(-1)
+    val selectedTagId: StateFlow<Int> = _selectedTagId
+
+    // 하위호환: 기존 HomeScreen에서 사용
+    val selectedCategoryIndex: StateFlow<Int> = _selectedTagId
 
     fun setSelectedCategory(index: Int) {
-        _selectedCategoryIndex.value = index
+        _selectedTagId.value = index
+    }
+
+    fun setSelectedTag(tagId: Int) {
+        _selectedTagId.value = tagId
+    }
+
+    // 메모별 태그 로드
+    private val _memoTags = MutableStateFlow<Map<Int, List<TagUiState>>>(emptyMap())
+    val memoTags: StateFlow<Map<Int, List<TagUiState>>> = _memoTags
+
+    fun loadMemoTags(memoIds: List<Int>) {
+        viewModelScope.launch(Dispatchers.IO) {
+            val tagsMap = memoIds.associateWith { memoId ->
+                tagDao.getTagsForMemo(memoId).map { TagUiState(it.id, it.name, it.emoji) }
+            }
+            _memoTags.value = tagsMap
+        }
     }
 
     private val _searchQuery = MutableStateFlow("")
@@ -66,11 +95,18 @@ class MainViewModel @Inject constructor(
     }
 
     val filteredList: StateFlow<List<MemoUiState>> = combine(
-        uiState, _selectedCategoryIndex, _searchQuery, _sortOrder
-    ) { list, categoryIndex, query, sort ->
+        uiState, _selectedTagId, _searchQuery, _sortOrder, _memoTags
+    ) { list, tagId, query, sort, tagsMap ->
+        val youtubeRegex = Regex("""(?:youtube\.com/watch\?v=|youtu\.be/|youtube\.com/shorts/)""")
         list
             .filter { memo ->
-                categoryIndex == -1 || memo.categoryId == categoryIndex + 1
+                when (tagId) {
+                    -1 -> true // 전체
+                    -2 -> memo.audioPath == null && !youtubeRegex.containsMatchIn(memo.content) // 일반 메모
+                    -3 -> youtubeRegex.containsMatchIn(memo.content) // 유튜브
+                    -4 -> memo.audioPath != null // 녹음
+                    else -> tagsMap[memo.id]?.any { it.id == tagId } == true // 사용자 태그
+                }
             }
             .filter { memo ->
                 if (query.isBlank()) true
@@ -95,6 +131,18 @@ class MainViewModel @Inject constructor(
         }
     }
 
+    fun createTag(name: String, emoji: String = "🏷️") {
+        viewModelScope.launch {
+            tagDao.insertTag(Tag(name = name, emoji = emoji))
+        }
+    }
+
+    fun deleteTag(tagId: Int) {
+        viewModelScope.launch {
+            tagDao.deleteTagById(tagId)
+        }
+    }
+
     fun togglePin(memo: MemoUiState) {
         viewModelScope.launch {
             repository.updateMemo(memo.copy(isPinned = !memo.isPinned).toMemo())
@@ -115,7 +163,8 @@ fun MemoUiState.toMemo(): Memo = Memo(
     },
     isPinned = this.isPinned,
     audioPath = this.audioPath,
-    styles = this.styles
+    styles = this.styles,
+    youtubeUrl = this.youtubeUrl
 )
 
 fun Memo.toUiState(): MemoUiState = MemoUiState(
@@ -131,5 +180,6 @@ fun Memo.toUiState(): MemoUiState = MemoUiState(
     },
     isPinned = this.isPinned,
     audioPath = this.audioPath,
-    styles = this.styles
+    styles = this.styles,
+    youtubeUrl = this.youtubeUrl
 )

--- a/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/home/components/MemoCard.kt
+++ b/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/home/components/MemoCard.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.unit.sp
 import me.pecos.memozy.feature.core.resource.CATEGORY_EMOJIS
 import me.pecos.memozy.feature.core.resource.CATEGORY_RES_IDS
 import me.pecos.memozy.presentation.screen.home.model.MemoUiState
+import me.pecos.memozy.presentation.screen.home.model.TagUiState
 import me.pecos.memozy.feature.core.resource.R
 import me.pecos.memozy.presentation.screen.home.util.formatMemoTime
 import me.pecos.memozy.presentation.theme.LocalAppColors
@@ -43,7 +44,8 @@ import me.pecos.memozy.presentation.theme.LocalAppColors
 
 @Composable
 fun MemoCardItem(
-    memo: MemoUiState
+    memo: MemoUiState,
+    tags: List<TagUiState> = emptyList()
 ) {
     val colors = LocalAppColors.current
     val context = LocalContext.current
@@ -98,18 +100,29 @@ fun MemoCardItem(
                             color = colors.textSecondary.copy(alpha = 0.7f)
                         )
                     }
-                    if (memo.categoryId in 1..CATEGORY_RES_IDS.size) {
-                        val categoryIndex = memo.categoryId - 1
-                        val categoryLabel = "${CATEGORY_EMOJIS[categoryIndex]} ${stringResource(CATEGORY_RES_IDS[categoryIndex])}"
+                    if (tags.isNotEmpty()) {
                         Spacer(modifier = Modifier.height(4.dp))
-                        Text(
-                            text = categoryLabel,
-                            fontSize = 11.sp,
-                            color = colors.chipText,
-                            modifier = Modifier
-                                .background(colors.chipBackground, RoundedCornerShape(50))
-                                .padding(horizontal = 8.dp, vertical = 2.dp)
-                        )
+                        Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                            tags.take(2).forEach { tag ->
+                                Text(
+                                    text = tag.name,
+                                    fontSize = 10.sp,
+                                    color = colors.chipText,
+                                    maxLines = 1,
+                                    modifier = Modifier
+                                        .background(colors.chipBackground, RoundedCornerShape(50))
+                                        .padding(horizontal = 6.dp, vertical = 2.dp)
+                                )
+                            }
+                            if (tags.size > 2) {
+                                Text(
+                                    text = "+${tags.size - 2}",
+                                    fontSize = 10.sp,
+                                    color = colors.textSecondary,
+                                    modifier = Modifier.padding(start = 2.dp)
+                                )
+                            }
+                        }
                     }
                 }
             }

--- a/feature/memo-plain/impl/src/main/java/me/pecos/memozy/feature/memoplain/impl/MemoPlainNavigationImpl.kt
+++ b/feature/memo-plain/impl/src/main/java/me/pecos/memozy/feature/memoplain/impl/MemoPlainNavigationImpl.kt
@@ -56,12 +56,25 @@ class MemoPlainNavigationImpl @Inject constructor(
     private val aiApiService: AIApiService,
     private val youtubeSummaryDao: YoutubeSummaryDao,
     private val captionService: YouTubeCaptionService,
-    private val aiUsageDao: AiUsageDao
+    private val aiUsageDao: AiUsageDao,
+    private val tagDao: me.pecos.memozy.data.datasource.local.TagDao
 ) : MemoPlainNavigation {
+
+    private suspend fun autoTag(memoId: Int, tagName: String) {
+        if (memoId <= 0) return
+        // 태그가 없으면 생성
+        val allTags = tagDao.getAllTagsOnce()
+        val tag = allTags.firstOrNull { it.name == tagName }
+            ?: run {
+                val newId = tagDao.insertTag(me.pecos.memozy.data.datasource.local.entity.Tag(name = tagName))
+                me.pecos.memozy.data.datasource.local.entity.Tag(id = newId.toInt(), name = tagName)
+            }
+        tagDao.insertMemoTag(me.pecos.memozy.data.datasource.local.entity.MemoTag(memoId = memoId, tagId = tag.id))
+    }
 
     companion object {
         private const val FEATURE_YOUTUBE_SUMMARY = "youtube_summary"
-        private const val DAILY_FREE_LIMIT = 5
+        private const val DAILY_FREE_LIMIT = 100
 
         private fun startOfToday(): Long {
             return Calendar.getInstance().apply {
@@ -166,9 +179,12 @@ class MemoPlainNavigationImpl @Inject constructor(
                                 "영상이 너무 길어 요약할 수 없어요. 약 30분 이하 영상을 시도해주세요."
                             e.message?.contains("Rate limit") == true ->
                                 "요청이 너무 많아요. 잠시 후 다시 시도해주세요."
+                            e.message?.contains("503") == true || e.message?.contains("UNAVAILABLE") == true ||
+                            e.message?.contains("high demand") == true ->
+                                "AI 서버가 일시적으로 바빠요. 잠시 후 다시 시도해주세요."
                             e.message?.contains("timeout") == true || e.message?.contains("Timeout") == true ->
                                 "응답 시간이 초과됐어요. 더 짧은 영상을 시도해주세요."
-                            else -> e.message ?: "요약 실패"
+                            else -> "요약 중 오류가 발생했어요. 다시 시도해주세요."
                         }
                         summaryState = SummaryState.Error(errorMsg)
                     }
@@ -217,7 +233,8 @@ class MemoPlainNavigationImpl @Inject constructor(
                             },
                             isPinned = it.isPinned,
                             audioPath = it.audioPath,
-                            styles = it.styles
+                            styles = it.styles,
+                            youtubeUrl = it.youtubeUrl
                         )
                     }
                     memoLoaded = true
@@ -372,10 +389,12 @@ class MemoPlainNavigationImpl @Inject constructor(
                             transcriptionResult = null
                             audioFile.delete()
                         } else {
-                            // 오디오 파일을 영구 저장소로 이동
+                            // 오디오 파일을 영구 저장소로 이동 (제목과 동일한 파일명)
                             val audioDir = java.io.File(context.filesDir, "audio")
                             if (!audioDir.exists()) audioDir.mkdirs()
-                            val permanentFile = java.io.File(audioDir, "recording_${System.currentTimeMillis()}.m4a")
+                            val now = java.text.SimpleDateFormat("yy.MM.dd HH:mm", java.util.Locale.getDefault()).format(java.util.Date())
+                            val safeFileName = "$now 녹음".replace(":", "-").replace("/", "-")
+                            val permanentFile = java.io.File(audioDir, "$safeFileName.m4a")
                             audioFile.copyTo(permanentFile, overwrite = true)
                             audioFile.delete()
                             savedAudioPath = permanentFile.absolutePath
@@ -474,6 +493,9 @@ class MemoPlainNavigationImpl @Inject constructor(
                                     "영상이 너무 길어 요약할 수 없어요. 약 30분 이하 영상을 시도해주세요."
                                 e.message?.contains("Rate limit") == true ->
                                     "요청이 너무 많아요. 잠시 후 다시 시도해주세요."
+                                e.message?.contains("503") == true || e.message?.contains("UNAVAILABLE") == true ||
+                                e.message?.contains("high demand") == true ->
+                                    "AI 서버가 일시적으로 바빠요. 잠시 후 다시 시도해주세요."
                                 e.message?.contains("timeout") == true || e.message?.contains("Timeout") == true ->
                                     "응답 시간이 초과됐어요. 더 짧은 영상을 시도해주세요."
                                 else -> "요약 중 오류가 발생했어요. 다시 시도해주세요."
@@ -485,12 +507,23 @@ class MemoPlainNavigationImpl @Inject constructor(
                 onSave = { memo ->
                     scope.launch {
                         val memoWithAudio = memo.copy(audioPath = savedAudioPath ?: memo.audioPath)
+                        val finalMemoId: Int
                         if (savedMemoId > 0) {
                             repository.updateMemo(memoWithAudio.copy(id = savedMemoId).toEntity())
+                            finalMemoId = savedMemoId
                         } else if (memoId > 0 && existingMemo != null) {
                             repository.updateMemo(memoWithAudio.toEntity())
+                            finalMemoId = memoId
                         } else {
-                            repository.addMemo(memoWithAudio.toEntity())
+                            finalMemoId = repository.addMemo(memoWithAudio.toEntity()).toInt()
+                        }
+                        // 자동 태그 부여
+                        if (memoWithAudio.audioPath != null) {
+                            autoTag(finalMemoId, "녹음")
+                        }
+                        val youtubeRegex = Regex("""(?:youtube\.com/watch\?v=|youtu\.be/|youtube\.com/shorts/)""")
+                        if (youtubeRegex.containsMatchIn(memoWithAudio.content) || inlineSummaryState is SummaryState.Success) {
+                            autoTag(finalMemoId, "유튜브")
                         }
                         onNavigateToHome()
                     }
@@ -511,7 +544,8 @@ class MemoPlainNavigationImpl @Inject constructor(
         categoryId = categoryId,
         content = content,
         audioPath = audioPath,
-        styles = styles
+        styles = styles,
+        youtubeUrl = youtubeUrl
     )
 
     private suspend fun summarizeVideo(

--- a/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/MemoScreen.kt
+++ b/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/MemoScreen.kt
@@ -27,11 +27,13 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Mic
 import androidx.compose.material.icons.filled.Pause
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Stop
+import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material.icons.filled.SmartDisplay
 import androidx.compose.foundation.shape.CircleShape
@@ -221,6 +223,12 @@ fun MemoScreen(
 
     // 유튜브 URL 입력 다이얼로그 표시
     var showYoutubeDialog by remember { mutableStateOf(false) }
+    var youtubeChipDismissed by remember { mutableStateOf(false) }
+    // 요약 전 원본 URL 보관 (요약 후 본문에서 URL이 대체되어도 유지)
+    var savedYoutubeUrl by remember { mutableStateOf(detectedYoutubeUrl ?: existingMemo.youtubeUrl) }
+    if (detectedYoutubeUrl != null && savedYoutubeUrl == null) {
+        savedYoutubeUrl = detectedYoutubeUrl
+    }
 
     // 요약 결과 표시 상태
     var showSummary by remember { mutableStateOf(false) }
@@ -229,7 +237,11 @@ fun MemoScreen(
     var summaryApplied by remember { mutableStateOf(false) }
     LaunchedEffect(summaryResult, isSummarizing) {
         if (summaryResult != null && !isSummarizing && !summaryApplied) {
-            bodyText = YOUTUBE_URL_REGEX.replace(bodyText) { summaryResult }.trim()
+            // 요약 전 URL 저장
+            if (savedYoutubeUrl == null) savedYoutubeUrl = detectedYoutubeUrl
+            val newText = YOUTUBE_URL_REGEX.replace(bodyText) { summaryResult }.trim()
+            bodyText = newText
+            richTextState.setText(newText)
             if (youtubeTitle != null && nameText.isBlank()) {
                 nameText = youtubeTitle
             }
@@ -244,7 +256,8 @@ fun MemoScreen(
             name = nameText,
             categoryId = categoryIndex + 1,
             content = bodyText,
-            styles = richTextState.toHtml().takeIf { it.isNotBlank() }
+            styles = richTextState.toHtml().takeIf { it.isNotBlank() },
+            youtubeUrl = savedYoutubeUrl
         )
     }
     val canAutoSave = nameText.isNotBlank() || bodyText.isNotBlank()
@@ -262,7 +275,9 @@ fun MemoScreen(
                         id = existingMemo.id,
                         name = name,
                         categoryId = catIdx + 1,
-                        content = body
+                        content = body,
+                        styles = richTextState.toHtml().takeIf { it.isNotBlank() },
+                        youtubeUrl = savedYoutubeUrl
                     )
                     val saveable = name.isNotBlank() || body.isNotBlank()
                     if (saveable && memo != lastSaved) {
@@ -322,7 +337,7 @@ fun MemoScreen(
                         .size(24.dp)
                         .clickable {
                             if (onAutoSave != null && canAutoSave) {
-                                onAutoSave(currentMemo)
+                                onAutoSave(currentMemo.copy(styles = richTextState.toHtml().takeIf { it.isNotBlank() }, youtubeUrl = savedYoutubeUrl))
                             }
                             onBack()
                         }
@@ -336,7 +351,7 @@ fun MemoScreen(
                     color = colors.chipText,
                     modifier = Modifier
                         .clickable {
-                            onSave(MemoUiState(id = existingMemo.id, name = nameText, categoryId = categoryIndex + 1, content = bodyText, styles = richTextState.toHtml().takeIf { it.isNotBlank() }))
+                            onSave(MemoUiState(id = existingMemo.id, name = nameText, categoryId = categoryIndex + 1, content = bodyText, styles = richTextState.toHtml().takeIf { it.isNotBlank() }, youtubeUrl = savedYoutubeUrl))
                         }
                         .padding(horizontal = 8.dp, vertical = 4.dp)
                 )
@@ -384,7 +399,7 @@ fun MemoScreen(
                     }
                 )
 
-                // 녹음 결과를 본문에 삽입
+                // 녹음 결과를 본문에 삽입 + 제목 자동 설정
                 LaunchedEffect(transcriptionResult) {
                     if (transcriptionResult != null) {
                         val current = richTextState.annotatedString.text
@@ -392,73 +407,20 @@ fun MemoScreen(
                         else "$current\n\n$transcriptionResult"
                         richTextState.setText(newText)
                         bodyText = newText
+                        // 제목이 비어있으면 자동 설정
+                        if (nameText.isBlank()) {
+                            val now = java.text.SimpleDateFormat("yy.MM.dd HH:mm", java.util.Locale.getDefault()).format(java.util.Date())
+                            nameText = "$now 녹음"
+                        }
                     }
                 }
 
-                Spacer(modifier = Modifier.height(16.dp))
-
-                // 오디오 재생 바 (녹음 파일이 있는 메모)
-                val effectiveAudioPath = audioPath ?: existingMemo.audioPath
-                if (effectiveAudioPath != null && java.io.File(effectiveAudioPath).exists()) {
-                    var isPlaying by remember { mutableStateOf(false) }
-                    val mediaPlayer = remember {
-                        android.media.MediaPlayer().apply {
-                            setDataSource(effectiveAudioPath)
-                            prepare()
-                            setOnCompletionListener { isPlaying = false }
-                        }
-                    }
-
-                    DisposableEffect(Unit) {
-                        onDispose {
-                            mediaPlayer.release()
-                        }
-                    }
-
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .clip(RoundedCornerShape(10.dp))
-                            .background(colors.chipBackground.copy(alpha = 0.5f))
-                            .padding(horizontal = 12.dp, vertical = 10.dp),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Box(
-                            modifier = Modifier
-                                .size(36.dp)
-                                .clip(CircleShape)
-                                .background(colors.chipText)
-                                .clickable {
-                                    if (isPlaying) {
-                                        mediaPlayer.pause()
-                                        isPlaying = false
-                                    } else {
-                                        mediaPlayer.start()
-                                        isPlaying = true
-                                    }
-                                },
-                            contentAlignment = Alignment.Center
-                        ) {
-                            Icon(
-                                imageVector = if (isPlaying) Icons.Default.Pause else Icons.Default.PlayArrow,
-                                contentDescription = null,
-                                tint = Color.White,
-                                modifier = Modifier.size(20.dp)
-                            )
-                        }
-                        Spacer(modifier = Modifier.width(10.dp))
-                        Text(
-                            text = "🎙️ 녹음 파일",
-                            fontSize = 14.sp,
-                            color = colors.textBody,
-                            fontWeight = FontWeight.SemiBold
-                        )
-                    }
-                    Spacer(modifier = Modifier.height(12.dp))
-                }
+                Spacer(modifier = Modifier.height(12.dp))
 
                 // 녹음 상태 인라인 표시 (녹음 중/변환 중일 때만)
-                if (isRecording || isTranscribing || transcriptionError != null) {
+                var transcriptionErrorDismissed by remember { mutableStateOf(false) }
+                LaunchedEffect(transcriptionError) { if (transcriptionError != null) transcriptionErrorDismissed = false }
+                if (isRecording || isTranscribing || (transcriptionError != null && !transcriptionErrorDismissed)) {
                     Row(
                         verticalAlignment = Alignment.CenterVertically,
                         modifier = Modifier.padding(bottom = 12.dp)
@@ -486,7 +448,9 @@ fun MemoScreen(
                                 Text("음성 변환 중...", fontSize = 13.sp, color = colors.textSecondary)
                             }
                             transcriptionError != null -> {
-                                Text("⚠️ $transcriptionError", fontSize = 13.sp, color = Color(0xFFE65100))
+                                Text("⚠️ $transcriptionError", fontSize = 13.sp, color = Color(0xFFE65100), modifier = Modifier.weight(1f))
+                                Icon(Icons.Default.Close, contentDescription = null, tint = Color(0xFFE65100),
+                                    modifier = Modifier.size(14.dp).clickable { transcriptionErrorDismissed = true })
                             }
                         }
                     }
@@ -507,129 +471,6 @@ fun MemoScreen(
                     val plainText = richTextState.annotatedString.text
                     if (plainText != bodyText) {
                         bodyText = plainText
-                    }
-                }
-
-                // 서식 툴바
-                var showColorPicker by remember { mutableStateOf(false) }
-                var savedColorSelection by remember { mutableStateOf(androidx.compose.ui.text.TextRange.Zero) }
-
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(bottom = 8.dp),
-                    horizontalArrangement = Arrangement.spacedBy(6.dp),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    val activeBg = colors.chipBackground
-                    val activeTint = colors.chipText
-
-                    // Bold
-                    val isBold = richTextState.currentSpanStyle.fontWeight == FontWeight.Bold
-                    Box(
-                        modifier = Modifier
-                            .size(36.dp)
-                            .clip(RoundedCornerShape(8.dp))
-                            .background(if (isBold) activeBg else activeBg.copy(alpha = 0.4f))
-                            .pointerInput(Unit) {
-                                detectTapGestures(onPress = {
-                                    richTextState.toggleSpanStyle(SpanStyle(fontWeight = FontWeight.Bold))
-                                    tryAwaitRelease()
-                                })
-                            },
-                        contentAlignment = Alignment.Center
-                    ) {
-                        Icon(Icons.Default.FormatBold, contentDescription = null, tint = activeTint, modifier = Modifier.size(20.dp))
-                    }
-                    // Italic
-                    val isItalic = richTextState.currentSpanStyle.fontStyle == FontStyle.Italic
-                    Box(
-                        modifier = Modifier
-                            .size(36.dp)
-                            .clip(RoundedCornerShape(8.dp))
-                            .background(if (isItalic) activeBg else activeBg.copy(alpha = 0.4f))
-                            .pointerInput(Unit) {
-                                detectTapGestures(onPress = {
-                                    richTextState.toggleSpanStyle(SpanStyle(fontStyle = FontStyle.Italic))
-                                    tryAwaitRelease()
-                                })
-                            },
-                        contentAlignment = Alignment.Center
-                    ) {
-                        Icon(Icons.Default.FormatItalic, contentDescription = null, tint = activeTint, modifier = Modifier.size(20.dp))
-                    }
-                    // Strikethrough
-                    val isStrike = richTextState.currentSpanStyle.textDecoration == TextDecoration.LineThrough
-                    Box(
-                        modifier = Modifier
-                            .size(36.dp)
-                            .clip(RoundedCornerShape(8.dp))
-                            .background(if (isStrike) activeBg else activeBg.copy(alpha = 0.4f))
-                            .pointerInput(Unit) {
-                                detectTapGestures(onPress = {
-                                    richTextState.toggleSpanStyle(SpanStyle(textDecoration = TextDecoration.LineThrough))
-                                    tryAwaitRelease()
-                                })
-                            },
-                        contentAlignment = Alignment.Center
-                    ) {
-                        Icon(Icons.Default.FormatStrikethrough, contentDescription = null, tint = activeTint, modifier = Modifier.size(20.dp))
-                    }
-                    // 색상 버튼 (탭하면 인라인으로 색상 펼침)
-                    Box(
-                        modifier = Modifier
-                            .size(36.dp)
-                            .clip(RoundedCornerShape(8.dp))
-                            .background(if (showColorPicker) activeBg else activeBg.copy(alpha = 0.4f))
-                            .pointerInput(Unit) {
-                                detectTapGestures(onPress = {
-                                    savedColorSelection = richTextState.selection
-                                    showColorPicker = !showColorPicker
-                                    tryAwaitRelease()
-                                })
-                            },
-                        contentAlignment = Alignment.Center
-                    ) {
-                        Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                            Text("A", fontSize = 16.sp, fontWeight = FontWeight.Bold, color = activeTint)
-                            Box(modifier = Modifier.width(16.dp).height(3.dp).background(Color(0xFFFF0000), RoundedCornerShape(1.dp)))
-                        }
-                    }
-
-                }
-
-                // 색상 팔레트 — 툴바 아래 별도 Row
-                if (showColorPicker) {
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(bottom = 8.dp),
-                        horizontalArrangement = Arrangement.spacedBy(10.dp)
-                    ) {
-                        val textColors = listOf(
-                            "#FF0000", "#FF9800", "#FFEB3B", "#4CAF50",
-                            "#2196F3", "#9C27B0", "#795548", "#607D8B"
-                        )
-                        textColors.forEach { hex ->
-                            Box(
-                                modifier = Modifier
-                                    .size(22.dp)
-                                    .clip(CircleShape)
-                                    .background(Color(android.graphics.Color.parseColor(hex)))
-                                    .pointerInput(hex) {
-                                        detectTapGestures(onPress = {
-                                            if (savedColorSelection.start != savedColorSelection.end) {
-                                                richTextState.addSpanStyle(
-                                                    SpanStyle(color = Color(android.graphics.Color.parseColor(hex))),
-                                                    savedColorSelection
-                                                )
-                                            }
-                                            showColorPicker = false
-                                            tryAwaitRelease()
-                                        })
-                                    }
-                            )
-                        }
                     }
                 }
 
@@ -673,138 +514,6 @@ fun MemoScreen(
                         val vid = videoIdRegex.find(detectedYoutubeUrl)?.groupValues?.get(1)
                         if (vid != null) {
                             onYoutubeDetected(vid)
-                        }
-                    }
-                }
-
-                if (detectedYoutubeUrl != null) {
-                    Spacer(modifier = Modifier.height(12.dp))
-                    Column {
-                        // 링크 칩
-                        Row(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .clip(RoundedCornerShape(10.dp))
-                                .background(colors.chipBackground.copy(alpha = 0.5f))
-                                .clickable { selectedYoutubeUrl = detectedYoutubeUrl }
-                                .padding(horizontal = 12.dp, vertical = 10.dp),
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            Text(text = "▶", fontSize = 14.sp)
-                            Spacer(modifier = Modifier.width(8.dp))
-                            Column(modifier = Modifier.weight(1f)) {
-                                if (youtubeTitle != null) {
-                                    Text(
-                                        text = youtubeTitle,
-                                        fontSize = 13.sp,
-                                        fontWeight = FontWeight.SemiBold,
-                                        color = colors.textBody,
-                                        maxLines = 2
-                                    )
-                                    Text(
-                                        text = detectedYoutubeUrl,
-                                        fontSize = 11.sp,
-                                        color = Color(0xFF2196F3),
-                                        maxLines = 1,
-                                        style = TextStyle(textDecoration = TextDecoration.Underline)
-                                    )
-                                } else {
-                                    Text(
-                                        text = detectedYoutubeUrl,
-                                        fontSize = 13.sp,
-                                        color = Color(0xFF2196F3),
-                                        maxLines = 1,
-                                        style = TextStyle(textDecoration = TextDecoration.Underline)
-                                    )
-                                }
-                            }
-                            if (onYoutubeSummarize != null && !isSummarizing && summaryResult == null) {
-                                Spacer(modifier = Modifier.width(8.dp))
-                                Text(
-                                    text = "🤖 요약",
-                                    fontSize = 12.sp,
-                                    color = colors.chipText,
-                                    fontWeight = FontWeight.SemiBold,
-                                    modifier = Modifier
-                                        .clip(RoundedCornerShape(6.dp))
-                                        .background(colors.chipBackground)
-                                        .clickable { onYoutubeSummarize(detectedYoutubeUrl) }
-                                        .padding(horizontal = 8.dp, vertical = 4.dp)
-                                )
-                            }
-                        }
-
-                        // 제한 도달 에러 메시지
-                        if (summaryError != null) {
-                            Spacer(modifier = Modifier.height(8.dp))
-                            Row(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .clip(RoundedCornerShape(8.dp))
-                                    .background(Color(0xFFFFF3E0))
-                                    .padding(12.dp),
-                                verticalAlignment = Alignment.CenterVertically
-                            ) {
-                                Text(text = "⚠️", fontSize = 16.sp)
-                                Spacer(modifier = Modifier.width(8.dp))
-                                Text(
-                                    text = summaryError,
-                                    fontSize = 13.sp,
-                                    color = Color(0xFFE65100),
-                                    lineHeight = 18.sp
-                                )
-                            }
-                        }
-
-                        // 로딩 중 — 칩 아래 작게 표시
-                        if (isSummarizing) {
-                            Spacer(modifier = Modifier.height(8.dp))
-                            Row(
-                                modifier = Modifier.padding(start = 4.dp),
-                                verticalAlignment = Alignment.CenterVertically
-                            ) {
-                                androidx.compose.material3.CircularProgressIndicator(
-                                    modifier = Modifier.size(14.dp),
-                                    strokeWidth = 2.dp,
-                                    color = colors.textSecondary
-                                )
-                                Spacer(modifier = Modifier.width(8.dp))
-                                Text(
-                                    text = "요약 중...",
-                                    fontSize = 12.sp,
-                                    color = colors.textSecondary
-                                )
-                            }
-                        }
-
-                        // 요약 완료 — "요약 보기" 버튼
-                        if (summaryResult != null) {
-                            Spacer(modifier = Modifier.height(8.dp))
-                            Text(
-                                text = if (showSummary) "▼ 요약 접기" else "▶ 요약 보기",
-                                fontSize = 13.sp,
-                                color = colors.chipText,
-                                fontWeight = FontWeight.SemiBold,
-                                modifier = Modifier
-                                    .clip(RoundedCornerShape(8.dp))
-                                    .background(colors.chipBackground)
-                                    .clickable { showSummary = !showSummary }
-                                    .padding(horizontal = 12.dp, vertical = 8.dp)
-                            )
-                            if (showSummary) {
-                                Spacer(modifier = Modifier.height(8.dp))
-                                Text(
-                                    text = summaryResult,
-                                    fontSize = 14.sp,
-                                    lineHeight = 22.sp,
-                                    color = colors.textBody,
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .clip(RoundedCornerShape(10.dp))
-                                        .background(colors.chipBackground.copy(alpha = 0.3f))
-                                        .padding(12.dp)
-                                )
-                            }
                         }
                     }
                 }
@@ -873,6 +582,31 @@ fun MemoScreen(
                                 Text("브라우저에서 열기", fontSize = 16.sp, color = colors.textBody)
                             }
 
+                            // ▶ YouTube에서 열기
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .clip(RoundedCornerShape(12.dp))
+                                    .clickable {
+                                        val fullUrl = if (url.startsWith("http")) url else "https://$url"
+                                        val ytIntent = Intent(Intent.ACTION_VIEW, Uri.parse(fullUrl)).apply {
+                                            setPackage("com.google.android.youtube")
+                                        }
+                                        try {
+                                            context.startActivity(ytIntent)
+                                        } catch (_: Exception) {
+                                            context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(fullUrl)))
+                                        }
+                                        selectedYoutubeUrl = null
+                                    }
+                                    .padding(vertical = 14.dp, horizontal = 4.dp),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Text("▶️", fontSize = 20.sp)
+                                Spacer(modifier = Modifier.width(12.dp))
+                                Text("YouTube에서 열기", fontSize = 16.sp, color = colors.textBody)
+                            }
+
                             // 🤖 AI 요약하기 (1회만 가능)
                             if (onYoutubeSummarize != null && !isSummarizing && summaryResult == null) {
                                 Row(
@@ -895,54 +629,189 @@ fun MemoScreen(
                     }
                 }
 
-                Spacer(modifier = Modifier.height(20.dp))
+                // 서식 툴바 (본문 아래)
+                var showColorPicker by remember { mutableStateOf(false) }
+                var savedColorSelection by remember { mutableStateOf(androidx.compose.ui.text.TextRange.Zero) }
 
-                // 카테고리 (내용 아래 배치, 탭하면 펼침)
-                var showCategoryPicker by remember { mutableStateOf(false) }
-                Text(
-                    text = "${CATEGORY_EMOJIS[categoryIndex]} ${categories[categoryIndex]}",
-                    fontSize = 12.sp,
-                    color = colors.chipText,
-                    modifier = Modifier
-                        .background(colors.chipBackground, RoundedCornerShape(50))
-                        .clickable { showCategoryPicker = !showCategoryPicker }
-                        .padding(horizontal = 10.dp, vertical = 4.dp)
-                )
-                if (showCategoryPicker) {
-                    Spacer(modifier = Modifier.height(8.dp))
-                    FlowRow(
-                        maxItemsInEachRow = 3,
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.spacedBy(6.dp),
-                        verticalArrangement = Arrangement.spacedBy(6.dp)
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(6.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    val activeBg = colors.chipBackground
+                    val activeTint = colors.chipText
+
+                    val isBold = richTextState.currentSpanStyle.fontWeight == FontWeight.Bold
+                    Box(
+                        modifier = Modifier.size(36.dp).clip(RoundedCornerShape(8.dp))
+                            .background(if (isBold) activeBg else activeBg.copy(alpha = 0.4f))
+                            .pointerInput(Unit) { detectTapGestures(onPress = { richTextState.toggleSpanStyle(SpanStyle(fontWeight = FontWeight.Bold)); tryAwaitRelease() }) },
+                        contentAlignment = Alignment.Center
+                    ) { Icon(Icons.Default.FormatBold, contentDescription = null, tint = activeTint, modifier = Modifier.size(20.dp)) }
+
+                    val isItalic = richTextState.currentSpanStyle.fontStyle == FontStyle.Italic
+                    Box(
+                        modifier = Modifier.size(36.dp).clip(RoundedCornerShape(8.dp))
+                            .background(if (isItalic) activeBg else activeBg.copy(alpha = 0.4f))
+                            .pointerInput(Unit) { detectTapGestures(onPress = { richTextState.toggleSpanStyle(SpanStyle(fontStyle = FontStyle.Italic)); tryAwaitRelease() }) },
+                        contentAlignment = Alignment.Center
+                    ) { Icon(Icons.Default.FormatItalic, contentDescription = null, tint = activeTint, modifier = Modifier.size(20.dp)) }
+
+                    val isStrike = richTextState.currentSpanStyle.textDecoration == TextDecoration.LineThrough
+                    Box(
+                        modifier = Modifier.size(36.dp).clip(RoundedCornerShape(8.dp))
+                            .background(if (isStrike) activeBg else activeBg.copy(alpha = 0.4f))
+                            .pointerInput(Unit) { detectTapGestures(onPress = { richTextState.toggleSpanStyle(SpanStyle(textDecoration = TextDecoration.LineThrough)); tryAwaitRelease() }) },
+                        contentAlignment = Alignment.Center
+                    ) { Icon(Icons.Default.FormatStrikethrough, contentDescription = null, tint = activeTint, modifier = Modifier.size(20.dp)) }
+
+                    Box(
+                        modifier = Modifier.size(36.dp).clip(RoundedCornerShape(8.dp))
+                            .background(if (showColorPicker) activeBg else activeBg.copy(alpha = 0.4f))
+                            .pointerInput(Unit) { detectTapGestures(onPress = { savedColorSelection = richTextState.selection; showColorPicker = !showColorPicker; tryAwaitRelease() }) },
+                        contentAlignment = Alignment.Center
                     ) {
-                        categories.forEachIndexed { index, category ->
-                            val selected = categoryIndex == index
-                            Box(
-                                modifier = Modifier
-                                    .weight(1f)
-                                    .fillMaxWidth()
-                                    .clip(RoundedCornerShape(12.dp))
-                                    .background(if (selected) colors.chipBackground else Color.Transparent)
-                                    .border(1.dp, if (selected) colors.chipText else colors.cardBorder, RoundedCornerShape(12.dp))
-                                    .clickable {
-                                        categoryIndex = index
-                                        showCategoryPicker = false
-                                    }
-                                    .padding(horizontal = 4.dp, vertical = 8.dp),
-                                contentAlignment = Alignment.Center
-                            ) {
-                                Text(
-                                    text = "${CATEGORY_EMOJIS[index]} $category",
-                                    maxLines = 1,
-                                    fontSize = 11.sp,
-                                    color = if (selected) colors.chipText else colors.textSecondary
-                                )
-                            }
+                        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                            Text("A", fontSize = 16.sp, fontWeight = FontWeight.Bold, color = activeTint)
+                            Box(modifier = Modifier.width(16.dp).height(3.dp).background(Color(0xFFFF0000), RoundedCornerShape(1.dp)))
                         }
-                        Spacer(modifier = Modifier.weight(1f))
                     }
                 }
+
+                if (showColorPicker) {
+                    Spacer(modifier = Modifier.height(6.dp))
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(10.dp)
+                    ) {
+                        listOf("#000000", "#FF0000", "#FF9800", "#FFEB3B", "#4CAF50", "#2196F3", "#9C27B0", "#795548", "#607D8B").forEach { hex ->
+                            Box(
+                                modifier = Modifier.size(22.dp).clip(CircleShape)
+                                    .background(Color(android.graphics.Color.parseColor(hex)))
+                                    .pointerInput(hex) {
+                                        detectTapGestures(onPress = {
+                                            if (savedColorSelection.start != savedColorSelection.end) {
+                                                richTextState.addSpanStyle(SpanStyle(color = Color(android.graphics.Color.parseColor(hex))), savedColorSelection)
+                                            }
+                                            showColorPicker = false; tryAwaitRelease()
+                                        })
+                                    }
+                            )
+                        }
+                    }
+                }
+
+                // 유튜브 칩 (서식 툴바 아래)
+                val youtubeUrlDisplay = detectedYoutubeUrl ?: savedYoutubeUrl ?: ""
+                val hasYoutubeSummaryContent = bodyText.contains("핵심 키워드") || bodyText.contains("한줄 요약") || bodyText.contains("타임라인별")
+                if ((detectedYoutubeUrl != null || summaryResult != null || youtubeTitle != null || hasYoutubeSummaryContent) && !youtubeChipDismissed) {
+                    Spacer(modifier = Modifier.height(12.dp))
+                    Box {
+                        Column {
+                            Row(
+                                modifier = Modifier.fillMaxWidth().clip(RoundedCornerShape(10.dp))
+                                    .background(colors.chipBackground.copy(alpha = 0.5f))
+                                    .padding(horizontal = 12.dp, vertical = 10.dp),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Text(text = "▶", fontSize = 14.sp)
+                                Spacer(modifier = Modifier.width(8.dp))
+                                Column(modifier = Modifier.weight(1f)) {
+                                    val chipTitle = youtubeTitle ?: nameText.takeIf { it.isNotBlank() }
+                                    if (chipTitle != null) {
+                                        Text(chipTitle, fontSize = 13.sp, fontWeight = FontWeight.SemiBold, color = colors.textBody, maxLines = 2)
+                                    }
+                                    if (youtubeUrlDisplay.isNotBlank()) {
+                                        Text(youtubeUrlDisplay, fontSize = 11.sp, color = Color(0xFF2196F3), maxLines = 1,
+                                            style = TextStyle(textDecoration = TextDecoration.Underline),
+                                            modifier = Modifier.clickable { selectedYoutubeUrl = youtubeUrlDisplay })
+                                    } else if (chipTitle == null) {
+                                        Text("📺 유튜브 요약", fontSize = 13.sp, fontWeight = FontWeight.SemiBold, color = colors.textBody)
+                                    }
+                                }
+                                if (onYoutubeSummarize != null && !isSummarizing && summaryResult == null) {
+                                    Spacer(modifier = Modifier.width(8.dp))
+                                    Text("🤖 요약", fontSize = 12.sp, color = colors.chipText, fontWeight = FontWeight.SemiBold,
+                                        modifier = Modifier.clip(RoundedCornerShape(6.dp)).background(colors.chipBackground)
+                                            .clickable { detectedYoutubeUrl?.let { onYoutubeSummarize(it) } }
+                                            .padding(horizontal = 8.dp, vertical = 4.dp))
+                                }
+                            }
+                            var errorDismissed by remember { mutableStateOf(false) }
+                            LaunchedEffect(summaryError) { if (summaryError != null) errorDismissed = false }
+                            if (summaryError != null && !errorDismissed) {
+                                Spacer(modifier = Modifier.height(8.dp))
+                                Box {
+                                    Row(modifier = Modifier.fillMaxWidth().clip(RoundedCornerShape(8.dp)).background(Color(0xFFFFF3E0)).padding(12.dp), verticalAlignment = Alignment.CenterVertically) {
+                                        Text("⚠️", fontSize = 16.sp); Spacer(modifier = Modifier.width(8.dp)); Text(summaryError, fontSize = 13.sp, color = Color(0xFFE65100), lineHeight = 18.sp, modifier = Modifier.weight(1f))
+                                    }
+                                    Icon(Icons.Default.Close, contentDescription = null, tint = Color(0xFFE65100),
+                                        modifier = Modifier.size(16.dp).align(Alignment.TopEnd).clickable { errorDismissed = true })
+                                }
+                            }
+                            if (isSummarizing) {
+                                Spacer(modifier = Modifier.height(8.dp))
+                                Row(modifier = Modifier.padding(start = 4.dp), verticalAlignment = Alignment.CenterVertically) {
+                                    androidx.compose.material3.CircularProgressIndicator(modifier = Modifier.size(14.dp), strokeWidth = 2.dp, color = colors.textSecondary)
+                                    Spacer(modifier = Modifier.width(8.dp)); Text("요약 중...", fontSize = 12.sp, color = colors.textSecondary)
+                                }
+                            }
+                        }
+                        // X 삭제 버튼
+                        Icon(Icons.Default.Close, contentDescription = null, tint = colors.textSecondary,
+                            modifier = Modifier.size(16.dp).align(Alignment.TopEnd).clickable { youtubeChipDismissed = true; showSummary = false })
+                    }
+                }
+
+                // 오디오 재생 바 (서식 툴바 아래)
+                var audioChipDismissed by remember { mutableStateOf(false) }
+                val effectiveAudioPath = audioPath ?: existingMemo.audioPath
+                if (effectiveAudioPath != null && java.io.File(effectiveAudioPath).exists() && !audioChipDismissed) {
+                    var isPlaying by remember { mutableStateOf(false) }
+                    val mediaPlayer = remember {
+                        android.media.MediaPlayer().apply {
+                            setDataSource(effectiveAudioPath)
+                            prepare()
+                            setOnCompletionListener { isPlaying = false }
+                        }
+                    }
+                    DisposableEffect(Unit) { onDispose { mediaPlayer.release() } }
+
+                    Spacer(modifier = Modifier.height(12.dp))
+                    Box {
+                    Row(
+                        modifier = Modifier.fillMaxWidth().clip(RoundedCornerShape(10.dp))
+                            .background(colors.chipBackground.copy(alpha = 0.5f))
+                            .padding(horizontal = 12.dp, vertical = 10.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Box(
+                            modifier = Modifier.size(36.dp).clip(CircleShape).background(colors.chipText)
+                                .clickable { if (isPlaying) { mediaPlayer.pause(); isPlaying = false } else { mediaPlayer.start(); isPlaying = true } },
+                            contentAlignment = Alignment.Center
+                        ) { Icon(if (isPlaying) Icons.Default.Pause else Icons.Default.PlayArrow, contentDescription = null, tint = Color.White, modifier = Modifier.size(20.dp)) }
+                        Spacer(modifier = Modifier.width(10.dp))
+                        Text("🎙️ ${nameText.ifBlank { "녹음 파일" }}", fontSize = 14.sp, color = colors.textBody, fontWeight = FontWeight.SemiBold, modifier = Modifier.weight(1f), maxLines = 1)
+                        Icon(Icons.Default.Download, contentDescription = null, tint = colors.textSecondary,
+                            modifier = Modifier.size(20.dp).clickable {
+                                val source = java.io.File(effectiveAudioPath); val dest = android.os.Environment.getExternalStoragePublicDirectory(android.os.Environment.DIRECTORY_DOWNLOADS)
+                                val target = java.io.File(dest, "memozy_${System.currentTimeMillis()}.m4a"); source.copyTo(target, overwrite = true)
+                                android.widget.Toast.makeText(context, "📁 내 파일 > Download 에 저장됨", android.widget.Toast.LENGTH_LONG).show()
+                            })
+                        Spacer(modifier = Modifier.width(12.dp))
+                        Icon(Icons.Default.Share, contentDescription = null, tint = colors.textSecondary,
+                            modifier = Modifier.size(20.dp).clickable {
+                                val uri = androidx.core.content.FileProvider.getUriForFile(context, "${context.packageName}.fileprovider", java.io.File(effectiveAudioPath))
+                                val shareIntent = Intent(Intent.ACTION_SEND).apply { type = "audio/mp4"; putExtra(Intent.EXTRA_STREAM, uri); addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION) }
+                                context.startActivity(Intent.createChooser(shareIntent, null))
+                            })
+                    }
+                    Icon(Icons.Default.Close, contentDescription = null, tint = colors.textSecondary,
+                        modifier = Modifier.size(16.dp).align(Alignment.TopEnd).clickable { audioChipDismissed = true })
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(20.dp))
             }
 
             // 하단 AI 액션 바 — 항상 표시
@@ -956,11 +825,16 @@ fun MemoScreen(
             ) {
                 // 🎙️ 녹음
                 if (onStartRecording != null) {
+                    val recordingBusy = isRecording || isTranscribing
                     Row(
                         modifier = Modifier
                             .clip(RoundedCornerShape(20.dp))
-                            .background(if (isRecording) Color(0xFFE24B4A) else colors.chipBackground)
-                            .clickable {
+                            .background(
+                                if (isRecording) Color(0xFFE24B4A)
+                                else if (isTranscribing) colors.chipBackground.copy(alpha = 0.3f)
+                                else colors.chipBackground
+                            )
+                            .clickable(enabled = !isTranscribing) {
                                 if (isRecording) onStopRecording?.invoke()
                                 else onStartRecording()
                             }
@@ -984,16 +858,18 @@ fun MemoScreen(
                 }
 
                 // 📺 유튜브 요약 (항상 표시)
-                if (onYoutubeSummarize != null && !isSummarizing && summaryResult == null) {
+                if (onYoutubeSummarize != null) {
                     val hasYoutubeUrl = detectedYoutubeUrl != null
                     Row(
                         modifier = Modifier
                             .clip(RoundedCornerShape(20.dp))
                             .background(
-                                if (hasYoutubeUrl) Color(0xFF2196F3).copy(alpha = 0.1f)
+                                if (isSummarizing) colors.chipBackground.copy(alpha = 0.3f)
+                                else if (hasYoutubeUrl) Color(0xFF2196F3).copy(alpha = 0.1f)
                                 else colors.chipBackground
                             )
-                            .clickable {
+                            .clickable(enabled = !isSummarizing) {
+                                youtubeChipDismissed = false
                                 if (hasYoutubeUrl) {
                                     onYoutubeSummarize(detectedYoutubeUrl ?: return@clickable)
                                 } else {
@@ -1048,18 +924,18 @@ fun MemoScreen(
                         singleLine = true,
                         modifier = Modifier.fillMaxWidth()
                     )
-                    if (clipHasYoutube && urlInput.isBlank()) {
+                    if (clipText.isNotBlank() && urlInput.isBlank()) {
                         Spacer(modifier = Modifier.height(8.dp))
                         Text(
-                            text = "📋 클립보드에서 붙여넣기",
+                            text = "📋 붙여넣기: $clipText",
                             fontSize = 13.sp,
                             color = Color(0xFF2196F3),
                             fontWeight = FontWeight.SemiBold,
+                            maxLines = 2,
                             modifier = Modifier
                                 .clip(RoundedCornerShape(6.dp))
                                 .clickable {
-                                    val url = YOUTUBE_URL_REGEX.find(clipText)?.value ?: ""
-                                    urlInput = url
+                                    urlInput = clipText
                                 }
                                 .padding(vertical = 4.dp)
                         )


### PR DESCRIPTION
## Summary

### 1. 태그 시스템 (카테고리 대체)
- Tag/MemoTag Entity + TagDao — N:N 관계 (메모 하나에 여러 태그)
- Migration 10→11: 태그 테이블 생성 + 기존 카테고리 데이터 마이그레이션
- 드롭다운 필터: 자동 뷰 (전체/메모/유튜브/녹음) + 사용자 태그
- 태그 추가 다이얼로그 (+ 버튼)
- 녹음/유튜브 저장 시 자동 태그 부여

### 2. 유튜브 요약 개선
- `youtubeUrl` DB 영구 저장 (Migration 11→12) — 수정 시에도 칩/URL 유지
- 칩 하단 URL 클릭 → 바텀시트 (복사/브라우저/YouTube에서 열기)
- 503/UNAVAILABLE 에러 한글 메시지
- 외부 공유(ACTION_SEND) 요약 결과 richTextState 동기화
- 요약 중에만 버튼 비활성화 (이외 항상 활성)

### 3. 녹음 기능 개선
- 녹음 파일 저장(Download)/공유 버튼
- 제목 자동 설정: `26.04.08 13:30 녹음`
- 녹음 파일명도 제목과 동일
- FileProvider 설정 추가
- 녹음 중 버튼 비활성화

### 4. UI 통합 및 정리
- 서식 툴바 → 본문 아래로 이동
- 유튜브/녹음 칩 → 서식 툴바 아래 통일 배치
- 모든 칩에 X 닫기 버튼 (유튜브/녹음/에러)
- 카테고리 선택 UI 제거
- MemoCard 태그 칩 표시 (이모지 제거)
- 색상 팔레트에 블랙 추가
- 제목-본문 간격 조정
- 메모 추가/수정 UI 완전 통일

## Test plan
- [x] 태그 필터 (전체/메모/유튜브/녹음) 동작
- [x] 사용자 태그 추가 및 필터
- [x] 녹음 → 자동 태그 + 제목 설정 + 파일 저장/공유
- [x] 유튜브 → 자동 태그 + URL 영구 저장 + 바텀시트
- [x] 메모 수정 시 유튜브 칩/녹음 칩 유지
- [x] 외부 공유 → 요약 정상 동작
- [x] 에러 메시지 한글 처리 + X 닫기
- [x] DB Migration 10→11→12 정상
- [x] 전체 앱 빌드 성공

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)