### PR TITLE
Update: #100 태그 시스템 개선

### DIFF
--- a/data/repository/memo/api/src/main/java/me/pecos/memozy/data/repository/MemoRepository.kt
+++ b/data/repository/memo/api/src/main/java/me/pecos/memozy/data/repository/MemoRepository.kt
@@ -11,6 +11,7 @@ interface MemoRepository {
     suspend fun updateMemo(memo: Memo)
     suspend fun clearAllMemos()
     suspend fun getRecentMemos(limit: Int = 5): List<Memo>
+    suspend fun getMemosOnce(): List<Memo>
 
     // ── Trash ──
     suspend fun softDeleteMemo(id: Int)

--- a/data/repository/memo/impl/src/main/java/me/pecos/memozy/data/repository/MemoRepositoryImpl.kt
+++ b/data/repository/memo/impl/src/main/java/me/pecos/memozy/data/repository/MemoRepositoryImpl.kt
@@ -31,6 +31,8 @@ class MemoRepositoryImpl @Inject constructor(private val memoDao: MemoDao) : Mem
         return memoDao.getRecentMemos(limit)
     }
 
+    override suspend fun getMemosOnce(): List<Memo> = memoDao.getAllMemosOnce()
+
     // ── Trash ──
 
     override suspend fun softDeleteMemo(id: Int) {

--- a/datasource/local/memo/api/src/main/java/me/pecos/memozy/data/datasource/local/MemoDao.kt
+++ b/datasource/local/memo/api/src/main/java/me/pecos/memozy/data/datasource/local/MemoDao.kt
@@ -55,6 +55,9 @@ interface MemoDao {
 
     // ── Backup & Restore ──
 
+    @Query("SELECT * FROM memo WHERE deletedAt IS NULL ORDER BY id ASC")
+    suspend fun getAllMemosOnce(): List<Memo>
+
     @Query("SELECT * FROM memo ORDER BY id ASC")
     suspend fun getAllMemosForBackup(): List<Memo>
 

--- a/datasource/local/memo/api/src/main/java/me/pecos/memozy/data/datasource/local/TagDao.kt
+++ b/datasource/local/memo/api/src/main/java/me/pecos/memozy/data/datasource/local/TagDao.kt
@@ -9,6 +9,13 @@ import kotlinx.coroutines.flow.Flow
 import me.pecos.memozy.data.datasource.local.entity.MemoTag
 import me.pecos.memozy.data.datasource.local.entity.Tag
 
+data class MemoTagRelation(
+    val memoId: Int,
+    val tagId: Int,
+    val tagName: String,
+    val tagEmoji: String
+)
+
 @Dao
 interface TagDao {
     @Query("SELECT * FROM tag ORDER BY name ASC")
@@ -49,6 +56,14 @@ interface TagDao {
     // 태그에 연결된 메모 ID 조회
     @Query("SELECT memoId FROM memo_tag WHERE tagId = :tagId")
     fun getMemoIdsForTag(tagId: Int): Flow<List<Int>>
+
+    // 전체 메모-태그 관계를 태그 정보 포함해서 조회 (reactive)
+    @Query("""
+        SELECT mt.memoId, t.id AS tagId, t.name AS tagName, t.emoji AS tagEmoji
+        FROM memo_tag mt
+        INNER JOIN tag t ON mt.tagId = t.id
+    """)
+    fun getAllMemoTagRelationsFlow(): Flow<List<MemoTagRelation>>
 
     // ── Backup & Restore ──
 

--- a/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/home/HomeScreen.kt
+++ b/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/home/HomeScreen.kt
@@ -24,58 +24,71 @@ import androidx.compose.foundation.gestures.rememberDraggableState
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.ui.unit.IntOffset
 import kotlin.math.roundToInt
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.offset
-import kotlinx.coroutines.launch
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.outlined.RadioButtonUnchecked
 import androidx.compose.material.icons.filled.Delete
-import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Star
-import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.filled.Check
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.SnackbarHost
-import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.wanted.android.wanted.design.actions.button.WantedButton
+import com.wanted.android.wanted.design.actions.button.config.WantedButtonDefaults
+import com.wanted.android.wanted.design.util.ButtonType
+import com.wanted.android.wanted.design.util.ButtonVariant
 import com.wanted.android.wanted.design.theme.DesignSystemTheme
 import me.pecos.memozy.presentation.components.AppPopup
-import me.pecos.memozy.feature.core.resource.CATEGORY_EMOJIS
-import me.pecos.memozy.feature.core.resource.CATEGORY_RES_IDS
 import me.pecos.memozy.presentation.screen.home.components.MemoCardItem
 import me.pecos.memozy.presentation.components.PopupActionArea
 import me.pecos.memozy.presentation.components.PopupNavigation
 import me.pecos.memozy.presentation.components.PopupSize
 import me.pecos.memozy.feature.core.resource.R
 import me.pecos.memozy.presentation.screen.home.model.SortOrder
+import me.pecos.memozy.presentation.screen.home.model.TagUiState
 import me.pecos.memozy.presentation.theme.LocalAppColors
+
+private val SYSTEM_TAG_NAMES = MainViewModel.SYSTEM_TAGS
 
 // ── 홈 화면 ────────────────────────────────────────────────────────────────────
 
@@ -93,29 +106,22 @@ fun HomeScreen(
     val filteredList by viewModel.filteredList.collectAsState()
     val allTags by viewModel.allTags.collectAsState()
     val memoTags by viewModel.memoTags.collectAsState()
-    // 하위호환
-    val selectedCategoryIndex = selectedTagId
-
-    // 메모 태그 로드
-    LaunchedEffect(filteredList) {
-        viewModel.loadMemoTags(filteredList.map { it.id })
-    }
 
     // 스와이프 열린 카드 추적 — null이면 모두 닫힌 상태
     var swipedOpenId by remember { mutableStateOf<Int?>(null) }
     val listState = remember(sortOrder) { LazyListState() }
     // 태그 추가 다이얼로그
     var showAddTagDialog by remember { mutableStateOf(false) }
+    // 태그 필터 팝업
+    var showFilterMenu by remember { mutableStateOf(false) }
+    // 태그 편집 BottomSheet
+    var tagEditMemoId by remember { mutableStateOf<Int?>(null) }
 
     // 다중 선택 모드
     var isSelectionMode by remember { mutableStateOf(false) }
     var selectedIds by remember { mutableStateOf(setOf<Int>()) }
     var showDeleteConfirm by remember { mutableStateOf(false) }
 
-    // 자동 뷰 필터 타입
-    // -1 = 전체, -2 = 일반메모, -3 = 유튜브, -4 = 녹음, 양수 = 사용자 태그 ID
-
-    // containerColor 명시 → MaterialTheme.colorScheme.surface 무시
     Scaffold(containerColor = colors.screenBackground) { innerPadding ->
         Box(
             modifier = Modifier
@@ -154,6 +160,7 @@ fun HomeScreen(
                         )
                     }
                 } else {
+                    // Row 1: "N개 선택됨" (Memozy 텍스트 자리)
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
@@ -161,131 +168,126 @@ fun HomeScreen(
                         verticalAlignment = Alignment.CenterVertically
                     ) {
                         Text(
-                            text = stringResource(R.string.cancel),
-                            fontSize = 14.sp,
-                            fontWeight = FontWeight.Medium,
-                            color = colors.chipText,
-                            modifier = Modifier
-                                .clip(RoundedCornerShape(12.dp))
-                                .clickable {
-                                    isSelectionMode = false
-                                    selectedIds = emptySet()
-                                }
-                                .padding(horizontal = 8.dp, vertical = 6.dp)
-                        )
-                        Spacer(modifier = Modifier.width(12.dp))
-                        Text(
                             text = stringResource(R.string.selected_count, selectedIds.size),
-                            fontSize = 16.sp,
+                            fontSize = 22.sp,
                             fontWeight = FontWeight.Bold,
                             color = colors.topbarTitle,
                             modifier = Modifier.weight(1f)
                         )
-                        val allSelected = selectedIds.size == filteredList.size && filteredList.isNotEmpty()
-                        Text(
-                            text = if (allSelected) stringResource(R.string.deselect_all) else stringResource(R.string.select_all),
-                            fontSize = 13.sp,
-                            fontWeight = FontWeight.Medium,
-                            color = colors.chipText,
-                            modifier = Modifier
-                                .clip(RoundedCornerShape(12.dp))
-                                .clickable {
-                                    selectedIds = if (allSelected) emptySet()
-                                                  else filteredList.map { it.id }.toSet()
-                                }
-                                .padding(horizontal = 8.dp, vertical = 6.dp)
-                        )
-                        Spacer(modifier = Modifier.width(8.dp))
-                        Text(
-                            text = stringResource(R.string.delete_action),
-                            fontSize = 14.sp,
-                            fontWeight = FontWeight.SemiBold,
-                            color = if (selectedIds.isNotEmpty()) Color(0xFFE24B4A) else colors.textSecondary,
-                            modifier = Modifier
-                                .clip(RoundedCornerShape(12.dp))
-                                .clickable(enabled = selectedIds.isNotEmpty()) {
-                                    showDeleteConfirm = true
-                                }
-                                .padding(horizontal = 14.dp, vertical = 6.dp)
-                        )
                     }
-                }
-
-                // 태그 필터 (드롭다운) + 정렬 버튼 — 선택 모드에서 숨김
-                if (!isSelectionMode) {
-                var showFilterMenu by remember { mutableStateOf(false) }
-                val filterAllLabel = stringResource(R.string.filter_all)
-                val autoViews = listOf(
-                    -1 to filterAllLabel,
-                    -2 to stringResource(R.string.filter_memo),
-                    -3 to stringResource(R.string.filter_youtube),
-                    -4 to stringResource(R.string.filter_recording)
-                )
-                val currentLabel = autoViews.firstOrNull { it.first == selectedTagId }?.second
-                    ?: allTags.firstOrNull { it.id == selectedTagId }?.name
-                    ?: filterAllLabel
-
-                Row(
-                    modifier = Modifier.padding(start = 16.dp),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Box {
+                    // Row 2: [취소] [전체선택] [삭제] — 메인화면 필터 Row와 동일 스타일, 우측 정렬
+                    val allSelected = selectedIds.size == filteredList.size && filteredList.isNotEmpty()
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(start = 16.dp, end = 16.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        Spacer(modifier = Modifier.weight(1f))
                         Row(
                             modifier = Modifier
                                 .border(1.5.dp, colors.cardBorder, RoundedCornerShape(12.dp))
-                                .clickable { showFilterMenu = true }
-                                .padding(horizontal = 14.dp, vertical = 6.dp),
+                                .clickable {
+                                    isSelectionMode = false
+                                    selectedIds = emptySet()
+                                }
+                                .padding(horizontal = 12.dp, vertical = 6.dp),
                             verticalAlignment = Alignment.CenterVertically
                         ) {
                             Text(
-                                text = currentLabel,
+                                text = stringResource(R.string.cancel),
                                 fontSize = 13.sp,
                                 fontWeight = FontWeight.Medium,
                                 color = colors.textSecondary
                             )
-                            Spacer(modifier = Modifier.width(4.dp))
-                            Icon(
-                                imageVector = Icons.Default.KeyboardArrowDown,
-                                contentDescription = null,
-                                tint = colors.textSecondary,
-                                modifier = Modifier.size(16.dp)
+                        }
+                        Row(
+                            modifier = Modifier
+                                .border(1.5.dp, colors.cardBorder, RoundedCornerShape(12.dp))
+                                .clickable {
+                                    selectedIds = if (allSelected) emptySet()
+                                               else filteredList.map { it.id }.toSet()
+                                }
+                                .padding(horizontal = 12.dp, vertical = 6.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Text(
+                                text = if (allSelected) stringResource(R.string.deselect_all)
+                                        else stringResource(R.string.select_all),
+                                fontSize = 13.sp,
+                                fontWeight = FontWeight.Medium,
+                                color = colors.chipText
                             )
                         }
-                        androidx.compose.material3.DropdownMenu(
-                            expanded = showFilterMenu,
-                            onDismissRequest = { showFilterMenu = false }
-                        ) {
-                            // 자동 뷰
-                            autoViews.forEach { (id, label) ->
-                                androidx.compose.material3.DropdownMenuItem(
-                                    text = { Text(label, fontWeight = if (selectedTagId == id) FontWeight.Bold else FontWeight.Normal) },
-                                    onClick = { viewModel.setSelectedTag(id); showFilterMenu = false }
-                                )
-                            }
-                            if (allTags.isNotEmpty()) {
-                                androidx.compose.material3.HorizontalDivider()
-                                // 사용자 태그
-                                allTags.forEach { tag ->
-                                    androidx.compose.material3.DropdownMenuItem(
-                                        text = { Text(tag.name, fontWeight = if (selectedTagId == tag.id) FontWeight.Bold else FontWeight.Normal) },
-                                        onClick = { viewModel.setSelectedTag(tag.id); showFilterMenu = false }
-                                    )
+                        Row(
+                            modifier = Modifier
+                                .border(1.5.dp, colors.cardBorder, RoundedCornerShape(12.dp))
+                                .clickable(enabled = selectedIds.isNotEmpty()) {
+                                    showDeleteConfirm = true
                                 }
-                            }
-                            androidx.compose.material3.HorizontalDivider()
-                            // 태그 추가
-                            androidx.compose.material3.DropdownMenuItem(
-                                text = { Text("+ 태그 추가", color = colors.chipText) },
-                                onClick = { showFilterMenu = false; showAddTagDialog = true }
+                                .padding(horizontal = 12.dp, vertical = 6.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Text(
+                                text = if (selectedIds.isNotEmpty())
+                                    "${stringResource(R.string.delete_action)} ${selectedIds.size}개"
+                                else
+                                    stringResource(R.string.delete_action),
+                                fontSize = 13.sp,
+                                fontWeight = FontWeight.Medium,
+                                color = if (selectedIds.isNotEmpty()) Color(0xFFE24B4A)
+                                        else colors.textSecondary
                             )
                         }
                     }
-                    Spacer(modifier = Modifier.width(8.dp))
+                }
+
+                // 태그 필터 버튼 + 정렬 버튼 — 선택 모드에서 숨김
+                if (!isSelectionMode) {
+                val currentFilterLabel = when (selectedTagId) {
+                    -1 -> stringResource(R.string.filter_all)
+                    else -> allTags.firstOrNull { it.id == selectedTagId }?.name
+                        ?: stringResource(R.string.filter_all)
+                }
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(start = 16.dp, end = 16.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    // 태그 필터 버튼 (AppPopup 트리거)
+                    Row(
+                        modifier = Modifier
+                            .border(1.5.dp, colors.cardBorder, RoundedCornerShape(12.dp))
+                            .clickable { showFilterMenu = true }
+                            .padding(horizontal = 12.dp, vertical = 6.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(4.dp)
+                    ) {
+                        Text(
+                            text = currentFilterLabel,
+                            fontSize = 13.sp,
+                            fontWeight = FontWeight.Medium,
+                            color = colors.textSecondary
+                        )
+                        Icon(
+                            imageVector = Icons.Default.KeyboardArrowDown,
+                            contentDescription = null,
+                            tint = colors.textSecondary,
+                            modifier = Modifier.size(16.dp)
+                        )
+                    }
+
+                    Spacer(modifier = Modifier.weight(1f))
+
+                    // 정렬 버튼
                     Row(
                         modifier = Modifier
                             .border(1.5.dp, colors.cardBorder, RoundedCornerShape(12.dp))
                             .clickable { viewModel.toggleSortOrder() }
-                            .padding(horizontal = 14.dp, vertical = 6.dp),
+                            .padding(horizontal = 12.dp, vertical = 6.dp),
                         verticalAlignment = Alignment.CenterVertically
                     ) {
                         Text(
@@ -298,7 +300,8 @@ fun HomeScreen(
                             color = colors.textSecondary
                         )
                     }
-                    Spacer(modifier = Modifier.width(8.dp))
+
+                    // 선택 버튼
                     Text(
                         text = stringResource(R.string.select),
                         fontSize = 13.sp,
@@ -329,7 +332,6 @@ fun HomeScreen(
                         )
 
                         if (isSelectionMode) {
-                            // ── 선택 모드: 체크 + 카드 (스와이프 없음) ──
                             val isSelected = memo.id in selectedIds
                             Row(
                                 modifier = itemModifier
@@ -340,6 +342,7 @@ fun HomeScreen(
                                     },
                                 verticalAlignment = Alignment.CenterVertically
                             ) {
+                                // 왼쪽: 체크 점
                                 Box(
                                     modifier = Modifier.width(40.dp),
                                     contentAlignment = Alignment.Center
@@ -348,16 +351,17 @@ fun HomeScreen(
                                         imageVector = if (isSelected) Icons.Default.CheckCircle
                                                       else Icons.Outlined.RadioButtonUnchecked,
                                         contentDescription = null,
-                                        tint = if (isSelected) Color(0xFF2196F3) else colors.textSecondary,
-                                        modifier = Modifier.size(24.dp)
+                                        tint = if (isSelected) Color(0xFF2196F3)
+                                               else colors.textSecondary.copy(alpha = 0.4f),
+                                        modifier = Modifier.size(22.dp)
                                     )
                                 }
+                                // 오른쪽: 카드 (살짝 밀린 상태)
                                 Box(modifier = Modifier.weight(1f)) {
                                     MemoCardItem(memo = memo, tags = memoTags[memo.id] ?: emptyList())
                                 }
                             }
                         } else {
-                            // ── 일반 모드: 스와이프 (기존 로직) ──
                             val revealWidth = 80f
                             val revealPx = with(androidx.compose.ui.platform.LocalDensity.current) { revealWidth.dp.toPx() }
                             val isOpen = swipedOpenId == memo.id
@@ -370,7 +374,6 @@ fun HomeScreen(
                             )
 
                             Box(modifier = itemModifier.fillMaxWidth()) {
-                                // 뒤쪽 액션 버튼
                                 Row(
                                     modifier = Modifier
                                         .matchParentSize()
@@ -378,7 +381,6 @@ fun HomeScreen(
                                         .clip(RoundedCornerShape(12.dp)),
                                     horizontalArrangement = Arrangement.SpaceBetween
                                 ) {
-                                    // 핀 토글
                                     Box(
                                         modifier = Modifier
                                             .width(revealWidth.dp)
@@ -398,7 +400,6 @@ fun HomeScreen(
                                             )
                                         }
                                     }
-                                    // 삭제
                                     Box(
                                         modifier = Modifier
                                             .width(revealWidth.dp)
@@ -420,7 +421,6 @@ fun HomeScreen(
                                     }
                                 }
 
-                                // 앞쪽 카드
                                 val dragState = rememberDraggableState { delta ->
                                     rawOffset = (rawOffset + delta).coerceIn(-revealPx, revealPx)
                                     swipedOpenId = memo.id
@@ -449,7 +449,11 @@ fun HomeScreen(
                                             }
                                         }
                                 ) {
-                                    MemoCardItem(memo = memo, tags = memoTags[memo.id] ?: emptyList())
+                                    MemoCardItem(
+                                        memo = memo,
+                                        tags = memoTags[memo.id] ?: emptyList(),
+                                        onTagsClick = { tagEditMemoId = memo.id }
+                                    )
                                 }
                             }
                         }
@@ -485,12 +489,12 @@ fun HomeScreen(
 
     // 다중 선택 삭제 확인 다이얼로그
     if (showDeleteConfirm) {
-        me.pecos.memozy.presentation.components.AppPopup(
+        AppPopup(
             onDismissRequest = { showDeleteConfirm = false },
             title = stringResource(R.string.delete_selected_title),
-            navigation = me.pecos.memozy.presentation.components.PopupNavigation.EMPHASIZED,
-            size = me.pecos.memozy.presentation.components.PopupSize.MEDIUM,
-            actionArea = me.pecos.memozy.presentation.components.PopupActionArea.NEUTRAL,
+            navigation = PopupNavigation.EMPHASIZED,
+            size = PopupSize.MEDIUM,
+            actionArea = PopupActionArea.NEUTRAL,
             primaryButtonText = stringResource(R.string.delete_action),
             isPrimaryDestructive = true,
             onPrimaryClick = {
@@ -504,43 +508,348 @@ fun HomeScreen(
         ) {
             Text(
                 stringResource(R.string.delete_selected_message, selectedIds.size),
-                color = colors.textBody
+                color = LocalAppColors.current.textBody
             )
         }
     }
 
-    // 태그 추가 다이얼로그
+    // 태그 추가 다이얼로그 (AppPopup 사용)
     if (showAddTagDialog) {
         var tagName by remember { mutableStateOf("") }
-        androidx.compose.material3.AlertDialog(
-            onDismissRequest = { showAddTagDialog = false },
-            title = { Text(stringResource(R.string.add_tag), fontWeight = FontWeight.Bold) },
-            text = {
-                androidx.compose.material3.OutlinedTextField(
-                    value = tagName,
-                    onValueChange = { tagName = it },
-                    placeholder = { Text(stringResource(R.string.tag_name)) },
-                    singleLine = true,
-                    modifier = Modifier.fillMaxWidth()
-                )
+        AppPopup(
+            onDismissRequest = { showAddTagDialog = false; tagName = "" },
+            title = stringResource(R.string.add_tag),
+            navigation = PopupNavigation.EMPHASIZED,
+            size = PopupSize.MEDIUM,
+            actionArea = PopupActionArea.NEUTRAL,
+            primaryButtonText = stringResource(R.string.add),
+            onPrimaryClick = {
+                if (tagName.isNotBlank()) {
+                    viewModel.createTag(tagName.trim())
+                    showAddTagDialog = false
+                    tagName = ""
+                }
             },
-            confirmButton = {
-                androidx.compose.material3.TextButton(
-                    onClick = {
-                        if (tagName.isNotBlank()) {
-                            viewModel.createTag(tagName.trim())
-                            showAddTagDialog = false
-                        }
+            secondaryButtonText = stringResource(R.string.cancel),
+            onSecondaryClick = { showAddTagDialog = false; tagName = "" }
+        ) {
+            val colors2 = LocalAppColors.current
+            val focusRequester = remember { FocusRequester() }
+            BasicTextField(
+                value = tagName,
+                onValueChange = { tagName = it },
+                singleLine = true,
+                textStyle = TextStyle(fontSize = 14.sp, color = colors2.textTitle),
+                cursorBrush = SolidColor(colors2.chipText),
+                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                keyboardActions = KeyboardActions(onDone = {
+                    if (tagName.isNotBlank()) {
+                        viewModel.createTag(tagName.trim())
+                        showAddTagDialog = false
+                        tagName = ""
                     }
-                ) { Text(stringResource(R.string.add)) }
+                }),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .focusRequester(focusRequester),
+                decorationBox = { innerTextField ->
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .border(1.dp, colors2.cardBorder, RoundedCornerShape(8.dp))
+                            .padding(horizontal = 12.dp, vertical = 10.dp)
+                    ) {
+                        if (tagName.isEmpty()) {
+                            Text(
+                                text = stringResource(R.string.tag_name),
+                                fontSize = 14.sp,
+                                color = colors2.textSecondary
+                            )
+                        }
+                        innerTextField()
+                    }
+                }
+            )
+            LaunchedEffect(Unit) { focusRequester.requestFocus() }
+        }
+    }
+
+    // 태그 필터 선택 팝업 (AppPopup)
+    if (showFilterMenu) {
+        TagFilterPopup(
+            selectedTagId = selectedTagId,
+            allTags = allTags,
+            onSelectTag = { tagId ->
+                viewModel.setSelectedTag(tagId)
+                showFilterMenu = false
             },
-            dismissButton = {
-                androidx.compose.material3.TextButton(
-                    onClick = { showAddTagDialog = false }
-                ) { Text(stringResource(R.string.cancel)) }
-            }
+            onAddTag = {
+                showFilterMenu = false
+                showAddTagDialog = true
+            },
+            onDismiss = { showFilterMenu = false }
+        )
+    }
+
+    // 태그 편집 BottomSheet
+    tagEditMemoId?.let { memoId ->
+        TagEditBottomSheet(
+            memoId = memoId,
+            currentTags = memoTags[memoId] ?: emptyList(),
+            allTags = allTags,
+            onAddTag = { tagId -> viewModel.addTagToMemo(memoId, tagId) },
+            onRemoveTag = { tagId -> viewModel.removeTagFromMemo(memoId, tagId) },
+            onCreateTag = { name -> viewModel.createTag(name) },
+            onDismiss = { tagEditMemoId = null }
         )
     }
 }
 
-// Preview removed: HomeScreen requires MainViewModel instance
+// ── 태그 필터 팝업 ─────────────────────────────────────────────────────────────
+
+@Composable
+private fun TagFilterPopup(
+    selectedTagId: Int,
+    allTags: List<TagUiState>,
+    onSelectTag: (Int) -> Unit,
+    onAddTag: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    val colors = LocalAppColors.current
+
+    AppPopup(
+        onDismissRequest = onDismiss,
+        title = "태그 필터",
+        navigation = PopupNavigation.EMPHASIZED,
+        size = PopupSize.LARGE,
+        actionArea = PopupActionArea.NONE
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .verticalScroll(rememberScrollState())
+        ) {
+            // 전체
+            TagFilterRow(
+                label = "전체",
+                selected = selectedTagId == -1,
+                onClick = { onSelectTag(-1) }
+            )
+            allTags.forEach { tag ->
+                HorizontalDivider(color = colors.cardBorder)
+                TagFilterRow(
+                    label = tag.name,
+                    selected = selectedTagId == tag.id,
+                    onClick = { onSelectTag(tag.id) }
+                )
+            }
+            Spacer(modifier = Modifier.height(12.dp))
+            WantedButton(
+                text = "+ 새 태그 만들기",
+                modifier = Modifier.fillMaxWidth(),
+                buttonDefault = WantedButtonDefaults.getDefault(
+                    type = ButtonType.ASSISTIVE,
+                    variant = ButtonVariant.OUTLINED
+                ).copy(contentColor = colors.textSecondary),
+                onClick = onAddTag
+            )
+        }
+    }
+}
+
+@Composable
+private fun TagFilterRow(
+    label: String,
+    selected: Boolean,
+    onClick: () -> Unit
+) {
+    val colors = LocalAppColors.current
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onClick() }
+            .padding(vertical = 14.dp, horizontal = 2.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = label,
+            fontSize = 15.sp,
+            fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Normal,
+            color = if (selected) colors.chipText else colors.textTitle,
+            modifier = Modifier.weight(1f)
+        )
+        if (selected) {
+            Icon(
+                imageVector = Icons.Default.Check,
+                contentDescription = null,
+                tint = colors.chipText,
+                modifier = Modifier.size(18.dp)
+            )
+        }
+    }
+}
+
+// ── 태그 편집 바텀시트 ──────────────────────────────────────────────────────────
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+@Composable
+fun TagEditBottomSheet(
+    memoId: Int,
+    currentTags: List<TagUiState>,
+    allTags: List<TagUiState>,
+    onAddTag: (Int) -> Unit,
+    onRemoveTag: (Int) -> Unit,
+    onCreateTag: (String) -> Unit,
+    onDismiss: () -> Unit
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val colors = LocalAppColors.current
+    var showCreateTagField by remember { mutableStateOf(false) }
+    var newTagName by remember { mutableStateOf("") }
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        containerColor = colors.cardBackground
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp)
+                .padding(bottom = 40.dp)
+        ) {
+            // 헤더
+            Text(
+                text = "태그 편집",
+                fontWeight = FontWeight.Bold,
+                fontSize = 17.sp,
+                color = colors.textTitle
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // 현재 태그
+            if (currentTags.isNotEmpty()) {
+                Text("현재 태그", fontSize = 11.sp, color = colors.textSecondary, fontWeight = FontWeight.Medium)
+                Spacer(modifier = Modifier.height(8.dp))
+                FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    currentTags.forEach { tag ->
+                        val isSystem = tag.name in SYSTEM_TAG_NAMES
+                        Row(
+                            modifier = Modifier
+                                .padding(bottom = 8.dp)
+                                .background(colors.chipBackground, RoundedCornerShape(50))
+                                .padding(
+                                    start = 10.dp,
+                                    end = if (isSystem) 10.dp else 6.dp,
+                                    top = 5.dp,
+                                    bottom = 5.dp
+                                ),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Text(tag.name, fontSize = 13.sp, color = colors.chipText, fontWeight = FontWeight.Medium)
+                            if (!isSystem) {
+                                Spacer(modifier = Modifier.width(4.dp))
+                                Icon(
+                                    imageVector = Icons.Default.Close,
+                                    contentDescription = "제거",
+                                    modifier = Modifier
+                                        .size(14.dp)
+                                        .clickable { onRemoveTag(tag.id) },
+                                    tint = colors.chipText.copy(alpha = 0.6f)
+                                )
+                            }
+                        }
+                    }
+                }
+                Spacer(modifier = Modifier.height(16.dp))
+                HorizontalDivider(color = colors.cardBorder)
+                Spacer(modifier = Modifier.height(16.dp))
+            }
+
+            // 추가 가능한 태그
+            val availableTags = allTags.filter { all -> currentTags.none { it.id == all.id } }
+            if (availableTags.isNotEmpty()) {
+                Text("태그 추가", fontSize = 11.sp, color = colors.textSecondary, fontWeight = FontWeight.Medium)
+                Spacer(modifier = Modifier.height(8.dp))
+                FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    availableTags.forEach { tag ->
+                        Box(
+                            modifier = Modifier
+                                .padding(bottom = 8.dp)
+                                .border(1.dp, colors.cardBorder, RoundedCornerShape(50))
+                                .clickable { onAddTag(tag.id) }
+                                .padding(horizontal = 10.dp, vertical = 5.dp)
+                        ) {
+                            Text("+ ${tag.name}", fontSize = 13.sp, color = colors.textSecondary)
+                        }
+                    }
+                }
+                Spacer(modifier = Modifier.height(8.dp))
+            }
+
+            // 새 태그 생성
+            if (showCreateTagField) {
+                Spacer(modifier = Modifier.height(4.dp))
+                val focusRequester = remember { FocusRequester() }
+                BasicTextField(
+                    value = newTagName,
+                    onValueChange = { newTagName = it },
+                    singleLine = true,
+                    textStyle = TextStyle(fontSize = 14.sp, color = colors.textTitle),
+                    cursorBrush = SolidColor(colors.chipText),
+                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                    keyboardActions = KeyboardActions(onDone = {
+                        if (newTagName.isNotBlank()) {
+                            onCreateTag(newTagName.trim())
+                            newTagName = ""
+                            showCreateTagField = false
+                        }
+                    }),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .focusRequester(focusRequester),
+                    decorationBox = { innerTextField ->
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .border(1.dp, colors.cardBorder, RoundedCornerShape(8.dp))
+                                .padding(horizontal = 12.dp, vertical = 10.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Box(modifier = Modifier.weight(1f)) {
+                                if (newTagName.isEmpty()) {
+                                    Text("태그 이름", fontSize = 14.sp, color = colors.textSecondary)
+                                }
+                                innerTextField()
+                            }
+                            Icon(
+                                imageVector = Icons.Default.Add,
+                                contentDescription = "추가",
+                                tint = if (newTagName.isNotBlank()) colors.chipText else colors.textSecondary,
+                                modifier = Modifier
+                                    .size(20.dp)
+                                    .clickable(enabled = newTagName.isNotBlank()) {
+                                        onCreateTag(newTagName.trim())
+                                        newTagName = ""
+                                        showCreateTagField = false
+                                    }
+                            )
+                        }
+                    }
+                )
+                LaunchedEffect(Unit) { focusRequester.requestFocus() }
+            } else {
+                Spacer(modifier = Modifier.height(4.dp))
+                WantedButton(
+                    text = "+ 새 태그 만들기",
+                    modifier = Modifier.fillMaxWidth(),
+                    buttonDefault = WantedButtonDefaults.getDefault(
+                        type = ButtonType.ASSISTIVE,
+                        variant = ButtonVariant.OUTLINED
+                    ).copy(contentColor = colors.textSecondary),
+                    onClick = { showCreateTagField = true }
+                )
+            }
+        }
+    }
+}

--- a/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/home/MainViewModel.kt
+++ b/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/home/MainViewModel.kt
@@ -1,8 +1,10 @@
 package me.pecos.memozy.presentation.screen.home
 
+import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -18,6 +20,7 @@ import me.pecos.memozy.presentation.screen.home.model.MemoUiState
 import me.pecos.memozy.presentation.screen.home.model.SortOrder
 import me.pecos.memozy.data.datasource.local.TagDao
 import me.pecos.memozy.data.datasource.local.entity.Memo
+import me.pecos.memozy.data.datasource.local.entity.MemoTag
 import me.pecos.memozy.data.datasource.local.entity.Tag
 import me.pecos.memozy.data.repository.MemoRepository
 import me.pecos.memozy.presentation.screen.home.model.TagUiState
@@ -25,11 +28,53 @@ import javax.inject.Inject
 
 @HiltViewModel
 class MainViewModel @Inject constructor(
+    @ApplicationContext private val context: Context,
     private val repository: MemoRepository,
     private val tagDao: TagDao
 ) : ViewModel() {
 
-    // 전체 태그 목록
+    companion object {
+        private val YOUTUBE_REGEX = Regex("""(?:youtube\.com/watch\?v=|youtu\.be/|youtube\.com/shorts/)""")
+        val SYSTEM_TAGS = setOf("유튜브", "웹", "녹음", "메모")
+    }
+
+    init {
+        migrateLegacyMemos()
+    }
+
+    private fun migrateLegacyMemos() {
+        viewModelScope.launch(Dispatchers.IO) {
+            val prefs = context.getSharedPreferences("settings", Context.MODE_PRIVATE)
+            if (prefs.getBoolean("tag_migrated_v1", false)) return@launch
+
+            val allMemos = repository.getMemosOnce()
+            val taggedIds = tagDao.getAllMemoTagsOnce().map { it.memoId }.toSet()
+
+            val tagCache = tagDao.getAllTagsOnce().associateBy { it.name }.toMutableMap()
+
+            suspend fun getOrCreateTag(name: String): Tag {
+                return tagCache[name] ?: run {
+                    val newId = tagDao.insertTag(Tag(name = name))
+                    Tag(id = newId.toInt(), name = name).also { tagCache[name] = it }
+                }
+            }
+
+            allMemos.filter { it.id !in taggedIds }.forEach { memo ->
+                val tagName = when {
+                    memo.audioPath != null -> "녹음"
+                    YOUTUBE_REGEX.containsMatchIn(memo.content) -> "유튜브"
+                    else -> "메모"
+                }
+                val tag = getOrCreateTag(tagName)
+                tagDao.insertMemoTag(MemoTag(memoId = memo.id, tagId = tag.id))
+            }
+
+            prefs.edit().putBoolean("tag_migrated_v1", true).apply()
+            // memoTags Flow가 DB 변경을 자동 감지하므로 별도 갱신 불필요
+        }
+    }
+
+    // 전체 태그 목록 (reactive)
     val allTags = tagDao.getAllTags()
         .map { list -> list.map { TagUiState(it.id, it.name, it.emoji) } }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
@@ -38,46 +83,20 @@ class MainViewModel @Inject constructor(
         .map { list -> list.map { it.toUiState() } }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
 
-    fun addMemo(name: String, categoryId: Int, content: String) {
-        viewModelScope.launch {
-            repository.addMemo(
-                Memo(
-                    name = name,
-                    categoryId = categoryId,
-                    content = content,
-                    createdAt = System.currentTimeMillis(),
-                    format = MemoFormat.MARKDOWN
-                )
-            )
+    // 메모별 태그 — DB 변경 시 자동 갱신 (reactive)
+    val memoTags: StateFlow<Map<Int, List<TagUiState>>> = tagDao.getAllMemoTagRelationsFlow()
+        .map { relations ->
+            relations.groupBy { it.memoId }
+                .mapValues { (_, tags) -> tags.map { TagUiState(it.tagId, it.tagName, it.tagEmoji) } }
         }
-    }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyMap())
 
     // -1 = 전체, 0+ = 태그 ID
     private val _selectedTagId = MutableStateFlow(-1)
     val selectedTagId: StateFlow<Int> = _selectedTagId
 
-    // 하위호환: 기존 HomeScreen에서 사용
-    val selectedCategoryIndex: StateFlow<Int> = _selectedTagId
-
-    fun setSelectedCategory(index: Int) {
-        _selectedTagId.value = index
-    }
-
     fun setSelectedTag(tagId: Int) {
         _selectedTagId.value = tagId
-    }
-
-    // 메모별 태그 로드
-    private val _memoTags = MutableStateFlow<Map<Int, List<TagUiState>>>(emptyMap())
-    val memoTags: StateFlow<Map<Int, List<TagUiState>>> = _memoTags
-
-    fun loadMemoTags(memoIds: List<Int>) {
-        viewModelScope.launch(Dispatchers.IO) {
-            val tagsMap = memoIds.associateWith { memoId ->
-                tagDao.getTagsForMemo(memoId).map { TagUiState(it.id, it.name, it.emoji) }
-            }
-            _memoTags.value = tagsMap
-        }
     }
 
     private val _searchQuery = MutableStateFlow("")
@@ -95,17 +114,13 @@ class MainViewModel @Inject constructor(
     }
 
     val filteredList: StateFlow<List<MemoUiState>> = combine(
-        uiState, _selectedTagId, _searchQuery, _sortOrder, _memoTags
+        uiState, _selectedTagId, _searchQuery, _sortOrder, memoTags
     ) { list, tagId, query, sort, tagsMap ->
-        val youtubeRegex = Regex("""(?:youtube\.com/watch\?v=|youtu\.be/|youtube\.com/shorts/)""")
         list
             .filter { memo ->
                 when (tagId) {
-                    -1 -> true // 전체
-                    -2 -> memo.audioPath == null && !youtubeRegex.containsMatchIn(memo.content) // 일반 메모
-                    -3 -> youtubeRegex.containsMatchIn(memo.content) // 유튜브
-                    -4 -> memo.audioPath != null // 녹음
-                    else -> tagsMap[memo.id]?.any { it.id == tagId } == true // 사용자 태그
+                    -1 -> true
+                    else -> tagsMap[memo.id]?.any { it.id == tagId } == true
                 }
             }
             .filter { memo ->
@@ -117,42 +132,38 @@ class MainViewModel @Inject constructor(
                 if (sort == SortOrder.NEWEST) filtered else filtered.reversed()
             }
     }.flowOn(Dispatchers.Default)
-     .stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
+     .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
 
     fun deleteMemo(id: Int) {
-        viewModelScope.launch {
-            repository.softDeleteMemo(id)
-        }
+        viewModelScope.launch { repository.softDeleteMemo(id) }
     }
 
     fun deleteMemos(ids: Set<Int>) {
-        viewModelScope.launch {
-            repository.softDeleteMemos(ids.toList())
-        }
+        viewModelScope.launch { repository.softDeleteMemos(ids.toList()) }
     }
 
     fun updateMemo(memo: MemoUiState) {
-        viewModelScope.launch {
-            repository.updateMemo(memo.toMemo())
-        }
+        viewModelScope.launch { repository.updateMemo(memo.toMemo()) }
     }
 
     fun createTag(name: String, emoji: String = "🏷️") {
-        viewModelScope.launch {
-            tagDao.insertTag(Tag(name = name, emoji = emoji))
-        }
+        viewModelScope.launch { tagDao.insertTag(Tag(name = name, emoji = emoji)) }
     }
 
     fun deleteTag(tagId: Int) {
-        viewModelScope.launch {
-            tagDao.deleteTagById(tagId)
-        }
+        viewModelScope.launch { tagDao.deleteTagById(tagId) }
+    }
+
+    fun addTagToMemo(memoId: Int, tagId: Int) {
+        viewModelScope.launch { tagDao.insertMemoTag(MemoTag(memoId, tagId)) }
+    }
+
+    fun removeTagFromMemo(memoId: Int, tagId: Int) {
+        viewModelScope.launch { tagDao.removeMemoTag(memoId, tagId) }
     }
 
     fun togglePin(memo: MemoUiState) {
-        viewModelScope.launch {
-            repository.updateMemo(memo.copy(isPinned = !memo.isPinned).toMemo())
-        }
+        viewModelScope.launch { repository.updateMemo(memo.copy(isPinned = !memo.isPinned).toMemo()) }
     }
 }
 

--- a/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/home/components/MemoCard.kt
+++ b/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/home/components/MemoCard.kt
@@ -3,6 +3,7 @@ package me.pecos.memozy.presentation.screen.home.components
 import android.content.Context
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -45,7 +46,8 @@ import me.pecos.memozy.presentation.theme.LocalAppColors
 @Composable
 fun MemoCardItem(
     memo: MemoUiState,
-    tags: List<TagUiState> = emptyList()
+    tags: List<TagUiState> = emptyList(),
+    onTagsClick: (() -> Unit)? = null
 ) {
     val colors = LocalAppColors.current
     val context = LocalContext.current
@@ -102,7 +104,10 @@ fun MemoCardItem(
                     }
                     if (tags.isNotEmpty()) {
                         Spacer(modifier = Modifier.height(4.dp))
-                        Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                        Row(
+                            horizontalArrangement = Arrangement.spacedBy(4.dp),
+                            modifier = if (onTagsClick != null) Modifier.clickable(onClick = onTagsClick) else Modifier
+                        ) {
                             tags.take(2).forEach { tag ->
                                 Text(
                                     text = tag.name,

--- a/feature/memo-plain/impl/src/main/java/me/pecos/memozy/feature/memoplain/impl/MemoPlainNavigationImpl.kt
+++ b/feature/memo-plain/impl/src/main/java/me/pecos/memozy/feature/memoplain/impl/MemoPlainNavigationImpl.kt
@@ -718,6 +718,13 @@ class MemoPlainNavigationImpl @Inject constructor(
                         if (webSummaryResult != null) {
                             autoTag(finalMemoId, "웹")
                         }
+                        val hasAutoTag = memoWithAudio.audioPath != null
+                            || youtubeRegex.containsMatchIn(memoWithAudio.content)
+                            || inlineSummaryState is SummaryState.Success
+                            || webSummaryResult != null
+                        if (!hasAutoTag) {
+                            autoTag(finalMemoId, "메모")
+                        }
                         onNavigateToHome()
                     }
                 },


### PR DESCRIPTION
## Summary
- 일반 메모에 "메모" 자동 태그 부여 + 기존 메모 마이그레이션
- 태그 필터 UI: AppPopup 팝업 방식 (디자인 시스템 적용)
- 태그 편집: MemoCard 태그 클릭 → BottomSheet (기본 태그 보호)
- memoTags를 reactive Flow로 전환하여 순환 의존 버그 해소
- 선택 모드 UI 정비: 메인화면과 동일 버튼 스타일 + 우측 정렬

## Test plan
- [ ] 메인화면 → 필터 버튼(전체▼) 클릭 → 태그 선택 팝업 정상 동작
- [ ] 태그 필터링 (메모/유튜브/웹/녹음) 정상 작동
- [ ] 메모 카드 태그 칩 클릭 → BottomSheet 열림, 태그 추가/삭제
- [ ] 기본 태그(유튜브/웹/녹음/메모)는 BottomSheet에서 삭제 불가
- [ ] 선택 모드: 취소/전체선택/삭제 버튼 크기·스타일·정렬 확인
- [ ] 선택 모드: 카드 좌측 체크 점 표시 + 클릭 시 선택/해제
- [ ] 기존 메모에 자동 태그 마이그레이션 (첫 실행 시)

🤖 Generated with [Claude Code](https://claude.com/claude-code)