### PR TITLE
Add: #88 리마인더 알림 기능

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,9 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
+    <uses-permission android:name="android.permission.USE_EXACT_ALARM" />
 
     <uses-permission
         android:name="com.google.android.gms.permission.AD_ID"
@@ -31,6 +34,10 @@
                 android:name="android.appwidget.provider"
                 android:resource="@xml/memo_widget_info" />
         </receiver>
+
+        <receiver
+            android:name=".reminder.ReminderReceiver"
+            android:exported="false" />
 
         <provider
             android:name="androidx.core.content.FileProvider"

--- a/app/src/main/java/me/pecos/memozy/reminder/ReminderReceiver.kt
+++ b/app/src/main/java/me/pecos/memozy/reminder/ReminderReceiver.kt
@@ -1,0 +1,64 @@
+package me.pecos.memozy.reminder
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import me.pecos.memozy.R
+
+class ReminderReceiver : BroadcastReceiver() {
+
+    override fun onReceive(context: Context, intent: Intent) {
+        val memoId = intent.getIntExtra("memo_id", -1)
+        val memoTitle = intent.getStringExtra("memo_title") ?: "Memozy"
+
+        if (memoId <= 0) return
+
+        createNotificationChannel(context)
+
+        // 탭 시 해당 메모 열기
+        val openIntent = Intent(context, Class.forName("me.pecos.memozy.MainActivity")).apply {
+            putExtra("widget_action", "open_memo")
+            putExtra("widget_memo_id", memoId)
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+        }
+        val pendingIntent = PendingIntent.getActivity(
+            context, memoId, openIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
+        val notification = NotificationCompat.Builder(context, CHANNEL_ID)
+            .setSmallIcon(R.mipmap.ic_launcher)
+            .setContentTitle(context.getString(R.string.reminder_notification_title))
+            .setContentText(memoTitle)
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .setAutoCancel(true)
+            .setContentIntent(pendingIntent)
+            .build()
+
+        val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        notificationManager.notify(memoId, notification)
+    }
+
+    private fun createNotificationChannel(context: Context) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(
+                CHANNEL_ID,
+                context.getString(R.string.reminder_channel_name),
+                NotificationManager.IMPORTANCE_HIGH
+            ).apply {
+                description = context.getString(R.string.reminder_channel_desc)
+            }
+            val manager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            manager.createNotificationChannel(channel)
+        }
+    }
+
+    companion object {
+        const val CHANNEL_ID = "memozy_reminder"
+    }
+}

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -82,4 +82,9 @@
     <string name="widget_description">Quickly view recent memos and create new ones</string>
     <string name="widget_empty">No memos yet</string>
     <string name="widget_untitled">Untitled</string>
+
+    <!-- Reminder -->
+    <string name="reminder_notification_title">Memo Reminder</string>
+    <string name="reminder_channel_name">Memo Reminders</string>
+    <string name="reminder_channel_desc">Memo reminder notifications</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -82,4 +82,9 @@
     <string name="widget_description">最近のメモを素早く確認して新しいメモを作成</string>
     <string name="widget_empty">メモがまだありません</string>
     <string name="widget_untitled">タイトルなし</string>
+
+    <!-- Reminder -->
+    <string name="reminder_notification_title">メモリマインダー</string>
+    <string name="reminder_channel_name">メモ通知</string>
+    <string name="reminder_channel_desc">メモリマインダー通知</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,4 +6,9 @@
     <string name="widget_description">최근 메모를 빠르게 확인하고 새 메모를 작성하세요</string>
     <string name="widget_empty">메모가 없어요</string>
     <string name="widget_untitled">제목 없음</string>
+
+    <!-- Reminder -->
+    <string name="reminder_notification_title">메모 리마인더</string>
+    <string name="reminder_channel_name">메모 알림</string>
+    <string name="reminder_channel_desc">메모 리마인더 알림</string>
 </resources>

