### PR TITLE
Update: HomeScreen 타이틀 위치 통일

### DIFF
--- a/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/home/HomeScreen.kt
+++ b/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/home/HomeScreen.kt
@@ -10,7 +10,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.WindowInsets
+
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -91,13 +91,12 @@ fun HomeScreen(
     var showDeleteConfirm by remember { mutableStateOf(false) }
 
     Scaffold(
-        containerColor = colors.screenBackground,
-        contentWindowInsets = WindowInsets(0)
+        containerColor = colors.screenBackground
     ) { innerPadding ->
         Box(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(top = innerPadding.calculateTopPadding())
+                .padding(innerPadding)
                 .clickable(
                     indication = null,
                     interactionSource = remember { androidx.compose.foundation.interaction.MutableInteractionSource() }
@@ -106,8 +105,7 @@ fun HomeScreen(
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 16.dp)
-                    .padding(top = 24.dp)
+                    .padding(horizontal = 16.dp, vertical = 24.dp)
             ) {
                 // 제목 + 메모 개수 (항상 표시)
                 Row(


### PR DESCRIPTION
## Summary
- HomeScreen의 Memozy 타이틀 위치를 SettingsScreen의 설정 타이틀과 동일하게 맞춤
- `contentWindowInsets = WindowInsets(0)` 제거, `padding(innerPadding)` 전체 적용
- Column padding 구조를 SettingsScreen과 동일하게 통일 (`horizontal + vertical`)

## Test plan
- [ ] 홈 화면 ↔ 설정 화면 전환 시 타이틀 위치 일관성 확인
- [ ] 홈 화면 스크롤 동작 정상 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)