### PR TITLE
Add: #37 홈 화면 위젯 (Glance API)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -30,9 +30,11 @@ android {
 dependencies {
     // 모듈 - Hilt 바인딩을 위해 implementation 필요
     implementation(projects.datasource.local.memo.impl)
+    implementation(projects.datasource.local.memo.api) // 위젯에서 Memo 엔티티 참조
     implementation(projects.datasource.local.chat.impl)
     implementation(projects.datasource.remote.ai.impl)
     implementation(projects.data.repository.memo.impl)
+    implementation(projects.data.repository.memo.api) // 위젯에서 MemoRepository 참조
     implementation(projects.data.repository.chat.impl)
     implementation(projects.feature.home.impl)
     implementation(projects.feature.memoPlain.impl)
@@ -43,6 +45,10 @@ dependencies {
 
     // MemozyApplication
     implementation(libs.android.joda)
+
+    // glance widget
+    implementation(libs.glance.appwidget)
+    implementation(libs.glance.material3)
 
     // firebase
     implementation(platform(libs.firebase.bom))

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,6 +20,18 @@
         android:theme="@style/Theme.Memozy"
         android:localeConfig="@xml/locales_config">
 
+        <receiver
+            android:name=".widget.MemoWidgetReceiver"
+            android:exported="true"
+            android:label="@string/widget_name">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/memo_widget_info" />
+        </receiver>
+
         <provider
             android:name="androidx.core.content.FileProvider"
             android:authorities="${applicationId}.fileprovider"

--- a/app/src/main/java/me/pecos/memozy/widget/MemoWidget.kt
+++ b/app/src/main/java/me/pecos/memozy/widget/MemoWidget.kt
@@ -1,0 +1,184 @@
+package me.pecos.memozy.widget
+
+import android.content.Context
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.glance.GlanceId
+import androidx.glance.GlanceModifier
+import androidx.glance.GlanceTheme
+import androidx.glance.Image
+import androidx.glance.ImageProvider
+import androidx.glance.action.actionParametersOf
+import androidx.glance.action.actionStartActivity
+import androidx.glance.action.clickable
+import androidx.glance.appwidget.GlanceAppWidget
+import androidx.glance.appwidget.cornerRadius
+import androidx.glance.appwidget.provideContent
+import androidx.glance.background
+import androidx.glance.layout.Alignment
+import androidx.glance.layout.Box
+import androidx.glance.layout.Column
+import androidx.glance.layout.Row
+import androidx.glance.layout.Spacer
+import androidx.glance.layout.fillMaxSize
+import androidx.glance.layout.fillMaxWidth
+import androidx.glance.layout.height
+import androidx.glance.layout.padding
+import androidx.glance.layout.size
+import androidx.glance.text.FontWeight
+import androidx.glance.text.Text
+import androidx.glance.text.TextStyle
+import dagger.hilt.android.EntryPointAccessors
+import me.pecos.memozy.MainActivity
+import me.pecos.memozy.R
+import me.pecos.memozy.data.datasource.local.entity.Memo
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+class MemoWidget : GlanceAppWidget() {
+
+    override suspend fun provideGlance(context: Context, id: GlanceId) {
+        val entryPoint = EntryPointAccessors.fromApplication(
+            context.applicationContext,
+            WidgetEntryPoint::class.java
+        )
+        val repository = entryPoint.memoRepository()
+        val memos = repository.getRecentMemos(5)
+
+        provideContent {
+            GlanceTheme {
+                Column(
+                    modifier = GlanceModifier
+                        .fillMaxSize()
+                        .background(MemoWidgetColors.background)
+                        .cornerRadius(16.dp)
+                        .padding(16.dp)
+                ) {
+                    // Header
+                    Row(
+                        modifier = GlanceModifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Text(
+                            text = "Memozy",
+                            style = TextStyle(
+                                color = MemoWidgetColors.title,
+                                fontSize = 18.sp,
+                                fontWeight = FontWeight.Bold
+                            ),
+                            modifier = GlanceModifier.defaultWeight()
+                        )
+                        Box(
+                            modifier = GlanceModifier
+                                .size(36.dp)
+                                .cornerRadius(18.dp)
+                                .background(MemoWidgetColors.addButtonBackground)
+                                .clickable(
+                                    actionStartActivity<MainActivity>(
+                                        parameters = newMemoParams()
+                                    )
+                                ),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Image(
+                                provider = ImageProvider(R.drawable.ic_widget_add),
+                                contentDescription = "새 메모",
+                                modifier = GlanceModifier.size(20.dp)
+                            )
+                        }
+                    }
+
+                    Spacer(modifier = GlanceModifier.height(12.dp))
+
+                    if (memos.isEmpty()) {
+                        Box(
+                            modifier = GlanceModifier
+                                .fillMaxWidth()
+                                .defaultWeight(),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Text(
+                                text = context.getString(R.string.widget_empty),
+                                style = TextStyle(
+                                    color = MemoWidgetColors.secondary,
+                                    fontSize = 14.sp
+                                )
+                            )
+                        }
+                    } else {
+                        Column(modifier = GlanceModifier.defaultWeight()) {
+                            for (memo in memos) {
+                                Column(
+                                    modifier = GlanceModifier
+                                        .fillMaxWidth()
+                                        .padding(vertical = 4.dp)
+                                        .cornerRadius(12.dp)
+                                        .background(MemoWidgetColors.cardBackground)
+                                        .padding(12.dp)
+                                        .clickable(
+                                            actionStartActivity<MainActivity>(
+                                                parameters = openMemoParams(memo.id)
+                                            )
+                                        )
+                                ) {
+                                    Text(
+                                        text = memo.name.ifBlank { context.getString(R.string.widget_untitled) },
+                                        style = TextStyle(
+                                            color = MemoWidgetColors.title,
+                                            fontSize = 14.sp,
+                                            fontWeight = FontWeight.Medium
+                                        ),
+                                        maxLines = 1
+                                    )
+                                    if (memo.content.isNotBlank()) {
+                                        Spacer(modifier = GlanceModifier.height(2.dp))
+                                        Text(
+                                            text = memo.content.take(80),
+                                            style = TextStyle(
+                                                color = MemoWidgetColors.body,
+                                                fontSize = 12.sp
+                                            ),
+                                            maxLines = 2
+                                        )
+                                    }
+                                    Spacer(modifier = GlanceModifier.height(4.dp))
+                                    Text(
+                                        text = formatDate(memo.updatedAt),
+                                        style = TextStyle(
+                                            color = MemoWidgetColors.secondary,
+                                            fontSize = 10.sp
+                                        )
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    companion object {
+        private fun newMemoParams() = actionParametersOf(
+            MemoWidgetKeys.ACTION_KEY to MemoWidgetKeys.ACTION_NEW_MEMO
+        )
+
+        private fun openMemoParams(memoId: Int) = actionParametersOf(
+            MemoWidgetKeys.ACTION_KEY to MemoWidgetKeys.ACTION_OPEN_MEMO,
+            MemoWidgetKeys.MEMO_ID_KEY to memoId
+        )
+
+        private fun formatDate(timestamp: Long): String {
+            val now = System.currentTimeMillis()
+            val diff = now - timestamp
+            return when {
+                diff < 60_000 -> "방금"
+                diff < 3_600_000 -> "${diff / 60_000}분 전"
+                diff < 86_400_000 -> "${diff / 3_600_000}시간 전"
+                diff < 604_800_000 -> "${diff / 86_400_000}일 전"
+                else -> SimpleDateFormat("M/d", Locale.getDefault()).format(Date(timestamp))
+            }
+        }
+    }
+}

--- a/app/src/main/java/me/pecos/memozy/widget/MemoWidgetKeys.kt
+++ b/app/src/main/java/me/pecos/memozy/widget/MemoWidgetKeys.kt
@@ -1,0 +1,11 @@
+package me.pecos.memozy.widget
+
+import androidx.glance.action.ActionParameters
+
+object MemoWidgetKeys {
+    const val ACTION_NEW_MEMO = "new_memo"
+    const val ACTION_OPEN_MEMO = "open_memo"
+
+    val ACTION_KEY = ActionParameters.Key<String>("widget_action")
+    val MEMO_ID_KEY = ActionParameters.Key<Int>("widget_memo_id")
+}

--- a/app/src/main/java/me/pecos/memozy/widget/MemoWidgetReceiver.kt
+++ b/app/src/main/java/me/pecos/memozy/widget/MemoWidgetReceiver.kt
@@ -1,0 +1,8 @@
+package me.pecos.memozy.widget
+
+import androidx.glance.appwidget.GlanceAppWidget
+import androidx.glance.appwidget.GlanceAppWidgetReceiver
+
+class MemoWidgetReceiver : GlanceAppWidgetReceiver() {
+    override val glanceAppWidget: GlanceAppWidget = MemoWidget()
+}

--- a/app/src/main/java/me/pecos/memozy/widget/MemoWidgetTheme.kt
+++ b/app/src/main/java/me/pecos/memozy/widget/MemoWidgetTheme.kt
@@ -1,0 +1,39 @@
+package me.pecos.memozy.widget
+
+import androidx.compose.ui.graphics.Color
+import androidx.glance.color.ColorProvider
+
+object MemoWidgetColors {
+    val background = ColorProvider(
+        day = Color(0xFFFFFFFF),
+        night = Color(0xFF1C1C1E)
+    )
+    val cardBackground = ColorProvider(
+        day = Color(0xFFF5F5F5),
+        night = Color(0xFF2C2C2E)
+    )
+    val title = ColorProvider(
+        day = Color(0xFF000000),
+        night = Color(0xFFF2F2F7)
+    )
+    val body = ColorProvider(
+        day = Color(0xFF616161),
+        night = Color(0xFFEBEBF5)
+    )
+    val secondary = ColorProvider(
+        day = Color(0xFF9E9E9E),
+        night = Color(0xFF8E8E93)
+    )
+    val accent = ColorProvider(
+        day = Color(0xFF1D6BF3),
+        night = Color(0xFF6B9FFF)
+    )
+    val addButtonBackground = ColorProvider(
+        day = Color(0xFF1D6BF3),
+        night = Color(0xFF6B9FFF)
+    )
+    val addButtonIcon = ColorProvider(
+        day = Color(0xFFFFFFFF),
+        night = Color(0xFF1C1C1E)
+    )
+}

--- a/app/src/main/java/me/pecos/memozy/widget/WidgetEntryPoint.kt
+++ b/app/src/main/java/me/pecos/memozy/widget/WidgetEntryPoint.kt
@@ -1,0 +1,12 @@
+package me.pecos.memozy.widget
+
+import dagger.hilt.EntryPoint
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import me.pecos.memozy.data.repository.MemoRepository
+
+@EntryPoint
+@InstallIn(SingletonComponent::class)
+interface WidgetEntryPoint {
+    fun memoRepository(): MemoRepository
+}

--- a/app/src/main/res/drawable/ic_widget_add.xml
+++ b/app/src/main/res/drawable/ic_widget_add.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M19,13h-6v6h-2v-6H5v-2h6V5h2v6h6z" />
+</vector>

--- a/app/src/main/res/drawable/widget_preview.xml
+++ b/app/src/main/res/drawable/widget_preview.xml
@@ -1,0 +1,8 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="#FFFFFF" />
+    <corners android:radius="16dp" />
+    <stroke
+        android:width="1dp"
+        android:color="#E0E0E0" />
+</shape>

--- a/app/src/main/res/layout/widget_loading.xml
+++ b/app/src/main/res/layout/widget_loading.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@drawable/widget_preview"
+    android:padding="16dp">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Memozy"
+        android:textSize="18sp"
+        android:textStyle="bold"
+        android:textColor="#000000" />
+</FrameLayout>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -76,4 +76,10 @@
     <string name="donation_error_title">Payment Error</string>
     <string name="donation_error_message">Something went wrong during payment.\nPlease try again.</string>
     <string name="donation_loading">Connecting…</string>
+
+    <!-- Widget -->
+    <string name="widget_name">Memozy Recent Memos</string>
+    <string name="widget_description">Quickly view recent memos and create new ones</string>
+    <string name="widget_empty">No memos yet</string>
+    <string name="widget_untitled">Untitled</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -76,4 +76,10 @@
     <string name="donation_error_title">決済エラー</string>
     <string name="donation_error_message">決済処理中に問題が発生しました。\nもう一度お試しください。</string>
     <string name="donation_loading">接続中…</string>
+
+    <!-- Widget -->
+    <string name="widget_name">Memozy 最近のメモ</string>
+    <string name="widget_description">最近のメモを素早く確認して新しいメモを作成</string>
+    <string name="widget_empty">メモがまだありません</string>
+    <string name="widget_untitled">タイトルなし</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,9 @@
 <resources>
     <string name="app_name">Memozy</string>
+
+    <!-- Widget -->
+    <string name="widget_name">Memozy 최근 메모</string>
+    <string name="widget_description">최근 메모를 빠르게 확인하고 새 메모를 작성하세요</string>
+    <string name="widget_empty">메모가 없어요</string>
+    <string name="widget_untitled">제목 없음</string>
 </resources>

--- a/app/src/main/res/xml/memo_widget_info.xml
+++ b/app/src/main/res/xml/memo_widget_info.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:initialLayout="@layout/widget_loading"
+    android:minWidth="180dp"
+    android:minHeight="180dp"
+    android:minResizeWidth="110dp"
+    android:minResizeHeight="110dp"
+    android:maxResizeWidth="420dp"
+    android:maxResizeHeight="600dp"
+    android:previewImage="@drawable/widget_preview"
+    android:resizeMode="horizontal|vertical"
+    android:targetCellWidth="3"
+    android:targetCellHeight="3"
+    android:updatePeriodMillis="1800000"
+    android:widgetCategory="home_screen"
+    android:description="@string/widget_description" />

--- a/data/repository/memo/api/src/main/java/me/pecos/memozy/data/repository/MemoRepository.kt
+++ b/data/repository/memo/api/src/main/java/me/pecos/memozy/data/repository/MemoRepository.kt
@@ -10,4 +10,5 @@ interface MemoRepository {
     suspend fun deleteMemo(id: Int)
     suspend fun updateMemo(memo: Memo)
     suspend fun clearAllMemos()
+    suspend fun getRecentMemos(limit: Int = 5): List<Memo>
 }

--- a/data/repository/memo/impl/src/main/java/me/pecos/memozy/data/repository/MemoRepositoryImpl.kt
+++ b/data/repository/memo/impl/src/main/java/me/pecos/memozy/data/repository/MemoRepositoryImpl.kt
@@ -26,4 +26,8 @@ class MemoRepositoryImpl @Inject constructor(private val memoDao: MemoDao) : Mem
     override suspend fun clearAllMemos() {
         memoDao.clearAllMemos()
     }
+
+    override suspend fun getRecentMemos(limit: Int): List<Memo> {
+        return memoDao.getRecentMemos(limit)
+    }
 }

--- a/datasource/local/memo/api/src/main/java/me/pecos/memozy/data/datasource/local/MemoDao.kt
+++ b/datasource/local/memo/api/src/main/java/me/pecos/memozy/data/datasource/local/MemoDao.kt
@@ -26,4 +26,7 @@ interface MemoDao {
 
     @Query("DELETE FROM memo")
     suspend fun clearAllMemos()
+
+    @Query("SELECT * FROM memo ORDER BY updatedAt DESC LIMIT :limit")
+    suspend fun getRecentMemos(limit: Int): List<Memo>
 }

--- a/feature/home/impl/src/main/java/me/pecos/memozy/MainActivity.kt
+++ b/feature/home/impl/src/main/java/me/pecos/memozy/MainActivity.kt
@@ -99,6 +99,18 @@ class MainActivity : AppCompatActivity() {
         super.attachBaseContext(newBase.createConfigurationContext(config))
     }
 
+    private fun getWidgetMemoRoute(intent: Intent?): String? {
+        val action = intent?.getStringExtra("widget_action") ?: return null
+        return when (action) {
+            "new_memo" -> MemoPlainRoute.createRoute("-${System.currentTimeMillis()}")
+            "open_memo" -> {
+                val memoId = intent.getIntExtra("widget_memo_id", -1)
+                if (memoId > 0) MemoPlainRoute.createRoute(memoId.toString()) else null
+            }
+            else -> null
+        }
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
@@ -143,6 +155,14 @@ class MainActivity : AppCompatActivity() {
                                 navController.navigate(
                                     MemoPlainRoute.createRoute("shared_$encoded")
                                 )
+                            }
+                        }
+
+                        // 위젯 액션 처리
+                        val widgetRoute = remember { getWidgetMemoRoute(intent) }
+                        LaunchedEffect(widgetRoute) {
+                            if (widgetRoute != null) {
+                                navController.navigate(widgetRoute)
                             }
                         }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,6 +23,7 @@ kotlinxCoroutines = "1.10.2"
 ktor = "3.1.3"
 kotlinxSerialization = "1.8.1"
 richeditor = "1.0.0-rc11"
+glance = "1.1.1"
 
 [libraries]
 gradlePlugin-android = { module = "com.android.tools.build:gradle", version.ref = "agp" }
@@ -57,6 +58,8 @@ androidx-compose-navigation = { group = "androidx.navigation", name = "navigatio
 kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "kotlinxCoroutines" }
 montage-android = { module = "com.github.wanteddev:montage-android", version.ref = "montageAndroid" }
 richeditor-compose = { module = "com.mohamedrejeb.richeditor:richeditor-compose", version.ref = "richeditor" }
+glance-appwidget = { group = "androidx.glance", name = "glance-appwidget", version.ref = "glance" }
+glance-material3 = { group = "androidx.glance", name = "glance-material3", version.ref = "glance" }
 room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
 room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
 room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }


### PR DESCRIPTION
## Summary
- Glance API 기반 홈 화면 위젯 구현
- 최근 메모 5개 리스트 + 새 메모 생성 버튼
- 라이트/다크 테마 자동 대응, 30분 주기 자동 업데이트
- 위젯 탭 → 앱 내 메모 편집/생성 화면 바로 진입

## Test plan
- [ ] 홈 화면에 위젯 추가 가능 확인
- [ ] 최근 메모 5개가 올바르게 표시되는지 확인
- [ ] 메모 탭 → 해당 메모 편집 화면 진입 확인
- [ ] + 버튼 탭 → 새 메모 생성 화면 진입 확인
- [ ] 라이트/다크 모드 전환 시 위젯 테마 반영 확인
- [ ] 메모 없을 때 빈 상태 메시지 표시 확인

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)