--- a/data/repository/memo/api/src/main/java/me/pecos/memozy/data/repository/MemoRepository.kt
+++ b/data/repository/memo/api/src/main/java/me/pecos/memozy/data/repository/MemoRepository.kt
@@ -19,4 +19,5 @@ interface MemoRepository {
     suspend fun emptyTrash()
     suspend fun purgeOldTrash(threshold: Long)
     fun getTrashCount(): Flow<Int>
+    suspend fun setReminder(id: Int, reminderAt: Long?)
 }

--- a/data/repository/memo/impl/src/main/java/me/pecos/memozy/data/repository/MemoRepositoryImpl.kt
+++ b/data/repository/memo/impl/src/main/java/me/pecos/memozy/data/repository/MemoRepositoryImpl.kt
@@ -52,4 +52,8 @@ class MemoRepositoryImpl @Inject constructor(private val memoDao: MemoDao) : Mem
     }
 
     override fun getTrashCount(): Flow<Int> = memoDao.getTrashCount()
+
+    override suspend fun setReminder(id: Int, reminderAt: Long?) {
+        memoDao.setReminder(id, reminderAt)
+    }
 }

--- a/datasource/local/memo/api/src/main/java/me/pecos/memozy/data/datasource/local/MemoDao.kt
+++ b/datasource/local/memo/api/src/main/java/me/pecos/memozy/data/datasource/local/MemoDao.kt
@@ -50,6 +50,14 @@ interface MemoDao {
     @Query("SELECT COUNT(*) FROM memo WHERE deletedAt IS NOT NULL")
     fun getTrashCount(): Flow<Int>
 
+    // ── Backup & Restore ──
+
+    @Query("SELECT * FROM memo ORDER BY id ASC")
+    suspend fun getAllMemosForBackup(): List<Memo>
+
+    @Insert
+    suspend fun insertMemos(memos: List<Memo>)
+
     // ── Reminder ──
 
     @Query("UPDATE memo SET reminderAt = :reminderAt WHERE id = :id")

--- a/datasource/local/memo/api/src/main/java/me/pecos/memozy/data/datasource/local/MemoDao.kt
+++ b/datasource/local/memo/api/src/main/java/me/pecos/memozy/data/datasource/local/MemoDao.kt
@@ -49,4 +49,9 @@ interface MemoDao {
 
     @Query("SELECT COUNT(*) FROM memo WHERE deletedAt IS NOT NULL")
     fun getTrashCount(): Flow<Int>
+
+    // ── Reminder ──
+
+    @Query("UPDATE memo SET reminderAt = :reminderAt WHERE id = :id")
+    suspend fun setReminder(id: Int, reminderAt: Long?)
 }

--- a/datasource/local/memo/api/src/main/java/me/pecos/memozy/data/datasource/local/entity/Memo.kt
+++ b/datasource/local/memo/api/src/main/java/me/pecos/memozy/data/datasource/local/entity/Memo.kt
@@ -18,5 +18,6 @@ data class Memo(
     val audioPath: String? = null,
     val styles: String? = null, // JSON: [{start,end,bold,italic,strikethrough,color}]
     val youtubeUrl: String? = null,
-    val deletedAt: Long? = null
+    val deletedAt: Long? = null,
+    val reminderAt: Long? = null
 )

--- a/datasource/local/memo/impl/src/main/java/me/pecos/memozy/data/datasource/local/MemoDatabase.kt
+++ b/datasource/local/memo/impl/src/main/java/me/pecos/memozy/data/datasource/local/MemoDatabase.kt
@@ -209,6 +209,12 @@ val MIGRATION_12_13 = object : Migration(12, 13) {
     }
 }
 
