### PR TITLE
Fix: #117 #116 YouTube 캐시 키 버그 수정 + 요약 버튼 숨기기

### DIFF
--- a/datasource/local/memo/api/src/main/java/me/pecos/memozy/data/datasource/local/YoutubeSummaryDao.kt
+++ b/datasource/local/memo/api/src/main/java/me/pecos/memozy/data/datasource/local/YoutubeSummaryDao.kt
@@ -8,8 +8,8 @@ import me.pecos.memozy.data.datasource.local.entity.YoutubeSummary
 
 @Dao
 interface YoutubeSummaryDao {
-    @Query("SELECT * FROM youtube_summary WHERE videoId = :videoId")
-    suspend fun getByVideoId(videoId: String): YoutubeSummary?
+    @Query("SELECT * FROM youtube_summary WHERE videoId = :videoId AND mode = :mode AND language = :language")
+    suspend fun getByKey(videoId: String, mode: String, language: String): YoutubeSummary?
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insert(summary: YoutubeSummary)

--- a/datasource/local/memo/api/src/main/java/me/pecos/memozy/data/datasource/local/entity/YoutubeSummary.kt
+++ b/datasource/local/memo/api/src/main/java/me/pecos/memozy/data/datasource/local/entity/YoutubeSummary.kt
@@ -1,12 +1,12 @@
 package me.pecos.memozy.data.datasource.local.entity
 
 import androidx.room.Entity
-import androidx.room.PrimaryKey
 
-@Entity(tableName = "youtube_summary")
+@Entity(tableName = "youtube_summary", primaryKeys = ["videoId", "mode", "language"])
 data class YoutubeSummary(
-    @PrimaryKey
     val videoId: String,
+    val mode: String = "SIMPLE",
+    val language: String = "ko",
     val url: String,
     val summary: String,
     val createdAt: Long = System.currentTimeMillis()

--- a/datasource/local/memo/impl/src/main/java/me/pecos/memozy/data/datasource/local/MemoDatabase.kt
+++ b/datasource/local/memo/impl/src/main/java/me/pecos/memozy/data/datasource/local/MemoDatabase.kt
@@ -239,6 +239,24 @@ val MIGRATION_14_15 = object : Migration(14, 15) {
     }
 }
 
+val MIGRATION_15_16 = object : Migration(15, 16) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        // youtube_summary 테이블을 복합 PK (videoId, mode, language)로 재생성
+        database.execSQL("DROP TABLE IF EXISTS `youtube_summary`")
+        database.execSQL("""
+            CREATE TABLE IF NOT EXISTS `youtube_summary` (
+                `videoId` TEXT NOT NULL,
+                `mode` TEXT NOT NULL DEFAULT 'SIMPLE',
+                `language` TEXT NOT NULL DEFAULT 'ko',
+                `url` TEXT NOT NULL,
+                `summary` TEXT NOT NULL,
+                `createdAt` INTEGER NOT NULL DEFAULT 0,
+                PRIMARY KEY(`videoId`, `mode`, `language`)
+            )
+        """.trimIndent())
+    }
+}
+
 private val PREPOPULATE_CALLBACK = object : RoomDatabase.Callback() {
     override fun onCreate(db: SupportSQLiteDatabase) {
         super.onCreate(db)
@@ -249,7 +267,7 @@ private val PREPOPULATE_CALLBACK = object : RoomDatabase.Callback() {
 @TypeConverters(MemoFormatConverter::class)
 @Database(
     entities = [Memo::class, Category::class, ChatSession::class, ChatMessage::class, YoutubeSummary::class, AiUsage::class, Tag::class, MemoTag::class],
-    version = 15,
+    version = 16,
     exportSchema = true
 )
 abstract class MemoDatabase : RoomDatabase() {
@@ -272,7 +290,7 @@ abstract class MemoDatabase : RoomDatabase() {
                     MemoDatabase::class.java,
                     "memo_database"
                 )
-                    .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14, MIGRATION_14_15)
+                    .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14, MIGRATION_14_15, MIGRATION_15_16)
                     .addCallback(PREPOPULATE_CALLBACK)
                     .build()
                 INSTANCE = instance

--- a/datasource/local/memo/impl/src/main/java/me/pecos/memozy/data/datasource/local/di/DatabaseModule.kt
+++ b/datasource/local/memo/impl/src/main/java/me/pecos/memozy/data/datasource/local/di/DatabaseModule.kt
@@ -24,6 +24,7 @@ import me.pecos.memozy.data.datasource.local.MIGRATION_11_12
 import me.pecos.memozy.data.datasource.local.MIGRATION_12_13
 import me.pecos.memozy.data.datasource.local.MIGRATION_13_14
 import me.pecos.memozy.data.datasource.local.MIGRATION_14_15
+import me.pecos.memozy.data.datasource.local.MIGRATION_15_16
 import me.pecos.memozy.data.datasource.local.AiUsageDao
 import me.pecos.memozy.data.datasource.local.MemoDao
 import me.pecos.memozy.data.datasource.local.MemoDatabase
@@ -45,7 +46,7 @@ object DatabaseModule {
             MemoDatabase::class.java,
             "memo_database"
         )
-            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14, MIGRATION_14_15)
+            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14, MIGRATION_14_15, MIGRATION_15_16)
             .addCallback(object : RoomDatabase.Callback() {
                 override fun onCreate(db: SupportSQLiteDatabase) {
                     super.onCreate(db)

--- a/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/quiz/QuizViewModel.kt
+++ b/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/quiz/QuizViewModel.kt
@@ -7,6 +7,8 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import me.pecos.memozy.data.datasource.local.AiUsageDao
+import me.pecos.memozy.data.datasource.local.entity.AiUsage
 import me.pecos.memozy.data.datasource.remote.ai.AIApiService
 import me.pecos.memozy.data.repository.MemoRepository
 import org.json.JSONArray
@@ -22,7 +24,8 @@ sealed class QuizState {
 class QuizViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val repository: MemoRepository,
-    private val aiApiService: AIApiService
+    private val aiApiService: AIApiService,
+    private val aiUsageDao: AiUsageDao
 ) : ViewModel() {
 
     private val memoId: Int = savedStateHandle.get<String>("memoId")?.toIntOrNull() ?: -1
@@ -80,6 +83,7 @@ $content"""
                     _quizState.value = QuizState.Error("퀴즈를 생성할 수 없습니다")
                 } else {
                     _quizState.value = QuizState.Ready(questions)
+                    aiUsageDao.insert(AiUsage(feature = "quiz"))
                 }
             } catch (e: Exception) {
                 _quizState.value = QuizState.Error(e.message ?: "퀴즈 생성 실패")

--- a/feature/memo-plain/impl/src/main/java/me/pecos/memozy/feature/memoplain/impl/MemoPlainNavigationImpl.kt
+++ b/feature/memo-plain/impl/src/main/java/me/pecos/memozy/feature/memoplain/impl/MemoPlainNavigationImpl.kt
@@ -76,6 +76,9 @@ class MemoPlainNavigationImpl @Inject constructor(
 
     companion object {
         private const val FEATURE_YOUTUBE_SUMMARY = "youtube_summary"
+        private const val FEATURE_WEB_SUMMARY = "web_summary"
+        private const val FEATURE_TRANSCRIPTION = "transcription"
+        private const val FEATURE_IMAGE_OCR = "image_ocr"
         private const val DAILY_FREE_LIMIT = 100
 
         private fun startOfToday(): Long {
@@ -237,8 +240,8 @@ class MemoPlainNavigationImpl @Inject constructor(
             LaunchedEffect(youtubeUrl) {
                 if (youtubeUrl != null && summaryState is SummaryState.Idle) {
                     val videoId = extractVideoId(youtubeUrl)
-                    // 캐��� 조회
-                    val cached = videoId?.let { youtubeSummaryDao.getByVideoId(it) }
+                    // 캐시 조회
+                    val cached = videoId?.let { youtubeSummaryDao.getByKey(it, SummaryMode.SIMPLE.name, languageCode) }
                     if (cached != null) {
                         summaryState = SummaryState.Success(cached.summary)
                         return@LaunchedEffect
@@ -254,6 +257,8 @@ class MemoPlainNavigationImpl @Inject constructor(
                         // 캐시 저장
                         youtubeSummaryDao.insert(YoutubeSummary(
                             videoId = videoId,
+                            mode = SummaryMode.SIMPLE.name,
+                            language = languageCode,
                             url = youtubeUrl,
                             summary = summary
                         ))
@@ -291,6 +296,7 @@ class MemoPlainNavigationImpl @Inject constructor(
                         val mimeType = imageContext.contentResolver.getType(sharedFileUri) ?: "image/jpeg"
                         val result = aiApiService.describeImage(base64, mimeType)
                         imageOcrState = SummaryState.Success(result)
+                        aiUsageDao.insert(AiUsage(feature = FEATURE_IMAGE_OCR))
                     } catch (e: Exception) {
                         imageOcrState = SummaryState.Error(e.message ?: "이미지 처리 실패")
                     }
@@ -518,6 +524,7 @@ class MemoPlainNavigationImpl @Inject constructor(
 
                             transcriptionResult = result
                             transcriptionError = null
+                            aiUsageDao.insert(AiUsage(feature = FEATURE_TRANSCRIPTION))
                         }
                     } catch (e: Exception) {
                         transcriptionError = "음성 변환에 실패했어요."
@@ -592,6 +599,7 @@ class MemoPlainNavigationImpl @Inject constructor(
                                     )
                                 }
                                 webSummaryResult = summary
+                                aiUsageDao.insert(AiUsage(feature = FEATURE_WEB_SUMMARY))
                             }
                         } catch (e: Exception) {
                             webSummaryError = when {
@@ -637,8 +645,8 @@ class MemoPlainNavigationImpl @Inject constructor(
                             return@launch
                         }
                         val videoId = extractVideoId(url)
-                        // 캐시 조회
-                        val cached = videoId?.let { youtubeSummaryDao.getByVideoId(it) }
+                        // 캐시 조회 (mode + language 기반)
+                        val cached = videoId?.let { youtubeSummaryDao.getByKey(it, mode.name, languageCode) }
                         if (cached != null) {
                             inlineSummaryState = SummaryState.Success(cached.summary)
                             return@launch
@@ -663,6 +671,8 @@ class MemoPlainNavigationImpl @Inject constructor(
                             if (videoId != null) {
                                 youtubeSummaryDao.insert(YoutubeSummary(
                                     videoId = videoId,
+                                    mode = mode.name,
+                                    language = languageCode,
                                     url = url,
                                     summary = summary
                                 ))

--- a/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/components/MemoActionBar.kt
+++ b/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/components/MemoActionBar.kt
@@ -85,7 +85,7 @@ fun MemoActionBar(
         }
 
         // 📺 유튜브 요약
-        if (onYoutubeSummarize != null) {
+        if (onYoutubeSummarize != null && !isSummarizing && !isWebSummarizing) {
             val hasYoutubeUrl = detectedYoutubeUrl != null
             Box(
                 modifier = Modifier.size(36.dp).clip(RoundedCornerShape(8.dp))
@@ -108,7 +108,7 @@ fun MemoActionBar(
         }
 
         // 🔗 웹 요약
-        if (onWebSummarize != null) {
+        if (onWebSummarize != null && !isSummarizing && !isWebSummarizing) {
             Box(
                 modifier = Modifier.size(36.dp).clip(RoundedCornerShape(8.dp))
                     .background(


### PR DESCRIPTION
## Summary
- **#117** YouTube 로컬 캐시 키를 `videoId` 단독 → `(videoId, mode, language)` 복합키로 변경하여 간단/상세 요약, 언어별 캐시 충돌 해결
- **#117** AI 기능별 사용량 추적 추가 (웹요약, 퀴즈, 음성전사, 이미지OCR)
- **#116** 요약 진행 중 액션바에서 유튜브/웹 요약 버튼 숨김 처리

## Changes
- `YoutubeSummary` 엔티티: 복합 PK `(videoId, mode, language)`
- `YoutubeSummaryDao`: `getByVideoId()` → `getByKey(videoId, mode, language)`
- `MemoDatabase`: MIGRATION_15_16 (youtube_summary 테이블 재생성)
- `DatabaseModule`: 마이그레이션 등록
- `MemoPlainNavigationImpl`: 캐시 조회/저장 mode+language 반영 + AI 사용량 추적
- `QuizViewModel`: 퀴즈 사용량 추적 추가
- `MemoActionBar`: 요약 중 버튼 숨김

## Test plan
- [ ] 기존 앱 → 업데이트 시 크래시 없이 실행되는지 확인
- [ ] 유튜브 간단요약 후 상세요약 재요청 시 다른 결과 반환되는지 확인
- [ ] 요약 시작 시 액션바에서 유튜브/웹 버튼이 사라지는지 확인

Closes #117
Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)