### PR TITLE
Add: #88 휴지통 (Soft Delete) 기능

### DIFF
--- a/data/repository/memo/api/src/main/java/me/pecos/memozy/data/repository/MemoRepository.kt
+++ b/data/repository/memo/api/src/main/java/me/pecos/memozy/data/repository/MemoRepository.kt
@@ -11,4 +11,12 @@ interface MemoRepository {
     suspend fun updateMemo(memo: Memo)
     suspend fun clearAllMemos()
     suspend fun getRecentMemos(limit: Int = 5): List<Memo>
+
+    // ── Trash ──
+    suspend fun softDeleteMemo(id: Int)
+    suspend fun restoreMemo(id: Int)
+    fun getDeletedMemos(): Flow<List<Memo>>
+    suspend fun emptyTrash()
+    suspend fun purgeOldTrash(threshold: Long)
+    fun getTrashCount(): Flow<Int>
 }

--- a/data/repository/memo/impl/src/main/java/me/pecos/memozy/data/repository/MemoRepositoryImpl.kt
+++ b/data/repository/memo/impl/src/main/java/me/pecos/memozy/data/repository/MemoRepositoryImpl.kt
@@ -30,4 +30,26 @@ class MemoRepositoryImpl @Inject constructor(private val memoDao: MemoDao) : Mem
     override suspend fun getRecentMemos(limit: Int): List<Memo> {
         return memoDao.getRecentMemos(limit)
     }
+
+    // ── Trash ──
+
+    override suspend fun softDeleteMemo(id: Int) {
+        memoDao.softDeleteMemoById(id)
+    }
+
+    override suspend fun restoreMemo(id: Int) {
+        memoDao.restoreMemoById(id)
+    }
+
+    override fun getDeletedMemos(): Flow<List<Memo>> = memoDao.getDeletedMemos()
+
+    override suspend fun emptyTrash() {
+        memoDao.emptyTrash()
+    }
+
+    override suspend fun purgeOldTrash(threshold: Long) {
+        memoDao.purgeOldTrash(threshold)
+    }
+
+    override fun getTrashCount(): Flow<Int> = memoDao.getTrashCount()
 }

--- a/datasource/local/memo/api/src/main/java/me/pecos/memozy/data/datasource/local/MemoDao.kt
+++ b/datasource/local/memo/api/src/main/java/me/pecos/memozy/data/datasource/local/MemoDao.kt
@@ -9,7 +9,7 @@ import me.pecos.memozy.data.datasource.local.entity.Memo
 
 @Dao
 interface MemoDao {
-    @Query("SELECT * FROM memo ORDER BY isPinned DESC, id DESC")
+    @Query("SELECT * FROM memo WHERE deletedAt IS NULL ORDER BY isPinned DESC, id DESC")
     fun getAllMemos(): Flow<List<Memo>>
 
     @Insert
@@ -27,6 +27,26 @@ interface MemoDao {
     @Query("DELETE FROM memo")
     suspend fun clearAllMemos()
 
-    @Query("SELECT * FROM memo ORDER BY updatedAt DESC LIMIT :limit")
+    @Query("SELECT * FROM memo WHERE deletedAt IS NULL ORDER BY updatedAt DESC LIMIT :limit")
     suspend fun getRecentMemos(limit: Int): List<Memo>
+
+    // ── Trash (Soft Delete) ──
+
+    @Query("UPDATE memo SET deletedAt = :deletedAt, isPinned = 0 WHERE id = :id")
+    suspend fun softDeleteMemoById(id: Int, deletedAt: Long = System.currentTimeMillis())
+
+    @Query("UPDATE memo SET deletedAt = NULL WHERE id = :id")
+    suspend fun restoreMemoById(id: Int)
+
+    @Query("SELECT * FROM memo WHERE deletedAt IS NOT NULL ORDER BY deletedAt DESC")
+    fun getDeletedMemos(): Flow<List<Memo>>
+
+    @Query("DELETE FROM memo WHERE deletedAt IS NOT NULL")
+    suspend fun emptyTrash()
+
+    @Query("DELETE FROM memo WHERE deletedAt IS NOT NULL AND deletedAt < :threshold")
+    suspend fun purgeOldTrash(threshold: Long)
+
+    @Query("SELECT COUNT(*) FROM memo WHERE deletedAt IS NOT NULL")
+    fun getTrashCount(): Flow<Int>
 }

--- a/datasource/local/memo/api/src/main/java/me/pecos/memozy/data/datasource/local/entity/Memo.kt
+++ b/datasource/local/memo/api/src/main/java/me/pecos/memozy/data/datasource/local/entity/Memo.kt
@@ -17,5 +17,6 @@ data class Memo(
     val isPinned: Boolean = false,
     val audioPath: String? = null,
     val styles: String? = null, // JSON: [{start,end,bold,italic,strikethrough,color}]
-    val youtubeUrl: String? = null
+    val youtubeUrl: String? = null,
+    val deletedAt: Long? = null
 )

--- a/datasource/local/memo/impl/src/main/java/me/pecos/memozy/data/datasource/local/MemoDatabase.kt
+++ b/datasource/local/memo/impl/src/main/java/me/pecos/memozy/data/datasource/local/MemoDatabase.kt
@@ -203,6 +203,12 @@ val MIGRATION_11_12 = object : Migration(11, 12) {
     }
 }
 
