### PR TITLE
Add: #88 메모 퀴즈 모드

### DIFF
--- a/feature/core/resource/src/main/res/values-en/strings.xml
+++ b/feature/core/resource/src/main/res/values-en/strings.xml
@@ -100,4 +100,13 @@
     <string name="trash_permanent_delete_action">Delete Permanently</string>
     <string name="trash_permanent_delete_message">This memo will be permanently deleted.\nIt cannot be restored.</string>
     <string name="trash_auto_delete_hint">Deleted memos are permanently removed after 30 days</string>
+
+    <!-- Quiz -->
+    <string name="quiz_title">Memo Quiz</string>
+    <string name="quiz_generating">Generating quiz…</string>
+    <string name="quiz_retry">Try Again</string>
+    <string name="quiz_next">Next</string>
+    <string name="quiz_show_result">Show Results</string>
+    <string name="quiz_explanation">Explanation</string>
+    <string name="quiz_back">Go Back</string>
 </resources>

--- a/feature/core/resource/src/main/res/values-ja/strings.xml
+++ b/feature/core/resource/src/main/res/values-ja/strings.xml
@@ -100,4 +100,13 @@
     <string name="trash_permanent_delete_action">完全に削除</string>
     <string name="trash_permanent_delete_message">このメモを完全に削除します。\n復元できません。</string>
     <string name="trash_auto_delete_hint">削除されたメモは30日後に自動的に完全削除されます</string>
+
+    <!-- Quiz -->
+    <string name="quiz_title">メモクイズ</string>
+    <string name="quiz_generating">クイズを作成中…</string>
+    <string name="quiz_retry">もう一度</string>
+    <string name="quiz_next">次へ</string>
+    <string name="quiz_show_result">結果を見る</string>
+    <string name="quiz_explanation">解説</string>
+    <string name="quiz_back">戻る</string>
 </resources>

--- a/feature/core/resource/src/main/res/values/strings.xml
+++ b/feature/core/resource/src/main/res/values/strings.xml
@@ -98,4 +98,13 @@
     <string name="trash_permanent_delete_action">영구 삭제</string>
     <string name="trash_permanent_delete_message">이 메모를 영구적으로 삭제합니다.\n복원할 수 없습니다.</string>
     <string name="trash_auto_delete_hint">삭제된 메모는 30일 후 자동으로 영구 삭제됩니다</string>
+
+    <!-- Quiz -->
+    <string name="quiz_title">메모 퀴즈</string>
+    <string name="quiz_generating">퀴즈를 만들고 있어요…</string>
+    <string name="quiz_retry">다시 도전</string>
+    <string name="quiz_next">다음 문제</string>
+    <string name="quiz_show_result">결과 보기</string>
+    <string name="quiz_explanation">해설</string>
+    <string name="quiz_back">돌아가기</string>
 </resources>

--- a/feature/home/api/src/main/java/me/pecos/memozy/feature/home/api/HomeNavigation.kt
+++ b/feature/home/api/src/main/java/me/pecos/memozy/feature/home/api/HomeNavigation.kt
@@ -9,6 +9,8 @@ object HomeRoute {
     const val MAIN = "main"
     const val SETTINGS = "settings"
     const val TRASH = "trash"
+    const val QUIZ = "quiz/{memoId}"
+    fun quizRoute(memoId: Int) = "quiz/$memoId"
 }
 
 interface HomeNavigation {

--- a/feature/home/impl/build.gradle.kts
+++ b/feature/home/impl/build.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
     implementation(projects.feature.memoPlain.api)
     implementation(projects.datasource.local.memo.api)
     implementation(projects.data.repository.memo.api)
+    implementation(projects.datasource.remote.ai.api)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.appcompat)

--- a/feature/home/impl/src/main/java/me/pecos/memozy/MainActivity.kt
+++ b/feature/home/impl/src/main/java/me/pecos/memozy/MainActivity.kt
@@ -253,6 +253,13 @@ class MainActivity : AppCompatActivity() {
                                         billingManager = this@MainActivity.billingManager
                                     )
                                 }
