### PR TITLE
Add: #88 백업 & 복원 기능

### DIFF
--- a/datasource/local/memo/api/src/main/java/me/pecos/memozy/data/datasource/local/MemoDao.kt
+++ b/datasource/local/memo/api/src/main/java/me/pecos/memozy/data/datasource/local/MemoDao.kt
@@ -49,4 +49,12 @@ interface MemoDao {
 
     @Query("SELECT COUNT(*) FROM memo WHERE deletedAt IS NOT NULL")
     fun getTrashCount(): Flow<Int>
+
+    // ── Backup & Restore ──
+
+    @Query("SELECT * FROM memo ORDER BY id ASC")
+    suspend fun getAllMemosForBackup(): List<Memo>
+
+    @Insert
+    suspend fun insertMemos(memos: List<Memo>)
 }

--- a/datasource/local/memo/api/src/main/java/me/pecos/memozy/data/datasource/local/TagDao.kt
+++ b/datasource/local/memo/api/src/main/java/me/pecos/memozy/data/datasource/local/TagDao.kt
@@ -49,4 +49,21 @@ interface TagDao {
     // 태그에 연결된 메모 ID 조회
     @Query("SELECT memoId FROM memo_tag WHERE tagId = :tagId")
     fun getMemoIdsForTag(tagId: Int): Flow<List<Int>>
+
+    // ── Backup & Restore ──
+
+    @Query("SELECT * FROM memo_tag")
+    suspend fun getAllMemoTagsOnce(): List<MemoTag>
+
+    @Insert
+    suspend fun insertTags(tags: List<Tag>)
+
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun insertMemoTags(memoTags: List<MemoTag>)
+
+    @Query("DELETE FROM memo_tag")
+    suspend fun deleteAllMemoTags()
+
+    @Query("DELETE FROM tag")
+    suspend fun deleteAllTags()
 }

--- a/feature/core/resource/src/main/res/values-en/strings.xml
+++ b/feature/core/resource/src/main/res/values-en/strings.xml
@@ -77,6 +77,14 @@
     <string name="donation_error_message">Something went wrong during payment.\nPlease try again.</string>
     <string name="donation_loading">Connecting…</string>
 
+    <!-- Backup -->
+    <string name="backup_export">Export Backup</string>
+    <string name="backup_restore">Restore Backup</string>
+    <string name="backup_restore_action">Restore</string>
+    <string name="backup_restore_confirm">All existing memos will be deleted and replaced with the backup.\nThis action cannot be undone.</string>
+    <string name="backup_success">%d memos processed</string>
+    <string name="backup_error">An error occurred during backup</string>
+
     <!-- Trash -->
     <string name="trash_title">Trash</string>
     <string name="trash_empty">Trash is empty</string>

--- a/feature/core/resource/src/main/res/values-ja/strings.xml
+++ b/feature/core/resource/src/main/res/values-ja/strings.xml
@@ -77,6 +77,14 @@
     <string name="donation_error_message">決済処理中に問題が発生しました。\nもう一度お試しください。</string>
     <string name="donation_loading">接続中…</string>
 
+    <!-- Backup -->
+    <string name="backup_export">バックアップを書き出す</string>
+    <string name="backup_restore">バックアップを復元</string>
+    <string name="backup_restore_action">復元</string>
+    <string name="backup_restore_confirm">既存のメモをすべて削除し、バックアップファイルから復元します。\nこの操作は元に戻せません。</string>
+    <string name="backup_success">%d件のメモを処理しました</string>
+    <string name="backup_error">バックアップ処理中にエラーが発生しました</string>
+
     <!-- Trash -->
     <string name="trash_title">ゴミ箱</string>
     <string name="trash_empty">ゴミ箱は空です</string>

--- a/feature/core/resource/src/main/res/values/strings.xml
+++ b/feature/core/resource/src/main/res/values/strings.xml
@@ -77,6 +77,14 @@
     <string name="donation_loading">연결 중…</string>
 
     <!-- Trash -->
+    <!-- Backup -->
+    <string name="backup_export">백업 내보내기</string>
+    <string name="backup_restore">백업 복원</string>
+    <string name="backup_restore_action">복원</string>
+    <string name="backup_restore_confirm">기존 메모를 모두 삭제하고 백업 파일로 복원합니다.\n이 작업은 되돌릴 수 없습니다.</string>
+    <string name="backup_success">%d개 메모가 처리되었습니다</string>
+    <string name="backup_error">백업 처리 중 오류가 발생했습니다</string>
+
     <string name="trash_title">휴지통</string>
     <string name="trash_empty">휴지통이 비어 있어요</string>
     <string name="trash_empty_action">비우기</string>

