### PR TITLE
Add: 요약 콘텐츠 카드 UX 통일 (SummaryCard)

### DIFF
--- a/feature/core/resource/src/main/res/values-en/strings.xml
+++ b/feature/core/resource/src/main/res/values-en/strings.xml
@@ -101,6 +101,12 @@
     <string name="trash_permanent_delete_message">This memo will be permanently deleted.\nIt cannot be restored.</string>
     <string name="trash_auto_delete_hint">Deleted memos are permanently removed after 30 days</string>
 
+    <!-- Summary Card -->
+    <string name="summary_card_web">Web Page</string>
+    <string name="summary_card_open">Open Original</string>
+    <string name="summary_card_view_summary">View Summary</string>
+    <string name="summary_card_summarize">AI Summary</string>
+
     <!-- Quiz -->
     <string name="quiz_title">Memo Quiz</string>
     <string name="quiz_generating">Generating quiz…</string>

--- a/feature/core/resource/src/main/res/values-ja/strings.xml
+++ b/feature/core/resource/src/main/res/values-ja/strings.xml
@@ -101,6 +101,12 @@
     <string name="trash_permanent_delete_message">このメモを完全に削除します。\n復元できません。</string>
     <string name="trash_auto_delete_hint">削除されたメモは30日後に自動的に完全削除されます</string>
 
+    <!-- Summary Card -->
+    <string name="summary_card_web">ウェブページ</string>
+    <string name="summary_card_open">元を見る</string>
+    <string name="summary_card_view_summary">要約を見る</string>
+    <string name="summary_card_summarize">AI要約</string>
+
     <!-- Quiz -->
     <string name="quiz_title">メモクイズ</string>
     <string name="quiz_generating">クイズを作成中…</string>

--- a/feature/core/resource/src/main/res/values/strings.xml
+++ b/feature/core/resource/src/main/res/values/strings.xml
@@ -99,6 +99,12 @@
     <string name="trash_permanent_delete_message">이 메모를 영구적으로 삭제합니다.\n복원할 수 없습니다.</string>
     <string name="trash_auto_delete_hint">삭제된 메모는 30일 후 자동으로 영구 삭제됩니다</string>
 
+    <!-- Summary Card -->
+    <string name="summary_card_web">웹페이지</string>
+    <string name="summary_card_open">원본 보기</string>
+    <string name="summary_card_view_summary">요약 보기</string>
+    <string name="summary_card_summarize">AI 요약</string>
+
     <!-- Quiz -->
     <string name="quiz_title">메모 퀴즈</string>
     <string name="quiz_generating">퀴즈를 만들고 있어요…</string>

--- a/feature/memo-plain/impl/build.gradle.kts
+++ b/feature/memo-plain/impl/build.gradle.kts
@@ -20,4 +20,5 @@ dependencies {
     implementation(libs.androidx.lifecycle.runtime.compose)
     implementation(libs.androidx.compose.material.icons.extended)
     implementation(libs.richeditor.compose)
+    implementation(libs.coil.compose)
 }

--- a/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/MemoScreen.kt
+++ b/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/MemoScreen.kt
@@ -832,78 +832,46 @@ fun MemoScreen(
                     }
                 }
 