+                                composable(HomeRoute.QUIZ) {
+                                    val quizViewModel: me.pecos.memozy.presentation.screen.quiz.QuizViewModel = viewModel()
+                                    me.pecos.memozy.presentation.screen.quiz.QuizScreen(
+                                        viewModel = quizViewModel,
+                                        onBack = { navController.popBackStack() }
+                                    )
+                                }
                                 memoPlainNavigation.registerGraph(
                                     navGraphBuilder = this,
                                     onNavigateToHome = {
@@ -263,6 +270,9 @@ class MainActivity : AppCompatActivity() {
                                     },
                                     onBack = {
                                         navController.popBackStack(HomeRoute.MAIN, inclusive = false)
+                                    },
+                                    onNavigateToQuiz = { memoId ->
+                                        navController.navigate(HomeRoute.quizRoute(memoId))
                                     }
                                 )
                             }

--- a/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/quiz/QuizModel.kt
+++ b/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/quiz/QuizModel.kt
@@ -1,0 +1,8 @@
+package me.pecos.memozy.presentation.screen.quiz
+
+data class QuizQuestion(
+    val question: String,
+    val options: List<String>,
+    val correctIndex: Int,
+    val explanation: String
+)

--- a/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/quiz/QuizScreen.kt
+++ b/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/quiz/QuizScreen.kt
@@ -1,0 +1,329 @@
+package me.pecos.memozy.presentation.screen.quiz
+
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.Cancel
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.wanted.android.wanted.design.actions.button.WantedButton
+import com.wanted.android.wanted.design.actions.button.config.WantedButtonDefaults
+import com.wanted.android.wanted.design.util.ButtonType
+import com.wanted.android.wanted.design.util.ButtonVariant
+import me.pecos.memozy.feature.core.resource.R
+import me.pecos.memozy.presentation.theme.LocalAppColors
+
+@Composable
+fun QuizScreen(
+    viewModel: QuizViewModel,
+    onBack: () -> Unit
+) {
+    val quizState by viewModel.quizState.collectAsState()
+    val currentIndex by viewModel.currentIndex.collectAsState()
+    val selectedAnswer by viewModel.selectedAnswer.collectAsState()
+    val correctCount by viewModel.correctCount.collectAsState()
+    val isFinished by viewModel.isFinished.collectAsState()
+    val memoTitle by viewModel.memoTitle.collectAsState()
+    val colors = LocalAppColors.current
+
+    Scaffold(containerColor = colors.screenBackground) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .padding(horizontal = 16.dp, vertical = 24.dp)
+        ) {
+            // Header
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                IconButton(onClick = onBack) {
+                    Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null, tint = colors.topbarTitle)
+                }
+                Text(
+                    text = stringResource(R.string.quiz_title),
+                    fontSize = 22.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = colors.topbarTitle
+                )
+            }
+
+            if (memoTitle.isNotBlank()) {
+                Text(
+                    text = memoTitle,
+                    fontSize = 13.sp,
+                    color = colors.textSecondary,
+                    modifier = Modifier.padding(start = 16.dp, bottom = 12.dp),
+                    maxLines = 1
+                )
+            }
+
+            when (val state = quizState) {
+                is QuizState.Loading -> {
+                    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                            CircularProgressIndicator(color = colors.chipText)
+                            Spacer(modifier = Modifier.height(16.dp))
+                            Text(stringResource(R.string.quiz_generating), color = colors.textSecondary, fontSize = 14.sp)
+                        }
+                    }
+                }
+
+                is QuizState.Error -> {
+                    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                            Text(state.message, color = colors.textSecondary, fontSize = 14.sp, textAlign = TextAlign.Center)
+                            Spacer(modifier = Modifier.height(16.dp))
+                            WantedButton(
+                                text = stringResource(R.string.quiz_retry),
+                                buttonDefault = WantedButtonDefaults.getDefault(type = ButtonType.ASSISTIVE, variant = ButtonVariant.OUTLINED)
+                                    .copy(contentColor = colors.chipText),
+                                onClick = { viewModel.retry() }
+                            )
+                        }
+                    }
+                }
+
+                is QuizState.Ready -> {
+                    if (isFinished) {
+                        // 결과 화면
+                        QuizResultScreen(
+                            totalCount = state.questions.size,
+                            correctCount = correctCount,
+                            onRetry = { viewModel.retry() },
+                            onBack = onBack,
+                            colors = colors
+                        )
+                    } else {
+                        // 퀴즈 진행
+                        val question = state.questions[currentIndex]
+                        val totalCount = state.questions.size
+
+                        // Progress
+                        LinearProgressIndicator(
+                            progress = { (currentIndex + 1).toFloat() / totalCount },
+                            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp).clip(RoundedCornerShape(4.dp)),
+                            color = colors.chipText,
+                            trackColor = colors.chipBackground,
+                        )
+                        Text(
+                            text = "${currentIndex + 1} / $totalCount",
+                            fontSize = 12.sp,
+                            color = colors.textSecondary,
+                            modifier = Modifier.padding(start = 16.dp, top = 4.dp)
+                        )
+
+                        Spacer(modifier = Modifier.height(24.dp))
+
+                        Column(
+                            modifier = Modifier
+                                .weight(1f)
+                                .verticalScroll(rememberScrollState())
+                                .padding(horizontal = 16.dp)
+                        ) {
+                            // 문제
+                            Text(
+                                text = question.question,
+                                fontSize = 18.sp,
+                                fontWeight = FontWeight.SemiBold,
+                                color = colors.textTitle,
+                                lineHeight = 26.sp
+                            )
+
+                            Spacer(modifier = Modifier.height(24.dp))
+
+                            // 선택지
+                            question.options.forEachIndexed { idx, option ->
+                                val isSelected = selectedAnswer == idx
+                                val isCorrect = idx == question.correctIndex
+                                val hasAnswered = selectedAnswer >= 0
+
+                                val bgColor by animateColorAsState(
+                                    when {
+                                        hasAnswered && isCorrect -> Color(0xFF4CAF50).copy(alpha = 0.12f)
+                                        hasAnswered && isSelected && !isCorrect -> Color(0xFFE24B4A).copy(alpha = 0.12f)
+                                        else -> colors.cardBackground
+                                    }, label = "optionBg"
+                                )
+                                val borderColor by animateColorAsState(
+                                    when {
+                                        hasAnswered && isCorrect -> Color(0xFF4CAF50)
+                                        hasAnswered && isSelected && !isCorrect -> Color(0xFFE24B4A)
+                                        isSelected -> colors.chipText
+                                        else -> colors.cardBorder
+                                    }, label = "optionBorder"
+                                )
+
+                                Row(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(vertical = 4.dp)
+                                        .clip(RoundedCornerShape(12.dp))
+                                        .background(bgColor)
+                                        .border(1.5.dp, borderColor, RoundedCornerShape(12.dp))
+                                        .clickable(enabled = !hasAnswered) { viewModel.selectAnswer(idx) }
+                                        .padding(16.dp),
+                                    verticalAlignment = Alignment.CenterVertically
+                                ) {
+                                    Text(
+                                        text = option,
+                                        fontSize = 15.sp,
+                                        color = colors.textTitle,
+                                        modifier = Modifier.weight(1f)
+                                    )
+                                    if (hasAnswered && isCorrect) {
+                                        Icon(Icons.Default.CheckCircle, null, tint = Color(0xFF4CAF50), modifier = Modifier.size(22.dp))
+                                    } else if (hasAnswered && isSelected && !isCorrect) {
+                                        Icon(Icons.Default.Cancel, null, tint = Color(0xFFE24B4A), modifier = Modifier.size(22.dp))
+                                    }
+                                }
+                            }
+
+                            // 해설
+                            if (selectedAnswer >= 0 && question.explanation.isNotBlank()) {
+                                Spacer(modifier = Modifier.height(16.dp))
+                                Column(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .clip(RoundedCornerShape(12.dp))
+                                        .background(colors.chipBackground)
+                                        .padding(16.dp)
+                                ) {
+                                    Text(
+                                        text = stringResource(R.string.quiz_explanation),
+                                        fontSize = 13.sp,
+                                        fontWeight = FontWeight.SemiBold,
+                                        color = colors.chipText
+                                    )
+                                    Spacer(modifier = Modifier.height(4.dp))
+                                    Text(
+                                        text = question.explanation,
+                                        fontSize = 14.sp,
+                                        color = colors.textBody,
+                                        lineHeight = 20.sp
+                                    )
+                                }
+                            }
+                        }
+
+                        // 다음 버튼
+                        if (selectedAnswer >= 0) {
+                            Spacer(modifier = Modifier.height(12.dp))
+                            WantedButton(
+                                text = if (currentIndex + 1 >= state.questions.size) stringResource(R.string.quiz_show_result)
+                                       else stringResource(R.string.quiz_next),
+                                modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+                                buttonDefault = WantedButtonDefaults.getDefault(type = ButtonType.ASSISTIVE, variant = ButtonVariant.OUTLINED)
+                                    .copy(contentColor = colors.chipText),
+                                onClick = { viewModel.nextQuestion() }
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun QuizResultScreen(
+    totalCount: Int,
+    correctCount: Int,
+    onRetry: () -> Unit,
+    onBack: () -> Unit,
+    colors: me.pecos.memozy.presentation.theme.AppColors
+) {
+    val score = if (totalCount > 0) (correctCount * 100) / totalCount else 0
+
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier.padding(32.dp)
+        ) {
+            Text(
+                text = if (score >= 80) "🎉" else if (score >= 50) "💪" else "📚",
+                fontSize = 48.sp
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            Text(
+                text = "${score}%",
+                fontSize = 48.sp,
+                fontWeight = FontWeight.Bold,
+                color = when {
+                    score >= 80 -> Color(0xFF4CAF50)
+                    score >= 50 -> Color(0xFFFFA726)
+                    else -> Color(0xFFE24B4A)
+                }
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = "$correctCount / $totalCount",
+                fontSize = 18.sp,
+                color = colors.textSecondary
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = when {
+                    score >= 80 -> "훌륭해요! 잘 기억하고 있어요"
+                    score >= 50 -> "좋아요! 조금 더 복습해볼까요?"
+                    else -> "다시 한번 메모를 읽어보세요!"
+                },
+                fontSize = 14.sp,
+                color = colors.textBody,
+                textAlign = TextAlign.Center
+            )
+
+            Spacer(modifier = Modifier.height(32.dp))
+
+            WantedButton(
+                text = stringResource(R.string.quiz_retry),
+                modifier = Modifier.fillMaxWidth(),
+                buttonDefault = WantedButtonDefaults.getDefault(type = ButtonType.ASSISTIVE, variant = ButtonVariant.OUTLINED)
+                    .copy(contentColor = colors.chipText),
+                onClick = onRetry
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+            WantedButton(
+                text = stringResource(R.string.quiz_back),
+                modifier = Modifier.fillMaxWidth(),
+                buttonDefault = WantedButtonDefaults.getDefault(type = ButtonType.ASSISTIVE, variant = ButtonVariant.OUTLINED)
+                    .copy(contentColor = colors.textTitle),
+                onClick = onBack
+            )
+        }
+    }
+}

--- a/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/quiz/QuizViewModel.kt
+++ b/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/quiz/QuizViewModel.kt
@@ -1,0 +1,147 @@
+package me.pecos.memozy.presentation.screen.quiz
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import me.pecos.memozy.data.datasource.remote.ai.AIApiService
+import me.pecos.memozy.data.repository.MemoRepository
+import org.json.JSONArray
+import javax.inject.Inject
+
+sealed class QuizState {
+    data object Loading : QuizState()
+    data class Ready(val questions: List<QuizQuestion>) : QuizState()
+    data class Error(val message: String) : QuizState()
+}
+
+@HiltViewModel
+class QuizViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+    private val repository: MemoRepository,
+    private val aiApiService: AIApiService
+) : ViewModel() {
+
+    private val memoId: Int = savedStateHandle.get<String>("memoId")?.toIntOrNull() ?: -1
+
+    private val _quizState = MutableStateFlow<QuizState>(QuizState.Loading)
+    val quizState: StateFlow<QuizState> = _quizState
+
+    private val _currentIndex = MutableStateFlow(0)
+    val currentIndex: StateFlow<Int> = _currentIndex
+
+    private val _selectedAnswer = MutableStateFlow(-1)
+    val selectedAnswer: StateFlow<Int> = _selectedAnswer
+
+    private val _correctCount = MutableStateFlow(0)
+    val correctCount: StateFlow<Int> = _correctCount
+
+    private val _isFinished = MutableStateFlow(false)
+    val isFinished: StateFlow<Boolean> = _isFinished
+
+    val memoTitle = MutableStateFlow("")
+
+    init {
+        generateQuiz()
+    }
+
+    private fun generateQuiz() {
+        viewModelScope.launch {
+            _quizState.value = QuizState.Loading
+            try {
+                val memo = repository.getMemoById(memoId)
+                    ?: throw Exception("메모를 찾을 수 없습니다")
+
+                memoTitle.value = memo.name
+                val content = "${memo.name}\n\n${memo.content}".take(3000)
+
+                val prompt = """다음 메모 내용을 바탕으로 5개의 객관식 퀴즈를 만들어줘.
+
+규칙:
+- 메모 내용에서 핵심 개념을 테스트하는 문제를 만들어
+- 각 문제는 4개의 선택지를 가져
+- 정답은 하나만 있어야 해
+- 해설은 왜 그 답이 맞는지 간결하게 설명해
+- 반드시 아래 JSON 배열 형식으로만 출력하고 다른 텍스트는 출력하지 마
+
+출력 형식:
+[{"question":"문제","options":["A","B","C","D"],"correctIndex":0,"explanation":"해설"}]
+
+메모 내용:
+$content"""
+
+                val response = aiApiService.generateContent(prompt)
+                val questions = parseQuizResponse(response)
+
+                if (questions.isEmpty()) {
+                    _quizState.value = QuizState.Error("퀴즈를 생성할 수 없습니다")
+                } else {
+                    _quizState.value = QuizState.Ready(questions)
+                }
+            } catch (e: Exception) {
+                _quizState.value = QuizState.Error(e.message ?: "퀴즈 생성 실패")
+            }
+        }
+    }
+
+    fun selectAnswer(index: Int) {
+        if (_selectedAnswer.value >= 0) return // already answered
+        _selectedAnswer.value = index
+
+        val state = _quizState.value
+        if (state is QuizState.Ready) {
+            val question = state.questions[_currentIndex.value]
+            if (index == question.correctIndex) {
+                _correctCount.value++
+            }
+        }
+    }
+
+    fun nextQuestion() {
+        val state = _quizState.value
+        if (state is QuizState.Ready) {
+            val nextIdx = _currentIndex.value + 1
+            if (nextIdx >= state.questions.size) {
+                _isFinished.value = true
+            } else {
+                _currentIndex.value = nextIdx
+                _selectedAnswer.value = -1
+            }
+        }
+    }
+
+    fun retry() {
+        _currentIndex.value = 0
+        _selectedAnswer.value = -1
+        _correctCount.value = 0
+        _isFinished.value = false
+        generateQuiz()
+    }
+
+    private fun parseQuizResponse(response: String): List<QuizQuestion> {
+        return try {
+            // JSON 배열 부분만 추출
+            val jsonStr = response.trim().let { raw ->
+                val start = raw.indexOf('[')
+                val end = raw.lastIndexOf(']')
+                if (start >= 0 && end > start) raw.substring(start, end + 1) else raw
+            }
+            val array = JSONArray(jsonStr)
+            (0 until array.length()).map { i ->
+                val obj = array.getJSONObject(i)
+                val options = obj.getJSONArray("options")
+                QuizQuestion(
+                    question = obj.getString("question"),
+                    options = (0 until options.length()).map { options.getString(it) },
+                    correctIndex = obj.getInt("correctIndex"),
+                    explanation = obj.optString("explanation", "")
+                )
+            }
+        } catch (e: Exception) {
+            emptyList()
+        }
+    }
+}

--- a/feature/memo-plain/api/src/main/java/me/pecos/memozy/feature/memoplain/api/MemoPlainNavigation.kt
+++ b/feature/memo-plain/api/src/main/java/me/pecos/memozy/feature/memoplain/api/MemoPlainNavigation.kt
@@ -15,6 +15,7 @@ interface MemoPlainNavigation {
     fun registerGraph(
         navGraphBuilder: NavGraphBuilder,
         onNavigateToHome: () -> Unit,
-        onBack: () -> Unit
+        onBack: () -> Unit,
+        onNavigateToQuiz: ((memoId: Int) -> Unit)? = null
     )
 }

--- a/feature/memo-plain/impl/src/main/java/me/pecos/memozy/feature/memoplain/impl/MemoPlainNavigationImpl.kt
+++ b/feature/memo-plain/impl/src/main/java/me/pecos/memozy/feature/memoplain/impl/MemoPlainNavigationImpl.kt
@@ -129,7 +129,8 @@ class MemoPlainNavigationImpl @Inject constructor(
     override fun registerGraph(
         navGraphBuilder: NavGraphBuilder,
         onNavigateToHome: () -> Unit,
-        onBack: () -> Unit
+        onBack: () -> Unit,
+        onNavigateToQuiz: ((memoId: Int) -> Unit)?
     ) {
         navGraphBuilder.composable(MemoPlainRoute.MEMO) { backStackEntry ->
             val memoIdStr = backStackEntry.arguments?.getString("memoId") ?: ""
@@ -537,6 +538,7 @@ class MemoPlainNavigationImpl @Inject constructor(
                 webSummaryResult = webSummaryResult,
                 webSummaryError = webSummaryError,
                 webPageTitle = webPageTitle,
+                onQuiz = if (onNavigateToQuiz != null) { id -> onNavigateToQuiz(id) } else null,
                 onSetReminder = { id, reminderAt ->
                     scope.launch {
                         repository.setReminder(id, reminderAt)

--- a/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/MemoScreen.kt
+++ b/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/MemoScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.material.icons.filled.Stop
 import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.Link
 import androidx.compose.material.icons.filled.Notifications
+import androidx.compose.material.icons.filled.Quiz
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material.icons.filled.SmartDisplay
 import androidx.compose.foundation.shape.CircleShape
@@ -196,6 +197,7 @@ fun MemoScreen(
     webSummaryError: String? = null,
     webPageTitle: String? = null,
     onSetReminder: ((memoId: Int, reminderAt: Long?) -> Unit)? = null,
+    onQuiz: ((memoId: Int) -> Unit)? = null,
     existingMemo: MemoUiState = MemoUiState(0, "", 1, "")
 ) {
     val isNewMemo = existingMemo.id <= 0
@@ -1096,6 +1098,23 @@ fun MemoScreen(
                                 showReminderPicker = false
                             }
                         )
+                    }
+                }
+
+                // 🧠 퀴즈
+                if (onQuiz != null && !isNewMemo && existingMemo.content.length >= 20) {
+                    Row(
+                        modifier = Modifier
+                            .clip(RoundedCornerShape(20.dp))
+                            .background(colors.chipBackground)
+                            .clickable { onQuiz(existingMemo.id) }
+                            .padding(horizontal = 12.dp, vertical = 8.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Icon(Icons.Default.Quiz, contentDescription = null,
+                            tint = colors.chipText, modifier = Modifier.size(16.dp))
+                        Spacer(modifier = Modifier.width(4.dp))
+                        Text("퀴즈", fontSize = 12.sp, color = colors.chipText, fontWeight = FontWeight.SemiBold)
                     }
                 }
 


### PR DESCRIPTION
## Summary
- 메모 내용 기반 AI 퀴즈 생성 (Gemini → 객관식 5문제)
- 4지선다 퀴즈 UI (정답/오답 색상 애니메이션 + 해설)
- 퀴즈 결과 화면 (점수 + 격려 메시지 + 다시 도전)
- 메모 하단 액션바에 "퀴즈" 칩 (20자 이상 메모에만 표시)

## Test plan
- [ ] 메모 상세 → 퀴즈 칩 탭 → 퀴즈 생성 로딩 확인
- [ ] 5개 문제 순서대로 풀기 가능 확인
- [ ] 정답 탭 → 초록 하이라이트 + 해설 확인
- [ ] 오답 탭 → 빨강 하이라이트 + 정답 초록 표시 확인
- [ ] 전부 풀고 결과 화면 → 점수 + 이모지 확인
- [ ] 다시 도전 → 새 퀴즈 생성 확인
- [ ] 20자 미만 메모 → 퀴즈 칩 숨김 확인
- [ ] 새 메모 작성 중 → 퀴즈 칩 숨김 확인

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)