### PR TITLE
Update: #120 #121 URL 칩 스타일 + 하단 네비 투명화 + edge-to-edge

### DIFF
--- a/feature/home/impl/src/main/java/me/pecos/memozy/MainActivity.kt
+++ b/feature/home/impl/src/main/java/me/pecos/memozy/MainActivity.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -54,6 +55,7 @@ import com.wanted.android.wanted.design.theme.DesignSystemTheme
 import dev.chrisbanes.haze.HazeStyle
 import dev.chrisbanes.haze.HazeTint
 import dev.chrisbanes.haze.hazeEffect
+import dev.chrisbanes.haze.hazeSource
 import dev.chrisbanes.haze.rememberHazeState
 import me.pecos.memozy.data.billing.BillingManager
 import me.pecos.memozy.feature.home.api.HomeRoute
@@ -205,9 +207,9 @@ class MainActivity : AppCompatActivity() {
                         val navBg = appColors.navBackground
                         val glassStyle = remember(navBg) {
                             HazeStyle(
-                                blurRadius = 20.dp,
-                                backgroundColor = navBg,
-                                tints = listOf(HazeTint(color = navBg.copy(alpha = 0.4f)))
+                                blurRadius = 24.dp,
+                                backgroundColor = navBg.copy(alpha = 0.15f),
+                                tints = listOf(HazeTint(color = navBg.copy(alpha = 0.45f)))
                             )
                         }
 
@@ -219,7 +221,7 @@ class MainActivity : AppCompatActivity() {
                             NavHost(
                                 navController = navController,
                                 startDestination = HomeRoute.MAIN,
-                                modifier = Modifier.fillMaxSize(),
+                                modifier = Modifier.fillMaxSize().hazeSource(state = hazeState),
                                 enterTransition = { fadeIn(tween(150)) },
                                 exitTransition = { fadeOut(tween(150)) },
                                 popEnterTransition = { fadeIn(tween(150)) },
@@ -301,14 +303,8 @@ class MainActivity : AppCompatActivity() {
                                         modifier = Modifier
                                             .fillMaxHeight()
                                             .aspectRatio(1f)
-                                            .shadow(
-                                                elevation = 16.dp,
-                                                shape = CircleShape,
-                                                ambientColor = Color.Black.copy(alpha = 0.28f),
-                                                spotColor = Color.Black.copy(alpha = 0.18f)
-                                            )
                                             .clip(CircleShape)
-                                            .hazeEffect(state = hazeState, style = glassStyle)
+                                            .background(appColors.navBackground.copy(alpha = 0.75f))
                                             .border(1.dp, appColors.navBorder, CircleShape)
                                             .clickable {
                                                 navController.navigate(

--- a/feature/home/impl/src/main/java/me/pecos/memozy/presentation/components/BottomNavBar.kt
+++ b/feature/home/impl/src/main/java/me/pecos/memozy/presentation/components/BottomNavBar.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -52,14 +53,8 @@ fun FloatingNavPill(
     Row(
         modifier = modifier
             .height(52.dp)
-            .shadow(
-                elevation = 16.dp,
-                shape = RoundedCornerShape(50),
-                ambientColor = Color.Black.copy(alpha = 0.28f),
-                spotColor = Color.Black.copy(alpha = 0.18f)
-            )
             .clip(RoundedCornerShape(50))
-            .hazeEffect(state = hazeState, style = glassStyle)
+            .background(colors.navBackground.copy(alpha = 0.75f))
             .border(width = 1.dp, color = colors.navBorder, shape = RoundedCornerShape(50))
             .padding(horizontal = 2.dp, vertical = 2.dp),
         horizontalArrangement = Arrangement.SpaceEvenly,

--- a/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/home/HomeScreen.kt
+++ b/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/home/HomeScreen.kt
@@ -11,6 +11,8 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -126,11 +128,14 @@ fun HomeScreen(
     var selectedIds by remember { mutableStateOf(setOf<Int>()) }
     var showDeleteConfirm by remember { mutableStateOf(false) }
 
-    Scaffold(containerColor = colors.screenBackground) { innerPadding ->
+    Scaffold(
+        containerColor = colors.screenBackground,
+        contentWindowInsets = WindowInsets(0)
+    ) { innerPadding ->
         Box(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(innerPadding)
+                .padding(top = innerPadding.calculateTopPadding())
                 .clickable(
                     indication = null,
                     interactionSource = remember { androidx.compose.foundation.interaction.MutableInteractionSource() }
@@ -296,7 +301,8 @@ fun HomeScreen(
 
                 LazyColumn(
                     state = listState,
-                    modifier = Modifier.weight(1f)
+                    modifier = Modifier.weight(1f),
+                    contentPadding = PaddingValues(bottom = 100.dp)
                 ) {
                     items(filteredList, key = { it.id }) { memo ->
                         val itemModifier = Modifier.animateItem(

--- a/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/components/WebSummaryInlineCard.kt
+++ b/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/components/WebSummaryInlineCard.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Link
 import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
@@ -83,7 +84,22 @@ fun WebSummaryInlineCard(
                 fontSize = 14.sp, fontWeight = FontWeight.SemiBold, color = colors.textTitle,
                 maxLines = 2, overflow = TextOverflow.Ellipsis
             )
-            Text(webUrl, fontSize = 11.sp, color = Color(0xFF2196F3), maxLines = 1, overflow = TextOverflow.Ellipsis)
+            Spacer(modifier = Modifier.height(2.dp))
+            Row(
+                modifier = Modifier
+                    .clip(RoundedCornerShape(6.dp))
+                    .background(colors.chipBackground.copy(alpha = 0.5f))
+                    .padding(horizontal = 6.dp, vertical = 3.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Icon(
+                    Icons.Default.Link, contentDescription = null,
+                    tint = Color(0xFF2196F3),
+                    modifier = Modifier.size(12.dp)
+                )
+                Spacer(modifier = Modifier.width(4.dp))
+                Text(webUrl, fontSize = 10.sp, color = Color(0xFF2196F3), maxLines = 1, overflow = TextOverflow.Ellipsis)
+            }
 
             // 액션 버튼
             Spacer(modifier = Modifier.height(10.dp))

--- a/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/components/YouTubeSummaryInlineCard.kt
+++ b/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/components/YouTubeSummaryInlineCard.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Link
 import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
@@ -98,7 +99,22 @@ fun YouTubeSummaryInlineCard(
                     maxLines = 2, overflow = TextOverflow.Ellipsis
                 )
                 if (youtubeUrl.isNotBlank()) {
-                    Text(youtubeUrl, fontSize = 11.sp, color = Color(0xFF2196F3), maxLines = 1, overflow = TextOverflow.Ellipsis)
+                    Spacer(modifier = Modifier.height(2.dp))
+                    Row(
+                        modifier = Modifier
+                            .clip(RoundedCornerShape(6.dp))
+                            .background(colors.chipBackground.copy(alpha = 0.5f))
+                            .padding(horizontal = 6.dp, vertical = 3.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Icon(
+                            Icons.Default.Link, contentDescription = null,
+                            tint = Color(0xFF2196F3),
+                            modifier = Modifier.size(12.dp)
+                        )
+                        Spacer(modifier = Modifier.width(4.dp))
+                        Text(youtubeUrl, fontSize = 10.sp, color = Color(0xFF2196F3), maxLines = 1, overflow = TextOverflow.Ellipsis)
+                    }
                 }
 
                 // 액션 버튼


### PR DESCRIPTION
## Summary
- **#120** YouTube/웹 요약 카드 URL 텍스트를 칩 스타일로 감싸기 (링크 아이콘 + 배경)
- **#121** 하단 네비(FloatingNavPill + FAB) 배경 투명화 (alpha 0.75)
- **#121** HomeScreen 콘텐츠 edge-to-edge 스크롤 (시스템 네비바 영역까지)

## Test plan
- [ ] 메모 수정 화면에서 YouTube/웹 요약 카드 URL이 칩 스타일로 표시되는지 확인
- [ ] 홈 화면 메모 리스트 스크롤 시 시스템 네비바 영역까지 콘텐츠가 내려가는지 확인
- [ ] FloatingNavPill/FAB 뒤로 콘텐츠가 비쳐보이는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)