--- a/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/settings/SettingsScreen.kt
+++ b/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/settings/SettingsScreen.kt
@@ -1,5 +1,8 @@
 package me.pecos.memozy.presentation.screen.settings
 
+import android.widget.Toast
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.rememberScrollState
@@ -16,6 +19,7 @@ import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -53,13 +57,39 @@ fun SettingsScreen(
     var showLicenseDialog by remember { mutableStateOf(false) }
     var showLanguageDialog by remember { mutableStateOf(false) }
     var showThemeDialog by remember { mutableStateOf(false) }
+    var showRestoreDialog by remember { mutableStateOf(false) }
 
     val selectedLanguage by settingsViewModel.selectedLanguage.collectAsState()
     val selectedTheme by settingsViewModel.selectedTheme.collectAsState()
+    val backupResult by settingsViewModel.backupResult.collectAsState()
     val isDonationEnabled by settingsViewModel.isDonationEnabled.collectAsState()
     val colors = LocalAppColors.current
     val context = LocalContext.current
     val activity = LocalActivity.current
+
+    // SAF launchers
+    val exportLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.CreateDocument("application/json")
+    ) { uri -> if (uri != null) settingsViewModel.exportBackup(uri) }
+
+    val importLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.OpenDocument()
+    ) { uri -> if (uri != null) settingsViewModel.importBackup(uri) }
+
+    // 백업 결과 토스트
+    LaunchedEffect(backupResult) {
+        when (val result = backupResult) {
+            is BackupResult.Success -> {
+                Toast.makeText(context, context.getString(R.string.backup_success, result.message.toIntOrNull() ?: 0), Toast.LENGTH_SHORT).show()
+                settingsViewModel.clearBackupResult()
+            }
+            is BackupResult.Error -> {
+                Toast.makeText(context, context.getString(R.string.backup_error), Toast.LENGTH_SHORT).show()
+                settingsViewModel.clearBackupResult()
+            }
+            else -> {}
+        }
+    }
 
     val versionName = remember {
         context.packageManager.getPackageInfo(context.packageName, 0).versionName
@@ -149,6 +179,26 @@ fun SettingsScreen(
                     }
                 }
             }
+        }
+    }
+
+    if (showRestoreDialog) {
+        AppPopup(
+            onDismissRequest = { showRestoreDialog = false },
+            title = stringResource(R.string.backup_restore),
+            navigation = PopupNavigation.EMPHASIZED,
+            size = PopupSize.MEDIUM,
+            actionArea = PopupActionArea.NEUTRAL,
+            primaryButtonText = stringResource(R.string.backup_restore_action),
+            isPrimaryDestructive = true,
+            onPrimaryClick = {
+                showRestoreDialog = false
+                importLauncher.launch(arrayOf("application/json"))
+            },
+            secondaryButtonText = stringResource(R.string.cancel),
+            onSecondaryClick = { showRestoreDialog = false }
+        ) {
+            Text(stringResource(R.string.backup_restore_confirm), color = colors.textBody)
         }
     }
 
@@ -293,6 +343,33 @@ fun SettingsScreen(
                         variant = ButtonVariant.OUTLINED
                     ).copy(contentColor = colors.textTitle),
                     onClick = { onTrash() }