+val MIGRATION_12_13 = object : Migration(12, 13) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        database.execSQL("ALTER TABLE memo ADD COLUMN deletedAt INTEGER DEFAULT NULL")
+    }
+}
+
 private val PREPOPULATE_CALLBACK = object : RoomDatabase.Callback() {
     override fun onCreate(db: SupportSQLiteDatabase) {
         super.onCreate(db)
@@ -213,7 +219,7 @@ private val PREPOPULATE_CALLBACK = object : RoomDatabase.Callback() {
 @TypeConverters(MemoFormatConverter::class)
 @Database(
     entities = [Memo::class, Category::class, ChatSession::class, ChatMessage::class, YoutubeSummary::class, AiUsage::class, Tag::class, MemoTag::class],
-    version = 12,
+    version = 13,
     exportSchema = true
 )
 abstract class MemoDatabase : RoomDatabase() {
@@ -236,7 +242,7 @@ abstract class MemoDatabase : RoomDatabase() {
                     MemoDatabase::class.java,
                     "memo_database"
                 )
-                    .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12)
+                    .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13)
                     .addCallback(PREPOPULATE_CALLBACK)
                     .build()
                 INSTANCE = instance

--- a/datasource/local/memo/impl/src/main/java/me/pecos/memozy/data/datasource/local/di/DatabaseModule.kt
+++ b/datasource/local/memo/impl/src/main/java/me/pecos/memozy/data/datasource/local/di/DatabaseModule.kt
@@ -19,6 +19,9 @@ import me.pecos.memozy.data.datasource.local.MIGRATION_7_8
 import me.pecos.memozy.data.datasource.local.MIGRATION_8_9
 import me.pecos.memozy.data.datasource.local.MIGRATION_9_10
 import me.pecos.memozy.data.datasource.local.MIGRATION_10_11
+
+import me.pecos.memozy.data.datasource.local.MIGRATION_11_12
+import me.pecos.memozy.data.datasource.local.MIGRATION_12_13
 import me.pecos.memozy.data.datasource.local.AiUsageDao
 import me.pecos.memozy.data.datasource.local.MemoDao
 import me.pecos.memozy.data.datasource.local.MemoDatabase
@@ -40,7 +43,7 @@ object DatabaseModule {
             MemoDatabase::class.java,
             "memo_database"
         )
-            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7)
+            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13)
             .addCallback(object : RoomDatabase.Callback() {
                 override fun onCreate(db: SupportSQLiteDatabase) {
                     super.onCreate(db)

--- a/feature/core/resource/src/main/java/me/pecos/memozy/presentation/screen/home/model/MemoUiState.kt
+++ b/feature/core/resource/src/main/java/me/pecos/memozy/presentation/screen/home/model/MemoUiState.kt
@@ -12,6 +12,7 @@ data class MemoUiState(
     val audioPath: String? = null,
     val styles: String? = null,
     val youtubeUrl: String? = null,
+    val deletedAt: Long? = null,
     val tags: List<TagUiState> = emptyList()
 )
 

--- a/feature/core/resource/src/main/res/values-en/strings.xml
+++ b/feature/core/resource/src/main/res/values-en/strings.xml
@@ -76,4 +76,16 @@
     <string name="donation_error_title">Payment Error</string>
     <string name="donation_error_message">Something went wrong during payment.\nPlease try again.</string>
     <string name="donation_loading">Connecting…</string>
+
+    <!-- Trash -->
+    <string name="trash_title">Trash</string>
+    <string name="trash_empty">Trash is empty</string>
+    <string name="trash_empty_action">Empty</string>
+    <string name="trash_empty_confirm_title">Empty Trash</string>
+    <string name="trash_empty_confirm_message">All memos will be permanently deleted.\nThis action cannot be undone.</string>
+    <string name="trash_restore">Restore</string>
+    <string name="trash_permanent_delete_title">Delete Permanently</string>
+    <string name="trash_permanent_delete_action">Delete Permanently</string>
+    <string name="trash_permanent_delete_message">This memo will be permanently deleted.\nIt cannot be restored.</string>
+    <string name="trash_auto_delete_hint">Deleted memos are permanently removed after 30 days</string>
 </resources>

--- a/feature/core/resource/src/main/res/values-ja/strings.xml
+++ b/feature/core/resource/src/main/res/values-ja/strings.xml
@@ -76,4 +76,16 @@
     <string name="donation_error_title">決済エラー</string>
     <string name="donation_error_message">決済処理中に問題が発生しました。\nもう一度お試しください。</string>
     <string name="donation_loading">接続中…</string>
+
+    <!-- Trash -->
+    <string name="trash_title">ゴミ箱</string>
+    <string name="trash_empty">ゴミ箱は空です</string>
+    <string name="trash_empty_action">空にする</string>
+    <string name="trash_empty_confirm_title">ゴミ箱を空にする</string>
+    <string name="trash_empty_confirm_message">すべてのメモが完全に削除されます。\nこの操作は元に戻せません。</string>
+    <string name="trash_restore">復元</string>
+    <string name="trash_permanent_delete_title">完全に削除</string>
+    <string name="trash_permanent_delete_action">完全に削除</string>
+    <string name="trash_permanent_delete_message">このメモを完全に削除します。\n復元できません。</string>
+    <string name="trash_auto_delete_hint">削除されたメモは30日後に自動的に完全削除されます</string>
 </resources>

--- a/feature/core/resource/src/main/res/values/strings.xml
+++ b/feature/core/resource/src/main/res/values/strings.xml
@@ -75,4 +75,16 @@
     <string name="donation_error_title">결제 오류</string>
     <string name="donation_error_message">결제 처리 중 문제가 발생했습니다.\n다시 시도해 주세요.</string>
     <string name="donation_loading">연결 중…</string>
+
+    <!-- Trash -->
+    <string name="trash_title">휴지통</string>
+    <string name="trash_empty">휴지통이 비어 있어요</string>
+    <string name="trash_empty_action">비우기</string>
+    <string name="trash_empty_confirm_title">휴지통 비우기</string>
+    <string name="trash_empty_confirm_message">모든 메모가 영구 삭제됩니다.\n이 작업은 되돌릴 수 없습니다.</string>
+    <string name="trash_restore">복원</string>
+    <string name="trash_permanent_delete_title">영구 삭제</string>
+    <string name="trash_permanent_delete_action">영구 삭제</string>
+    <string name="trash_permanent_delete_message">이 메모를 영구적으로 삭제합니다.\n복원할 수 없습니다.</string>
+    <string name="trash_auto_delete_hint">삭제된 메모는 30일 후 자동으로 영구 삭제됩니다</string>
 </resources>

--- a/feature/home/api/src/main/java/me/pecos/memozy/feature/home/api/HomeNavigation.kt
+++ b/feature/home/api/src/main/java/me/pecos/memozy/feature/home/api/HomeNavigation.kt
@@ -8,6 +8,7 @@ import androidx.navigation.NavGraphBuilder
 object HomeRoute {
     const val MAIN = "main"
     const val SETTINGS = "settings"
+    const val TRASH = "trash"
 }
 
 interface HomeNavigation {

--- a/feature/home/impl/build.gradle.kts
+++ b/feature/home/impl/build.gradle.kts
@@ -23,4 +23,5 @@ dependencies {
     implementation(libs.montage.android)
     implementation(libs.billing.ktx)
     implementation(libs.kotlinx.coroutines.android)
+    implementation(libs.androidx.compose.material.icons.extended)
 }

--- a/feature/home/impl/src/main/java/me/pecos/memozy/MainActivity.kt
+++ b/feature/home/impl/src/main/java/me/pecos/memozy/MainActivity.kt
@@ -213,7 +213,15 @@ class MainActivity : AppCompatActivity() {
                                     SettingsScreen(
                                         onBack = { navController.popBackStack() },
                                         onDonation = { navController.navigate("donation") },
+                                        onTrash = { navController.navigate(HomeRoute.TRASH) },
                                         settingsViewModel = settingsViewModel
+                                    )
+                                }
+                                composable(HomeRoute.TRASH) {
+                                    val trashViewModel: me.pecos.memozy.presentation.screen.trash.TrashViewModel = viewModel()
+                                    me.pecos.memozy.presentation.screen.trash.TrashScreen(
+                                        viewModel = trashViewModel,
+                                        onBack = { navController.popBackStack() }
                                     )
                                 }
                                 composable("donation") {

--- a/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/home/MainViewModel.kt
+++ b/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/home/MainViewModel.kt
@@ -121,7 +121,7 @@ class MainViewModel @Inject constructor(
 
     fun deleteMemo(id: Int) {
         viewModelScope.launch {
-            repository.deleteMemo(id)
+            repository.softDeleteMemo(id)
         }
     }
 
@@ -164,7 +164,8 @@ fun MemoUiState.toMemo(): Memo = Memo(
     isPinned = this.isPinned,
     audioPath = this.audioPath,
     styles = this.styles,
-    youtubeUrl = this.youtubeUrl
+    youtubeUrl = this.youtubeUrl,
+    deletedAt = this.deletedAt
 )
 
 fun Memo.toUiState(): MemoUiState = MemoUiState(
@@ -181,5 +182,6 @@ fun Memo.toUiState(): MemoUiState = MemoUiState(
     isPinned = this.isPinned,
     audioPath = this.audioPath,
     styles = this.styles,
-    youtubeUrl = this.youtubeUrl
+    youtubeUrl = this.youtubeUrl,
+    deletedAt = this.deletedAt
 )

--- a/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/settings/SettingsScreen.kt
+++ b/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/settings/SettingsScreen.kt
@@ -46,6 +46,7 @@ import me.pecos.memozy.presentation.theme.LocalAppColors
 fun SettingsScreen(
     onBack: () -> Unit = {},
     onDonation: () -> Unit = {},
+    onTrash: () -> Unit = {},
     settingsViewModel: SettingsViewModel = viewModel()
 ) {
     var showClearDialog by remember { mutableStateOf(false) }
@@ -280,6 +281,18 @@ fun SettingsScreen(
                         variant = ButtonVariant.OUTLINED
                     ).copy(contentColor = colors.textTitle),
                     onClick = { showLicenseDialog = true }
+                )
+
+                Spacer(modifier = Modifier.height(12.dp))
+
+                WantedButton(
+                    text = stringResource(R.string.trash_title),
+                    modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+                    buttonDefault = WantedButtonDefaults.getDefault(
+                        type = ButtonType.ASSISTIVE,
+                        variant = ButtonVariant.OUTLINED
+                    ).copy(contentColor = colors.textTitle),
+                    onClick = { onTrash() }
                 )
 
                 if (isDonationEnabled) {

--- a/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/trash/TrashScreen.kt
+++ b/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/trash/TrashScreen.kt
@@ -1,0 +1,275 @@
+package me.pecos.memozy.presentation.screen.trash
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.DeleteForever
+import androidx.compose.material.icons.filled.RestoreFromTrash
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import me.pecos.memozy.feature.core.resource.R
+import me.pecos.memozy.presentation.components.AppPopup
+import me.pecos.memozy.presentation.components.PopupActionArea
+import me.pecos.memozy.presentation.components.PopupNavigation
+import me.pecos.memozy.presentation.components.PopupSize
+import me.pecos.memozy.presentation.screen.home.model.MemoUiState
+import me.pecos.memozy.presentation.theme.LocalAppColors
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.concurrent.TimeUnit
+
+@Composable
+fun TrashScreen(
+    viewModel: TrashViewModel,
+    onBack: () -> Unit
+) {
+    val deletedMemos by viewModel.deletedMemos.collectAsState()
+    val colors = LocalAppColors.current
+    var showEmptyDialog by remember { mutableStateOf(false) }
+
+    if (showEmptyDialog) {
+        AppPopup(
+            onDismissRequest = { showEmptyDialog = false },
+            title = stringResource(R.string.trash_empty_confirm_title),
+            navigation = PopupNavigation.EMPHASIZED,
+            size = PopupSize.MEDIUM,
+            actionArea = PopupActionArea.NEUTRAL,
+            primaryButtonText = stringResource(R.string.trash_empty_action),
+            isPrimaryDestructive = true,
+            onPrimaryClick = {
+                viewModel.emptyTrash()
+                showEmptyDialog = false
+            },
+            secondaryButtonText = stringResource(R.string.cancel),
+            onSecondaryClick = { showEmptyDialog = false }
+        ) {
+            Text(
+                stringResource(R.string.trash_empty_confirm_message),
+                color = colors.textBody
+            )
+        }
+    }
+
+    Scaffold(containerColor = colors.screenBackground) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .padding(horizontal = 16.dp, vertical = 24.dp)
+        ) {
+            // Header
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                IconButton(onClick = onBack) {
+                    Icon(
+                        Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = null,
+                        tint = colors.topbarTitle
+                    )
+                }
+                Text(
+                    text = stringResource(R.string.trash_title),
+                    fontSize = 22.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = colors.topbarTitle,
+                    modifier = Modifier.weight(1f)
+                )
+                if (deletedMemos.isNotEmpty()) {
+                    TextButton(onClick = { showEmptyDialog = true }) {
+                        Text(
+                            stringResource(R.string.trash_empty_action),
+                            color = Color(0xFFE24B4A),
+                            fontSize = 14.sp
+                        )
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            Text(
+                text = stringResource(R.string.trash_auto_delete_hint),
+                fontSize = 12.sp,
+                color = colors.textSecondary,
+                modifier = Modifier.padding(horizontal = 16.dp)
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            if (deletedMemos.isEmpty()) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .weight(1f),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text = stringResource(R.string.trash_empty),
+                        color = colors.textSecondary,
+                        fontSize = 14.sp
+                    )
+                }
+            } else {
+                LazyColumn(
+                    modifier = Modifier.weight(1f),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    items(deletedMemos, key = { it.id }) { memo ->
+                        TrashMemoItem(
+                            memo = memo,
+                            onRestore = { viewModel.restoreMemo(memo.id) },
+                            onDelete = { viewModel.permanentlyDeleteMemo(memo.id) }
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun TrashMemoItem(
+    memo: MemoUiState,
+    onRestore: () -> Unit,
+    onDelete: () -> Unit
+) {
+    val colors = LocalAppColors.current
+    var showDeleteDialog by remember { mutableStateOf(false) }
+
+    if (showDeleteDialog) {
+        AppPopup(
+            onDismissRequest = { showDeleteDialog = false },
+            title = stringResource(R.string.trash_permanent_delete_title),
+            navigation = PopupNavigation.EMPHASIZED,
+            size = PopupSize.MEDIUM,
+            actionArea = PopupActionArea.NEUTRAL,
+            primaryButtonText = stringResource(R.string.trash_permanent_delete_action),
+            isPrimaryDestructive = true,
+            onPrimaryClick = {
+                onDelete()
+                showDeleteDialog = false
+            },
+            secondaryButtonText = stringResource(R.string.cancel),
+            onSecondaryClick = { showDeleteDialog = false }
+        ) {
+            Text(
+                stringResource(R.string.trash_permanent_delete_message),
+                color = colors.textBody
+            )
+        }
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .background(colors.cardBackground)
+            .padding(16.dp)
+    ) {
+        Text(
+            text = memo.name.ifBlank { stringResource(R.string.memo_title_placeholder) },
+            fontSize = 16.sp,
+            fontWeight = FontWeight.Medium,
+            color = colors.textTitle,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
+
+        if (memo.content.isNotBlank()) {
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = memo.content.take(100),
+                fontSize = 13.sp,
+                color = colors.textBody,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = formatDeletedTime(memo.deletedAt),
+                fontSize = 11.sp,
+                color = colors.textSecondary
+            )
+
+            Row {
+                IconButton(
+                    onClick = onRestore,
+                    modifier = Modifier.size(36.dp)
+                ) {
+                    Icon(
+                        Icons.Default.RestoreFromTrash,
+                        contentDescription = stringResource(R.string.trash_restore),
+                        tint = Color(0xFF4A9EE8),
+                        modifier = Modifier.size(20.dp)
+                    )
+                }
+                Spacer(modifier = Modifier.width(4.dp))
+                IconButton(
+                    onClick = { showDeleteDialog = true },
+                    modifier = Modifier.size(36.dp)
+                ) {
+                    Icon(
+                        Icons.Default.DeleteForever,
+                        contentDescription = stringResource(R.string.trash_permanent_delete_action),
+                        tint = Color(0xFFE24B4A),
+                        modifier = Modifier.size(20.dp)
+                    )
+                }
+            }
+        }
+    }
+}
+
+private fun formatDeletedTime(deletedAt: Long?): String {
+    if (deletedAt == null) return ""
+    val now = System.currentTimeMillis()
+    val daysLeft = 30 - TimeUnit.MILLISECONDS.toDays(now - deletedAt)
+    return if (daysLeft > 0) {
+        "${daysLeft}일 후 영구 삭제"
+    } else {
+        "곧 영구 삭제"
+    }
+}

--- a/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/trash/TrashViewModel.kt
+++ b/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/trash/TrashViewModel.kt
@@ -1,0 +1,50 @@
+package me.pecos.memozy.presentation.screen.trash
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import me.pecos.memozy.data.repository.MemoRepository
+import me.pecos.memozy.presentation.screen.home.model.MemoUiState
+import me.pecos.memozy.presentation.screen.home.toUiState
+import javax.inject.Inject
+
+@HiltViewModel
+class TrashViewModel @Inject constructor(
+    private val repository: MemoRepository
+) : ViewModel() {
+
+    init {
+        // 30일 지난 메모 자동 영구 삭제
+        viewModelScope.launch {
+            val threshold = System.currentTimeMillis() - 30L * 24 * 60 * 60 * 1000
+            repository.purgeOldTrash(threshold)
+        }
+    }
+
+    val deletedMemos: StateFlow<List<MemoUiState>> = repository.getDeletedMemos()
+        .map { list -> list.map { it.toUiState() } }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
+    fun restoreMemo(id: Int) {
+        viewModelScope.launch {
+            repository.restoreMemo(id)
+        }
+    }
+
+    fun permanentlyDeleteMemo(id: Int) {
+        viewModelScope.launch {
+            repository.deleteMemo(id)
+        }
+    }
+
+    fun emptyTrash() {
+        viewModelScope.launch {
+            repository.emptyTrash()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Memo 엔티티에 `deletedAt` 필드 추가 + DB 마이그레이션 (v12 → v13)
- 삭제 시 soft delete 전환 — 복원 가능한 삭제
- 설정 → 휴지통 화면: 복원 / 영구삭제 / 비우기
- 30일 경과 메모 자동 영구 삭제
- DatabaseModule 누락 마이그레이션(7~12) 일괄 등록 수정

## Test plan
- [ ] 메모 삭제 → 홈 리스트에서 사라지고 휴지통에 표시
- [ ] 휴지통 → 복원 → 홈 리스트에 다시 나타남
- [ ] 휴지통 → 영구 삭제 → 완전히 제거됨
- [ ] 휴지통 비우기 → 전체 영구 삭제
- [ ] 30일 경과 메모 자동 영구 삭제 확인
- [ ] 라이트/다크 모드 대응 확인
- [ ] 기존 메모 데이터 마이그레이션 안전성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)