+val MIGRATION_13_14 = object : Migration(13, 14) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        database.execSQL("ALTER TABLE memo ADD COLUMN reminderAt INTEGER DEFAULT NULL")
+    }
+}
+
 private val PREPOPULATE_CALLBACK = object : RoomDatabase.Callback() {
     override fun onCreate(db: SupportSQLiteDatabase) {
         super.onCreate(db)
@@ -219,7 +225,7 @@ private val PREPOPULATE_CALLBACK = object : RoomDatabase.Callback() {
 @TypeConverters(MemoFormatConverter::class)
 @Database(
     entities = [Memo::class, Category::class, ChatSession::class, ChatMessage::class, YoutubeSummary::class, AiUsage::class, Tag::class, MemoTag::class],
-    version = 13,
+    version = 14,
     exportSchema = true
 )
 abstract class MemoDatabase : RoomDatabase() {
@@ -242,7 +248,7 @@ abstract class MemoDatabase : RoomDatabase() {
                     MemoDatabase::class.java,
                     "memo_database"
                 )
-                    .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13)
+                    .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14)
                     .addCallback(PREPOPULATE_CALLBACK)
                     .build()
                 INSTANCE = instance

--- a/datasource/local/memo/impl/src/main/java/me/pecos/memozy/data/datasource/local/di/DatabaseModule.kt
+++ b/datasource/local/memo/impl/src/main/java/me/pecos/memozy/data/datasource/local/di/DatabaseModule.kt
@@ -22,6 +22,7 @@ import me.pecos.memozy.data.datasource.local.MIGRATION_10_11
 
 import me.pecos.memozy.data.datasource.local.MIGRATION_11_12
 import me.pecos.memozy.data.datasource.local.MIGRATION_12_13
+import me.pecos.memozy.data.datasource.local.MIGRATION_13_14
 import me.pecos.memozy.data.datasource.local.AiUsageDao
 import me.pecos.memozy.data.datasource.local.MemoDao
 import me.pecos.memozy.data.datasource.local.MemoDatabase
@@ -43,7 +44,7 @@ object DatabaseModule {
             MemoDatabase::class.java,
             "memo_database"
         )
-            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13)
+            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14)
             .addCallback(object : RoomDatabase.Callback() {
                 override fun onCreate(db: SupportSQLiteDatabase) {
                     super.onCreate(db)

--- a/feature/core/resource/src/main/java/me/pecos/memozy/presentation/reminder/ReminderScheduler.kt
+++ b/feature/core/resource/src/main/java/me/pecos/memozy/presentation/reminder/ReminderScheduler.kt
@@ -1,0 +1,47 @@
+package me.pecos.memozy.presentation.reminder
+
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+
+object ReminderScheduler {
+
+    private const val RECEIVER_CLASS = "me.pecos.memozy.reminder.ReminderReceiver"
+
+    fun schedule(context: Context, memoId: Int, memoTitle: String, triggerAtMillis: Long) {
+        val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+        val intent = Intent().apply {
+            setClassName(context, RECEIVER_CLASS)
+            putExtra("memo_id", memoId)
+            putExtra("memo_title", memoTitle)
+        }
+        val pendingIntent = PendingIntent.getBroadcast(
+            context, memoId, intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            if (alarmManager.canScheduleExactAlarms()) {
+                alarmManager.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, triggerAtMillis, pendingIntent)
+            } else {
+                alarmManager.setAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, triggerAtMillis, pendingIntent)
+            }
+        } else {
+            alarmManager.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, triggerAtMillis, pendingIntent)
+        }
+    }
+
+    fun cancel(context: Context, memoId: Int) {
+        val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+        val intent = Intent().apply {
+            setClassName(context, RECEIVER_CLASS)
+        }
+        val pendingIntent = PendingIntent.getBroadcast(
+            context, memoId, intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+        alarmManager.cancel(pendingIntent)
+    }
+}

--- a/feature/core/resource/src/main/java/me/pecos/memozy/presentation/screen/home/model/MemoUiState.kt
+++ b/feature/core/resource/src/main/java/me/pecos/memozy/presentation/screen/home/model/MemoUiState.kt
@@ -13,6 +13,7 @@ data class MemoUiState(
     val styles: String? = null,
     val youtubeUrl: String? = null,
     val deletedAt: Long? = null,
+    val reminderAt: Long? = null,
     val tags: List<TagUiState> = emptyList()
 )
 

--- a/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/home/MainViewModel.kt
+++ b/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/home/MainViewModel.kt
@@ -165,7 +165,8 @@ fun MemoUiState.toMemo(): Memo = Memo(
     audioPath = this.audioPath,
     styles = this.styles,
     youtubeUrl = this.youtubeUrl,
-    deletedAt = this.deletedAt
+    deletedAt = this.deletedAt,
+    reminderAt = this.reminderAt
 )
 
 fun Memo.toUiState(): MemoUiState = MemoUiState(
@@ -183,5 +184,6 @@ fun Memo.toUiState(): MemoUiState = MemoUiState(
     audioPath = this.audioPath,
     styles = this.styles,
     youtubeUrl = this.youtubeUrl,
-    deletedAt = this.deletedAt
+    deletedAt = this.deletedAt,
+    reminderAt = this.reminderAt
 )

--- a/feature/memo-plain/impl/src/main/java/me/pecos/memozy/feature/memoplain/impl/MemoPlainNavigationImpl.kt
+++ b/feature/memo-plain/impl/src/main/java/me/pecos/memozy/feature/memoplain/impl/MemoPlainNavigationImpl.kt
@@ -134,16 +134,29 @@ class MemoPlainNavigationImpl @Inject constructor(
         navGraphBuilder.composable(MemoPlainRoute.MEMO) { backStackEntry ->
             val memoIdStr = backStackEntry.arguments?.getString("memoId") ?: ""
             val isShared = memoIdStr.startsWith("shared_")
+            val isSharedImage = memoIdStr.startsWith("shared_image_")
+            val isSharedPdf = memoIdStr.startsWith("shared_pdf_")
             val memoId = memoIdStr.toIntOrNull() ?: -1
 
             // 공유 텍스트를 route parameter에서 디코딩
             val sharedText = remember {
-                if (isShared) {
+                if (isShared && !isSharedImage && !isSharedPdf) {
                     try {
                         java.net.URLDecoder.decode(memoIdStr.removePrefix("shared_"), "UTF-8")
                     } catch (e: Exception) { "" }
                 } else ""
             }
+
+            // 이미지/PDF URI 디코딩
+            val sharedFileUri = remember {
+                if (isSharedImage || isSharedPdf) {
+                    try {
+                        val prefix = if (isSharedImage) "shared_image_" else "shared_pdf_"
+                        android.net.Uri.parse(java.net.URLDecoder.decode(memoIdStr.removePrefix(prefix), "UTF-8"))
+                    } catch (e: Exception) { null }
+                } else null
+            }
+
             val youtubeUrl = remember { YOUTUBE_REGEX.find(sharedText)?.value }
 
             // YouTube 요약 상태
@@ -194,8 +207,28 @@ class MemoPlainNavigationImpl @Inject constructor(
                 }
             }
 
+            // 이미지 OCR 처리
+            var imageOcrState by remember { mutableStateOf<SummaryState>(SummaryState.Idle) }
+            val imageContext = LocalContext.current
+
+            LaunchedEffect(sharedFileUri, isSharedImage) {
+                if (isSharedImage && sharedFileUri != null && imageOcrState is SummaryState.Idle) {
+                    imageOcrState = SummaryState.Loading
+                    try {
+                        val bytes = imageContext.contentResolver.openInputStream(sharedFileUri)?.use { it.readBytes() }
+                            ?: throw Exception("Cannot read image")
+                        val base64 = Base64.encodeToString(bytes, Base64.NO_WRAP)
+                        val mimeType = imageContext.contentResolver.getType(sharedFileUri) ?: "image/jpeg"
+                        val result = aiApiService.describeImage(base64, mimeType)
+                        imageOcrState = SummaryState.Success(result)
+                    } catch (e: Exception) {
+                        imageOcrState = SummaryState.Error(e.message ?: "이미지 처리 실패")
+                    }
+                }
+            }
+
             // 일반 공유 텍스트 프리필
-            val sharedMemo = remember(summaryState) {
+            val sharedMemo = remember(summaryState, imageOcrState) {
                 when {
                     youtubeUrl != null -> when (val state = summaryState) {
                         is SummaryState.Success -> {
@@ -206,6 +239,17 @@ class MemoPlainNavigationImpl @Inject constructor(
                         }
                         else -> null
                     }
+                    isSharedImage -> when (val state = imageOcrState) {
+                        is SummaryState.Success -> {
+                            val lines = state.text.split("\n", limit = 2)
+                            val title = lines.firstOrNull()?.take(50) ?: "이미지 메모"
+                            val content = state.text
+                            MemoUiState(0, title, 1, content)
+                        }
+                        is SummaryState.Error -> MemoUiState(0, "이미지 메모", 1, "[이미지 인식 실패: ${state.message}]")
+                        else -> null
+                    }
+                    isSharedPdf -> MemoUiState(0, "PDF 메모", 1, "[PDF 파일이 첨부되었습니다]")
                     isShared && sharedText.isNotEmpty() -> {
                         val lines = sharedText.split("\n", limit = 2)
                         val title = lines.firstOrNull()?.take(50) ?: ""

--- a/feature/memo-plain/impl/src/main/java/me/pecos/memozy/feature/memoplain/impl/MemoPlainNavigationImpl.kt
+++ b/feature/memo-plain/impl/src/main/java/me/pecos/memozy/feature/memoplain/impl/MemoPlainNavigationImpl.kt
@@ -493,6 +493,17 @@ class MemoPlainNavigationImpl @Inject constructor(
                 webSummaryResult = webSummaryResult,
                 webSummaryError = webSummaryError,
                 webPageTitle = webPageTitle,
+                onSetReminder = { id, reminderAt ->
+                    scope.launch {
+                        repository.setReminder(id, reminderAt)
+                        if (reminderAt != null) {
+                            val title = existingMemo?.name ?: "메모"
+                            me.pecos.memozy.presentation.reminder.ReminderScheduler.schedule(context, id, title, reminderAt)
+                        } else {
+                            me.pecos.memozy.presentation.reminder.ReminderScheduler.cancel(context, id)
+                        }
+                    }
+                },
                 onYoutubeDetected = { videoId ->
                     scope.launch {
                         val title = captionService.fetchTitle(videoId)

--- a/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/MemoScreen.kt
+++ b/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/MemoScreen.kt
@@ -35,14 +35,20 @@ import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Stop
 import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.Link
+import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material.icons.filled.SmartDisplay
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.DatePicker
+import androidx.compose.material3.DatePickerDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.TimePicker
+import androidx.compose.material3.rememberDatePickerState
+import androidx.compose.material3.rememberTimePickerState
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Scaffold
@@ -189,6 +195,7 @@ fun MemoScreen(
     webSummaryResult: String? = null,
     webSummaryError: String? = null,
     webPageTitle: String? = null,
+    onSetReminder: ((memoId: Int, reminderAt: Long?) -> Unit)? = null,
     existingMemo: MemoUiState = MemoUiState(0, "", 1, "")
 ) {
     val isNewMemo = existingMemo.id <= 0
@@ -986,6 +993,50 @@ fun MemoScreen(
                     }
                 }
 
+                // ⏰ 리마인더
+                if (onSetReminder != null && !isNewMemo) {
+                    var showReminderPicker by remember { mutableStateOf(false) }
+                    val reminderTime = existingMemo.reminderAt
+                    val hasReminder = reminderTime != null && reminderTime > System.currentTimeMillis()
+                    Row(
+                        modifier = Modifier
+                            .clip(RoundedCornerShape(20.dp))
+                            .background(
+                                if (hasReminder) Color(0xFFFFA726).copy(alpha = 0.15f)
+                                else colors.chipBackground
+                            )
+                            .clickable { showReminderPicker = true }
+                            .padding(horizontal = 12.dp, vertical = 8.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Icon(Icons.Default.Notifications, contentDescription = null,
+                            tint = if (hasReminder) Color(0xFFFFA726) else colors.chipText,
+                            modifier = Modifier.size(16.dp))
+                        Spacer(modifier = Modifier.width(4.dp))
+                        Text(
+                            text = if (hasReminder) "알림" else "알림",
+                            fontSize = 12.sp,
+                            color = if (hasReminder) Color(0xFFFFA726) else colors.chipText,
+                            fontWeight = FontWeight.SemiBold
+                        )
+                    }
+
+                    if (showReminderPicker) {
+                        ReminderPickerDialog(
+                            currentReminder = existingMemo.reminderAt,
+                            onDismiss = { showReminderPicker = false },
+                            onConfirm = { reminderAt ->
+                                onSetReminder(existingMemo.id, reminderAt)
+                                showReminderPicker = false
+                            },
+                            onCancel = {
+                                onSetReminder(existingMemo.id, null)
+                                showReminderPicker = false
+                            }
+                        )
+                    }
+                }
+
                 Spacer(modifier = Modifier.weight(1f))
             }
         } // outer Column
@@ -1150,6 +1201,76 @@ fun MemoScreen(
             dismissButton = {
                 TextButton(onClick = { showYoutubeDialog = false }) {
                     Text("취소", color = colors.textSecondary)
+                }
+            }
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ReminderPickerDialog(
+    currentReminder: Long?,
+    onDismiss: () -> Unit,
+    onConfirm: (Long) -> Unit,
+    onCancel: () -> Unit
+) {
+    val calendar = java.util.Calendar.getInstance()
+    if (currentReminder != null) calendar.timeInMillis = currentReminder
+
+    val datePickerState = rememberDatePickerState(
+        initialSelectedDateMillis = calendar.timeInMillis
+    )
+    var showTimePicker by remember { mutableStateOf(false) }
+    val colors = me.pecos.memozy.presentation.theme.LocalAppColors.current
+
+    if (!showTimePicker) {
+        DatePickerDialog(
+            onDismissRequest = onDismiss,
+            confirmButton = {
+                TextButton(onClick = { showTimePicker = true }) {
+                    Text("다음")
+                }
+            },
+            dismissButton = {
+                if (currentReminder != null) {
+                    TextButton(onClick = onCancel) {
+                        Text("알림 해제", color = Color(0xFFE24B4A))
+                    }
+                }
+                TextButton(onClick = onDismiss) {
+                    Text("취소")
+                }
+            }
+        ) {
+            DatePicker(state = datePickerState)
+        }
+    } else {
+        val timePickerState = rememberTimePickerState(
+            initialHour = calendar.get(java.util.Calendar.HOUR_OF_DAY),
+            initialMinute = calendar.get(java.util.Calendar.MINUTE)
+        )
+        AlertDialog(
+            onDismissRequest = onDismiss,
+            title = { Text("시간 선택") },
+            text = { TimePicker(state = timePickerState) },
+            confirmButton = {
+                TextButton(onClick = {
+                    val selectedDate = datePickerState.selectedDateMillis ?: System.currentTimeMillis()
+                    val cal = java.util.Calendar.getInstance().apply {
+                        timeInMillis = selectedDate
+                        set(java.util.Calendar.HOUR_OF_DAY, timePickerState.hour)
+                        set(java.util.Calendar.MINUTE, timePickerState.minute)
+                        set(java.util.Calendar.SECOND, 0)
+                    }
+                    onConfirm(cal.timeInMillis)
+                }) {
+                    Text("확인")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showTimePicker = false }) {
+                    Text("이전")
                 }
             }
         )

--- a/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/MemoScreen.kt
+++ b/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/MemoScreen.kt
@@ -348,6 +348,68 @@ fun MemoScreen(
                         }
                 )
                 Spacer(modifier = Modifier.weight(1f))
+
+                // 공유 버튼 (기존 메모만 표시)
+                if (!isNewMemo) {
+                    Icon(
+                        imageVector = Icons.Default.Share,
+                        contentDescription = stringResource(R.string.memo_share),
+                        tint = colors.textSecondary,
+                        modifier = Modifier
+                            .size(22.dp)
+                            .clickable {
+                                val shareText = buildString {
+                                    if (nameText.isNotBlank()) {
+                                        appendLine(nameText)
+                                        appendLine()
+                                    }
+                                    append(safeContent())
+                                }
+                                val shareIntent = Intent(Intent.ACTION_SEND).apply {
+                                    type = "text/plain"
+                                    putExtra(Intent.EXTRA_SUBJECT, nameText)
+                                    putExtra(Intent.EXTRA_TEXT, shareText)
+                                }
+                                context.startActivity(Intent.createChooser(shareIntent, null))
+                            }
+                    )
+                    Spacer(modifier = Modifier.width(16.dp))
+
+                    // 마크다운 내보내기
+                    Icon(
+                        imageVector = Icons.Default.Download,
+                        contentDescription = stringResource(R.string.memo_export_md),
+                        tint = colors.textSecondary,
+                        modifier = Modifier
+                            .size(22.dp)
+                            .clickable {
+                                val mdContent = buildString {
+                                    if (nameText.isNotBlank()) {
+                                        appendLine("# $nameText")
+                                        appendLine()
+                                    }
+                                    append(safeContent())
+                                }
+                                val fileName = (nameText.ifBlank { "memo" })
+                                    .replace(Regex("[^a-zA-Z0-9가-힣ぁ-ヶ一-龠\\s_-]"), "")
+                                    .take(50)
+                                    .trim()
+                                val file = java.io.File(context.cacheDir, "${fileName}.md")
+                                file.writeText(mdContent)
+                                val uri = androidx.core.content.FileProvider.getUriForFile(
+                                    context, "${context.packageName}.fileprovider", file
+                                )
+                                val exportIntent = Intent(Intent.ACTION_SEND).apply {
+                                    type = "text/markdown"
+                                    putExtra(Intent.EXTRA_STREAM, uri)
+                                    addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                                }
+                                context.startActivity(Intent.createChooser(exportIntent, null))
+                            }
+                    )
+                    Spacer(modifier = Modifier.width(16.dp))
+                }
+
                 // 완료 버튼 (새 메모 + 기존 메모 모두 표시)
                 Text(
                     text = "완료",


### PR DESCRIPTION
## Summary
- Memo에 `reminderAt` 필드 추가 + DB 마이그레이션 (v13 → v14)
- 메모 상세 하단 액션바에 알림(⏰) 칩 추가
- DatePicker → TimePicker 2단계로 날짜/시간 선택
- AlarmManager로 정확한 시간에 알림 스케줄링
- 알림 탭 → 해당 메모 바로 열기 (위젯 인텐트 재활용)
- 알림 해제/변경 지원

## Test plan
- [ ] 메모 상세 → 알림 칩 탭 → 날짜 선택 → 시간 선택 → 알림 설정 확인
- [ ] 설정된 시간에 알림 수신 확인
- [ ] 알림 탭 → 해당 메모 열림 확인
- [ ] 알림 해제 → 알림 취소 확인
- [ ] 새 메모에서는 알림 칩 숨김 확인
- [ ] 알림 설정된 메모 → 칩 주황색 하이라이트 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)