+                )
+
+                Spacer(modifier = Modifier.height(12.dp))
+
+                WantedButton(
+                    text = stringResource(R.string.backup_export),
+                    modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+                    buttonDefault = WantedButtonDefaults.getDefault(
+                        type = ButtonType.ASSISTIVE,
+                        variant = ButtonVariant.OUTLINED
+                    ).copy(contentColor = colors.textTitle),
+                    onClick = {
+                        val fileName = "memozy_backup_${java.text.SimpleDateFormat("yyyyMMdd_HHmm", java.util.Locale.getDefault()).format(java.util.Date())}.json"
+                        exportLauncher.launch(fileName)
+                    }
+                )
+
+                Spacer(modifier = Modifier.height(12.dp))
+
+                WantedButton(
+                    text = stringResource(R.string.backup_restore),
+                    modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+                    buttonDefault = WantedButtonDefaults.getDefault(
+                        type = ButtonType.ASSISTIVE,
+                        variant = ButtonVariant.OUTLINED
+                    ).copy(contentColor = colors.textTitle),
+                    onClick = { showRestoreDialog = true }
                 )
 
                 if (isDonationEnabled) {

--- a/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/settings/SettingsViewModel.kt
+++ b/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/settings/SettingsViewModel.kt
@@ -1,14 +1,25 @@
 package me.pecos.memozy.presentation.screen.settings
 
 import android.content.Context
+import android.net.Uri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import me.pecos.memozy.data.datasource.local.MemoDao
+import me.pecos.memozy.data.datasource.local.TagDao
+import me.pecos.memozy.data.datasource.local.entity.Memo
+import me.pecos.memozy.data.datasource.local.entity.MemoTag
+import me.pecos.memozy.data.datasource.local.entity.Tag
 import me.pecos.memozy.data.repository.MemoRepository
+import me.pecos.memozy.data.repository.model.MemoFormat
+import org.json.JSONArray
+import org.json.JSONObject
 import javax.inject.Inject
 
 data class Language(val name: String, val code: String)
@@ -19,10 +30,19 @@ val LANGUAGES = listOf(
     Language("日本語", "ja"),
 )
 
+sealed class BackupResult {
+    data object Idle : BackupResult()
+    data object Loading : BackupResult()
+    data class Success(val message: String) : BackupResult()
+    data class Error(val message: String) : BackupResult()
+}
+
 @HiltViewModel
 class SettingsViewModel @Inject constructor(
     @ApplicationContext private val context: Context,
-    private val repository: MemoRepository
+    private val repository: MemoRepository,
+    private val memoDao: MemoDao,
+    private val tagDao: TagDao
 ) : ViewModel() {
 
     private val prefs = context.getSharedPreferences("settings", Context.MODE_PRIVATE)
@@ -41,9 +61,12 @@ class SettingsViewModel @Inject constructor(
 
     val isDonationEnabled: StateFlow<Boolean> = MutableStateFlow(false)
 
+    private val _backupResult = MutableStateFlow<BackupResult>(BackupResult.Idle)
+    val backupResult: StateFlow<BackupResult> = _backupResult
+
     fun selectLanguage(language: Language) {
         _selectedLanguage.value = language
-        prefs.edit().putString("language_code", language.code).commit() // 동기 저장 - recreate 전 반드시 완료
+        prefs.edit().putString("language_code", language.code).commit()
     }
 
     fun selectTheme(mode: ThemeMode) {
@@ -55,5 +78,151 @@ class SettingsViewModel @Inject constructor(
         viewModelScope.launch {
             repository.clearAllMemos()
         }
+    }
+
+    fun clearBackupResult() {
+        _backupResult.value = BackupResult.Idle
+    }
+
+    // ── Backup (Export) ──
+
+    fun exportBackup(uri: Uri) {
+        viewModelScope.launch {
+            _backupResult.value = BackupResult.Loading
+            try {
+                val json = withContext(Dispatchers.IO) { buildBackupJson() }
+                withContext(Dispatchers.IO) {
+                    context.contentResolver.openOutputStream(uri)?.use { out ->
+                        out.write(json.toString(2).toByteArray(Charsets.UTF_8))
+                    } ?: throw Exception("Cannot open file")
+                }
+                val memoCount = json.getJSONArray("memos").length()
+                _backupResult.value = BackupResult.Success("$memoCount")
+            } catch (e: Exception) {
+                _backupResult.value = BackupResult.Error(e.message ?: "Unknown error")
+            }
+        }
+    }
+
+    private suspend fun buildBackupJson(): JSONObject {
+        val memos = memoDao.getAllMemosForBackup()
+        val tags = tagDao.getAllTagsOnce()
+        val memoTags = tagDao.getAllMemoTagsOnce()
+
+        return JSONObject().apply {
+            put("version", 1)
+            put("appVersion", "memozy")
+            put("exportedAt", System.currentTimeMillis())
+            put("memos", JSONArray().apply {
+                memos.forEach { m ->
+                    put(JSONObject().apply {
+                        put("id", m.id)
+                        put("name", m.name)
+                        put("categoryId", m.categoryId)
+                        put("content", m.content)
+                        put("createdAt", m.createdAt)
+                        put("updatedAt", m.updatedAt)
+                        put("format", m.format.name)
+                        put("isPinned", m.isPinned)
+                        put("audioPath", m.audioPath ?: JSONObject.NULL)
+                        put("styles", m.styles ?: JSONObject.NULL)
+                        put("youtubeUrl", m.youtubeUrl ?: JSONObject.NULL)
+                        put("deletedAt", m.deletedAt ?: JSONObject.NULL)
+                    })
+                }
+            })
+            put("tags", JSONArray().apply {
+                tags.forEach { t ->
+                    put(JSONObject().apply {
+                        put("id", t.id)
+                        put("name", t.name)
+                        put("emoji", t.emoji)
+                        put("createdAt", t.createdAt)
+                    })
+                }
+            })
+            put("memoTags", JSONArray().apply {
+                memoTags.forEach { mt ->
+                    put(JSONObject().apply {
+                        put("memoId", mt.memoId)
+                        put("tagId", mt.tagId)
+                    })
+                }
+            })
+        }
+    }
+
+    // ── Restore (Import) ──
+
+    fun importBackup(uri: Uri) {
+        viewModelScope.launch {
+            _backupResult.value = BackupResult.Loading
+            try {
+                val jsonStr = withContext(Dispatchers.IO) {
+                    context.contentResolver.openInputStream(uri)?.use { input ->
+                        input.bufferedReader().readText()
+                    } ?: throw Exception("Cannot open file")
+                }
+                val json = JSONObject(jsonStr)
+                val version = json.optInt("version", 0)
+                if (version < 1) throw Exception("Invalid backup file")
+
+                withContext(Dispatchers.IO) { restoreFromJson(json) }
+
+                val memoCount = json.getJSONArray("memos").length()
+                _backupResult.value = BackupResult.Success("$memoCount")
+            } catch (e: Exception) {
+                _backupResult.value = BackupResult.Error(e.message ?: "Unknown error")
+            }
+        }
+    }
+
+    private suspend fun restoreFromJson(json: JSONObject) {
+        // 1. 기존 데이터 삭제 (순서 중요: junction → child)
+        tagDao.deleteAllMemoTags()
+        memoDao.clearAllMemos()
+        tagDao.deleteAllTags()
+
+        // 2. 태그 복원
+        val tagsArray = json.getJSONArray("tags")
+        val tags = (0 until tagsArray.length()).map { i ->
+            val t = tagsArray.getJSONObject(i)
+            Tag(
+                id = t.getInt("id"),
+                name = t.getString("name"),
+                emoji = t.optString("emoji", "🏷️"),
+                createdAt = t.optLong("createdAt", System.currentTimeMillis())
+            )
+        }
+        if (tags.isNotEmpty()) tagDao.insertTags(tags)
+
+        // 3. 메모 복원
+        val memosArray = json.getJSONArray("memos")
+        val memos = (0 until memosArray.length()).map { i ->
+            val m = memosArray.getJSONObject(i)
+            Memo(
+                id = m.getInt("id"),
+                name = m.getString("name"),
+                categoryId = m.optInt("categoryId", 1),
+                content = m.getString("content"),
+                createdAt = m.optLong("createdAt", System.currentTimeMillis()),
+                updatedAt = m.optLong("updatedAt", System.currentTimeMillis()),
+                format = try { MemoFormat.valueOf(m.optString("format", "PLAIN")) } catch (_: Exception) { MemoFormat.PLAIN },
+                isPinned = m.optBoolean("isPinned", false),
+                audioPath = m.optString("audioPath").takeIf { it != "null" && it.isNotEmpty() },
+                styles = m.optString("styles").takeIf { it != "null" && it.isNotEmpty() },
+                youtubeUrl = m.optString("youtubeUrl").takeIf { it != "null" && it.isNotEmpty() },
+                deletedAt = if (m.isNull("deletedAt")) null else m.optLong("deletedAt")
+            )
+        }
+        if (memos.isNotEmpty()) memoDao.insertMemos(memos)
+
+        // 4. 메모-태그 관계 복원
+        val memoTagsArray = json.getJSONArray("memoTags")
+        val memoTags = (0 until memoTagsArray.length()).map { i ->
+            val mt = memoTagsArray.getJSONObject(i)
+            MemoTag(memoId = mt.getInt("memoId"), tagId = mt.getInt("tagId"))
+        }
+        if (memoTags.isNotEmpty()) tagDao.insertMemoTags(memoTags)
     }
 }


### PR DESCRIPTION
## Summary
- 설정 화면에 백업 내보내기 / 복원 버튼 추가
- JSON 형식으로 메모 + 태그 + 메모-태그 관계 전체 백업
- SAF 파일 피커로 저장 위치 선택 (Google Drive 등 클라우드도 가능)
- 복원 시 기존 데이터 삭제 후 전체 교체 (확인 다이얼로그)

## Test plan
- [ ] 설정 → 백업 내보내기 → 파일 저장 확인
- [ ] 설정 → 백업 복원 → 확인 다이얼로그 → 파일 선택 → 복원 완료
- [ ] 복원 후 메모/태그/태그 관계 정상 확인
- [ ] 잘못된 JSON 파일 복원 시도 → 에러 토스트 확인
- [ ] 메모 0개 상태에서 백업 → 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)