### PR TITLE
Add: #88 메모 내보내기 & 공유 기능

### DIFF
--- a/feature/core/resource/src/main/res/values-en/strings.xml
+++ b/feature/core/resource/src/main/res/values-en/strings.xml
@@ -77,6 +77,10 @@
     <string name="donation_error_message">Something went wrong during payment.\nPlease try again.</string>
     <string name="donation_loading">Connecting…</string>
 
+    <!-- Export -->
+    <string name="memo_share">Share as text</string>
+    <string name="memo_export_md">Export as Markdown</string>
+
     <!-- Trash -->
     <string name="trash_title">Trash</string>
     <string name="trash_empty">Trash is empty</string>

--- a/feature/core/resource/src/main/res/values-ja/strings.xml
+++ b/feature/core/resource/src/main/res/values-ja/strings.xml
@@ -77,6 +77,10 @@
     <string name="donation_error_message">決済処理中に問題が発生しました。\nもう一度お試しください。</string>
     <string name="donation_loading">接続中…</string>
 
+    <!-- Export -->
+    <string name="memo_share">テキストで共有</string>
+    <string name="memo_export_md">Markdownで書き出し</string>
+
     <!-- Trash -->
     <string name="trash_title">ゴミ箱</string>
     <string name="trash_empty">ゴミ箱は空です</string>

--- a/feature/core/resource/src/main/res/values/strings.xml
+++ b/feature/core/resource/src/main/res/values/strings.xml
@@ -77,6 +77,10 @@
     <string name="donation_loading">연결 중…</string>
 
     <!-- Trash -->
+    <!-- Export -->
+    <string name="memo_share">텍스트 공유</string>
+    <string name="memo_export_md">마크다운 내보내기</string>
+
     <string name="trash_title">휴지통</string>
     <string name="trash_empty">휴지통이 비어 있어요</string>
     <string name="trash_empty_action">비우기</string>

--- a/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/MemoScreen.kt
+++ b/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/MemoScreen.kt
@@ -341,6 +341,68 @@ fun MemoScreen(
                         }
                 )
                 Spacer(modifier = Modifier.weight(1f))
+
+                // 공유 버튼 (기존 메모만 표시)
+                if (!isNewMemo) {
+                    Icon(
+                        imageVector = Icons.Default.Share,
+                        contentDescription = stringResource(R.string.memo_share),
+                        tint = colors.textSecondary,
+                        modifier = Modifier
+                            .size(22.dp)
+                            .clickable {
+                                val shareText = buildString {
+                                    if (nameText.isNotBlank()) {
+                                        appendLine(nameText)
+                                        appendLine()
+                                    }
+                                    append(safeContent())
+                                }
+                                val shareIntent = Intent(Intent.ACTION_SEND).apply {
+                                    type = "text/plain"
+                                    putExtra(Intent.EXTRA_SUBJECT, nameText)
+                                    putExtra(Intent.EXTRA_TEXT, shareText)
+                                }
+                                context.startActivity(Intent.createChooser(shareIntent, null))
+                            }
+                    )
+                    Spacer(modifier = Modifier.width(16.dp))
+
+                    // 마크다운 내보내기
+                    Icon(
+                        imageVector = Icons.Default.Download,
+                        contentDescription = stringResource(R.string.memo_export_md),
+                        tint = colors.textSecondary,
+                        modifier = Modifier
+                            .size(22.dp)
+                            .clickable {
+                                val mdContent = buildString {
+                                    if (nameText.isNotBlank()) {
+                                        appendLine("# $nameText")
+                                        appendLine()
+                                    }
+                                    append(safeContent())
+                                }
+                                val fileName = (nameText.ifBlank { "memo" })
+                                    .replace(Regex("[^a-zA-Z0-9가-힣ぁ-ヶ一-龠\\s_-]"), "")
+                                    .take(50)
+                                    .trim()
+                                val file = java.io.File(context.cacheDir, "${fileName}.md")
+                                file.writeText(mdContent)
+                                val uri = androidx.core.content.FileProvider.getUriForFile(
+                                    context, "${context.packageName}.fileprovider", file
+                                )
+                                val exportIntent = Intent(Intent.ACTION_SEND).apply {
+                                    type = "text/markdown"
+                                    putExtra(Intent.EXTRA_STREAM, uri)
+                                    addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                                }
+                                context.startActivity(Intent.createChooser(exportIntent, null))
+                            }
+                    )
+                    Spacer(modifier = Modifier.width(16.dp))
+                }
+
                 // 완료 버튼 (새 메모 + 기존 메모 모두 표시)
                 Text(
                     text = "완료",


### PR DESCRIPTION
## Summary
- 메모 상세 화면 상단바에 공유(Share) + 내보내기(Download) 아이콘 추가
- 텍스트 공유: 제목 + 내용을 Intent.ACTION_SEND로 공유
- 마크다운 내보내기: .md 파일 생성 → FileProvider로 외부 앱에 공유
- 기존 메모에서만 표시 (새 메모 작성 중에는 숨김)

## Test plan
- [ ] 기존 메모 → 상단 공유 아이콘 탭 → 공유 시트에서 텍스트 공유 확인
- [ ] 기존 메모 → 상단 다운로드 아이콘 탭 → .md 파일 공유 시트 확인
- [ ] 새 메모 작성 시 → 공유/내보내기 아이콘 숨김 확인
- [ ] 제목 없는 메모 → 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)