-                // 유튜브 칩 (서식 툴바 아래)
+                // 유튜브 요약 카드 (SummaryCard)
                 val youtubeUrlDisplay = detectedYoutubeUrl ?: savedYoutubeUrl ?: ""
                 val hasYoutubeSummaryContent = bodyText.contains("핵심 키워드") || bodyText.contains("한줄 요약") || bodyText.contains("타임라인별")
                 if ((detectedYoutubeUrl != null || summaryResult != null || youtubeTitle != null || hasYoutubeSummaryContent) && !youtubeChipDismissed) {
                     Spacer(modifier = Modifier.height(12.dp))
-                    Box {
-                        Column {
-                            Row(
-                                modifier = Modifier.fillMaxWidth().clip(RoundedCornerShape(10.dp))
-                                    .background(colors.chipBackground.copy(alpha = 0.5f))
-                                    .padding(horizontal = 12.dp, vertical = 10.dp),
-                                verticalAlignment = Alignment.CenterVertically
-                            ) {
-                                Text(text = "▶", fontSize = 14.sp)
-                                Spacer(modifier = Modifier.width(8.dp))
-                                Column(modifier = Modifier.weight(1f)) {
-                                    val chipTitle = youtubeTitle ?: nameText.takeIf { it.isNotBlank() }
-                                    if (chipTitle != null) {
-                                        Text(chipTitle, fontSize = 13.sp, fontWeight = FontWeight.SemiBold, color = colors.textBody, maxLines = 2)
-                                    }
-                                    if (youtubeUrlDisplay.isNotBlank()) {
-                                        Text(youtubeUrlDisplay, fontSize = 11.sp, color = Color(0xFF2196F3), maxLines = 1,
-                                            style = TextStyle(textDecoration = TextDecoration.Underline),
-                                            modifier = Modifier.clickable { selectedYoutubeUrl = youtubeUrlDisplay })
-                                    } else if (chipTitle == null) {
-                                        Text("📺 유튜브 요약", fontSize = 13.sp, fontWeight = FontWeight.SemiBold, color = colors.textBody)
-                                    }
-                                }
-                                if (onYoutubeSummarize != null && !isSummarizing && summaryResult == null) {
-                                    Spacer(modifier = Modifier.width(8.dp))
-                                    Text("🤖 요약", fontSize = 12.sp, color = colors.chipText, fontWeight = FontWeight.SemiBold,
-                                        modifier = Modifier.clip(RoundedCornerShape(6.dp)).background(colors.chipBackground)
-                                            .clickable { detectedYoutubeUrl?.let { onYoutubeSummarize(it) } }
-                                            .padding(horizontal = 8.dp, vertical = 4.dp))
+                    val videoId = youtubeUrlDisplay.let {
+                        Regex("""(?:v=|youtu\.be/|shorts/)([a-zA-Z0-9_-]{11})""").find(it)?.groupValues?.get(1)
+                    }
+                    me.pecos.memozy.presentation.screen.memo.components.SummaryCard(
+                        sourceType = me.pecos.memozy.presentation.screen.memo.components.SummarySourceType.YOUTUBE,
+                        url = youtubeUrlDisplay,
+                        title = youtubeTitle ?: nameText.takeIf { it.isNotBlank() },
+                        imageUrl = videoId?.let { "https://img.youtube.com/vi/$it/hqdefault.jpg" },
+                        hasSummary = summaryResult != null || hasYoutubeSummaryContent,
+                        onViewSummary = if (onYoutubeSummarize != null) {
+                            {
+                                if (summaryResult != null || hasYoutubeSummaryContent) {
+                                    selectedYoutubeUrl = youtubeUrlDisplay
+                                } else {
+                                    detectedYoutubeUrl?.let { onYoutubeSummarize(it) }
                                 }
                             }
-                        }
-                        // X 삭제 버튼
-                        Icon(Icons.Default.Close, contentDescription = null, tint = colors.textSecondary,
-                            modifier = Modifier.size(16.dp).align(Alignment.TopEnd).clickable { youtubeChipDismissed = true; showSummary = false })
-                    }
+                        } else null,
+                        onDismiss = { youtubeChipDismissed = true; showSummary = false }
+                    )
                 }
 
-                // 웹 요약 칩 (유튜브 칩 아래)
+                // 웹 요약 카드 (SummaryCard)
                 if ((webSummaryResult != null || savedWebUrl != null) && !webChipDismissed) {
                     Spacer(modifier = Modifier.height(12.dp))
-                    Box {
-                        Row(
-                            modifier = Modifier.fillMaxWidth().clip(RoundedCornerShape(10.dp))
-                                .background(colors.chipBackground.copy(alpha = 0.5f))
-                                .padding(horizontal = 12.dp, vertical = 10.dp),
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            Text(text = "🔗", fontSize = 14.sp)
-                            Spacer(modifier = Modifier.width(8.dp))
-                            Column(modifier = Modifier.weight(1f)) {
-                                val webTitle = webPageTitle ?: nameText.takeIf { it.isNotBlank() }
-                                if (webTitle != null) {
-                                    Text(webTitle, fontSize = 13.sp, fontWeight = FontWeight.SemiBold, color = colors.textBody, maxLines = 2)
-                                }
-                                if (savedWebUrl != null) {
-                                    Text(savedWebUrl!!, fontSize = 11.sp, color = Color(0xFF2196F3), maxLines = 1,
-                                        style = TextStyle(textDecoration = TextDecoration.Underline),
-                                        modifier = Modifier.clickable { selectedWebUrl = savedWebUrl })
-                                } else if (webTitle == null) {
-                                    Text("🔗 웹페이지 요약", fontSize = 13.sp, fontWeight = FontWeight.SemiBold, color = colors.textBody)
-                                }
-                            }
-                        }
-                        Icon(Icons.Default.Close, contentDescription = null, tint = colors.textSecondary,
-                            modifier = Modifier.size(16.dp).align(Alignment.TopEnd).clickable { webChipDismissed = true })
-                    }
+                    me.pecos.memozy.presentation.screen.memo.components.SummaryCard(
+                        sourceType = me.pecos.memozy.presentation.screen.memo.components.SummarySourceType.WEB,
+                        url = savedWebUrl ?: "",
+                        title = webPageTitle ?: nameText.takeIf { it.isNotBlank() },
+                        hasSummary = webSummaryResult != null,
+                        onViewSummary = if (savedWebUrl != null) {
+                            { selectedWebUrl = savedWebUrl }
+                        } else null,
+                        onDismiss = { webChipDismissed = true }
+                    )
                 }
 
                 // 오디오 재생 바 (서식 툴바 아래)

--- a/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/components/SummaryCard.kt
+++ b/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/components/SummaryCard.kt
@@ -1,0 +1,213 @@
+package me.pecos.memozy.presentation.screen.memo.components
+
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.widget.Toast
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material.icons.filled.OpenInBrowser
+import androidx.compose.material.icons.filled.Summarize
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil.compose.AsyncImage
+import me.pecos.memozy.feature.core.resource.R
+import me.pecos.memozy.presentation.theme.LocalAppColors
+
+enum class SummarySourceType { YOUTUBE, WEB, TWITTER }
+
+@Composable
+fun SummaryCard(
+    sourceType: SummarySourceType,
+    url: String,
+    title: String?,
+    imageUrl: String? = null,
+    hasSummary: Boolean = false,
+    onViewSummary: (() -> Unit)? = null,
+    onDismiss: () -> Unit
+) {
+    val colors = LocalAppColors.current
+    val context = LocalContext.current
+
+    Box {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(12.dp))
+                .background(colors.cardBackground)
+        ) {
+            // 프리뷰 이미지
+            if (imageUrl != null) {
+                AsyncImage(
+                    model = imageUrl,
+                    contentDescription = null,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .aspectRatio(16f / 9f)
+                        .clip(RoundedCornerShape(topStart = 12.dp, topEnd = 12.dp)),
+                    contentScale = ContentScale.Crop
+                )
+            }
+
+            Column(modifier = Modifier.padding(12.dp)) {
+                // 소스 태그
+                val sourceEmoji = when (sourceType) {
+                    SummarySourceType.YOUTUBE -> "▶"
+                    SummarySourceType.WEB -> "🔗"
+                    SummarySourceType.TWITTER -> "𝕏"
+                }
+                val sourceLabel = when (sourceType) {
+                    SummarySourceType.YOUTUBE -> "YouTube"
+                    SummarySourceType.WEB -> stringResource(R.string.summary_card_web)
+                    SummarySourceType.TWITTER -> "X / Twitter"
+                }
+                Text(
+                    text = "$sourceEmoji $sourceLabel",
+                    fontSize = 11.sp,
+                    color = colors.textSecondary,
+                    fontWeight = FontWeight.Medium
+                )
+
+                Spacer(modifier = Modifier.height(4.dp))
+
+                // 제목
+                Text(
+                    text = title ?: url,
+                    fontSize = 14.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    color = colors.textTitle,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis
+                )
+
+                if (title != null) {
+                    Text(
+                        text = url,
+                        fontSize = 11.sp,
+                        color = Color(0xFF2196F3),
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(10.dp))
+
+                // 액션 버튼 row
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    // 원본 보기
+                    Row(
+                        modifier = Modifier
+                            .clip(RoundedCornerShape(8.dp))
+                            .background(colors.chipBackground)
+                            .clickable {
+                                val intent = when (sourceType) {
+                                    SummarySourceType.YOUTUBE -> {
+                                        Intent(Intent.ACTION_VIEW, Uri.parse(url)).apply {
+                                            setPackage("com.google.android.youtube")
+                                        }
+                                    }
+                                    else -> Intent(Intent.ACTION_VIEW, Uri.parse(url))
+                                }
+                                try {
+                                    context.startActivity(intent)
+                                } catch (_: Exception) {
+                                    context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
+                                }
+                            }
+                            .padding(horizontal = 10.dp, vertical = 6.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Icon(Icons.Default.OpenInBrowser, null, tint = colors.chipText, modifier = Modifier.size(14.dp))
+                        Spacer(modifier = Modifier.width(4.dp))
+                        Text(stringResource(R.string.summary_card_open), fontSize = 11.sp, color = colors.chipText, fontWeight = FontWeight.Medium)
+                    }
+
+                    // 요약 보기
+                    if (onViewSummary != null) {
+                        Row(
+                            modifier = Modifier
+                                .clip(RoundedCornerShape(8.dp))
+                                .background(
+                                    if (hasSummary) colors.chipBackground
+                                    else Color(0xFF2196F3).copy(alpha = 0.1f)
+                                )
+                                .clickable { onViewSummary() }
+                                .padding(horizontal = 10.dp, vertical = 6.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Icon(Icons.Default.Summarize, null,
+                                tint = if (hasSummary) colors.chipText else Color(0xFF2196F3),
+                                modifier = Modifier.size(14.dp))
+                            Spacer(modifier = Modifier.width(4.dp))
+                            Text(
+                                text = if (hasSummary) stringResource(R.string.summary_card_view_summary) else stringResource(R.string.summary_card_summarize),
+                                fontSize = 11.sp,
+                                color = if (hasSummary) colors.chipText else Color(0xFF2196F3),
+                                fontWeight = FontWeight.Medium
+                            )
+                        }
+                    }
+
+                    // URL 복사
+                    Row(
+                        modifier = Modifier
+                            .clip(RoundedCornerShape(8.dp))
+                            .background(colors.chipBackground)
+                            .clickable {
+                                val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+                                clipboard.setPrimaryClip(ClipData.newPlainText("url", url))
+                                Toast.makeText(context, context.getString(R.string.memo_copied), Toast.LENGTH_SHORT).show()
+                            }
+                            .padding(horizontal = 10.dp, vertical = 6.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Icon(Icons.Default.ContentCopy, null, tint = colors.chipText, modifier = Modifier.size(14.dp))
+                    }
+                }
+            }
+        }
+
+        // 닫기 버튼
+        Icon(
+            Icons.Default.Close, null,
+            tint = colors.textSecondary,
+            modifier = Modifier
+                .size(20.dp)
+                .align(Alignment.TopEnd)
+                .padding(4.dp)
+                .clickable { onDismiss() }
+        )
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,6 +24,7 @@ ktor = "3.1.3"
 kotlinxSerialization = "1.8.1"
 richeditor = "1.0.0-rc11"
 glance = "1.1.1"
+coil = "2.7.0"
 
 [libraries]
 gradlePlugin-android = { module = "com.android.tools.build:gradle", version.ref = "agp" }
@@ -58,6 +59,7 @@ androidx-compose-navigation = { group = "androidx.navigation", name = "navigatio
 kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "kotlinxCoroutines" }
 montage-android = { module = "com.github.wanteddev:montage-android", version.ref = "montageAndroid" }
 richeditor-compose = { module = "com.mohamedrejeb.richeditor:richeditor-compose", version.ref = "richeditor" }
+coil-compose = { group = "io.coil-kt", name = "coil-compose", version.ref = "coil" }
 glance-appwidget = { group = "androidx.glance", name = "glance-appwidget", version.ref = "glance" }
 glance-material3 = { group = "androidx.glance", name = "glance-material3", version.ref = "glance" }
 room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }


### PR DESCRIPTION
## Summary
- 공통 `SummaryCard` Composable 생성 — YouTube/웹/트위터 소스 타입별 분기
- YouTube 썸네일 자동 표시 (`img.youtube.com/vi/{id}/hqdefault.jpg`)
- 통일된 3-버튼 액션 바: **원본 보기** + **요약 보기/AI 요약** + **URL 복사**
- 기존 유튜브/웹 개별 칩 → SummaryCard로 교체
- Coil 이미지 로딩 라이브러리 추가 (v2.7.0)
- 팀 피드백(김성훈) 반영

## Test plan
- [ ] 유튜브 URL 입력 → SummaryCard에 썸네일 + 제목 표시
- [ ] 원본 보기 탭 → 유튜브 앱 실행
- [ ] AI 요약 → 요약 완료 후 "요약 보기"로 버튼 변경
- [ ] URL 복사 버튼 → 클립보드 복사 + 토스트
- [ ] 웹 URL → SummaryCard에 제목 표시 (이미지 없음)
- [ ] X 버튼 → 카드 닫기
- [ ] 라이트/다크 모드 대응

🤖 Generated with [Claude Code](https://claude.com/claude-code)