### PR TITLE
Add: Supabase 백업 스키마 마이그레이션 (#125)

### DIFF
--- a/supabase/migrations/20260412_001_create_backup_tables.sql
+++ b/supabase/migrations/20260412_001_create_backup_tables.sql
@@ -1,0 +1,66 @@
+-- ============================================================
+-- Memozy Cloud Backup Schema
+-- Issue: #125
+-- ============================================================
+
+-- 1. backups: 백업 메타데이터 (목록 조회용)
+CREATE TABLE public.backups (
+    id          UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+    user_id     UUID REFERENCES auth.users(id) ON DELETE CASCADE NOT NULL,
+    device_name TEXT NOT NULL,
+    app_version TEXT NOT NULL,
+    db_version  INT NOT NULL,
+    memo_count  INT NOT NULL DEFAULT 0,
+    size_bytes  BIGINT NOT NULL DEFAULT 0,
+    created_at  TIMESTAMPTZ DEFAULT now() NOT NULL
+);
+
+CREATE INDEX idx_backups_user_id ON public.backups(user_id);
+CREATE INDEX idx_backups_created_at ON public.backups(created_at DESC);
+
+-- 2. backup_data: 백업 실제 데이터 (테이블별 JSON)
+CREATE TABLE public.backup_data (
+    id          UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+    backup_id   UUID REFERENCES public.backups(id) ON DELETE CASCADE NOT NULL,
+    table_name  TEXT NOT NULL,
+    data        JSONB NOT NULL,
+    row_count   INT NOT NULL DEFAULT 0
+);
+
+CREATE INDEX idx_backup_data_backup_id ON public.backup_data(backup_id);
+
+-- 3. RLS: 사용자 본인 데이터만 접근 가능
+ALTER TABLE public.backups ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users manage own backups"
+    ON public.backups FOR ALL
+    USING (auth.uid() = user_id)
+    WITH CHECK (auth.uid() = user_id);
+
+ALTER TABLE public.backup_data ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users manage own backup data"
+    ON public.backup_data FOR ALL
+    USING (
+        backup_id IN (SELECT id FROM public.backups WHERE user_id = auth.uid())
+    );
+
+-- 4. 백업 개수 제한 함수: 사용자당 최대 5개, 초과 시 가장 오래된 것 삭제
+CREATE OR REPLACE FUNCTION public.enforce_backup_limit()
+RETURNS TRIGGER AS $$
+BEGIN
+    DELETE FROM public.backups
+    WHERE id IN (
+        SELECT id FROM public.backups
+        WHERE user_id = NEW.user_id
+        ORDER BY created_at DESC
+        OFFSET 5
+    );
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+CREATE TRIGGER trg_enforce_backup_limit
+    AFTER INSERT ON public.backups
+    FOR EACH ROW
+    EXECUTE FUNCTION public.enforce_backup_limit();


### PR DESCRIPTION
## Summary

클라우드 백업 기능(#123)의 Phase 1 — Supabase PostgreSQL 백업 스키마 설계

- `backups` 테이블: 백업 메타데이터 (디바이스명, 앱버전, DB버전, 메모수, 용량)
- `backup_data` 테이블: 테이블별 실제 데이터 (JSONB)
- RLS 정책: 사용자 본인 데이터만 CRUD 가능
- 트리거: 사용자당 최대 5개 백업, 초과 시 가장 오래된 것 자동 삭제

## 스키마 구조

```
backups (메타데이터)          backup_data (실제 데이터)
├── id (PK)                  ├── id (PK)
├── user_id (FK → auth.users)├── backup_id (FK → backups, CASCADE)
├── device_name              ├── table_name ('memo', 'category', ...)
├── app_version              ├── data (JSONB - row 배열)
├── db_version               └── row_count
├── memo_count
├── size_bytes
└── created_at
```

## 설계 결정
- **JSONB**: 테이블별 스키마가 다르므로 유연한 JSON 저장
- **테이블 분리**: 목록 조회 성능을 위해 메타데이터와 실제 데이터 분리
- **CASCADE DELETE**: 백업 삭제 시 backup_data 자동 삭제
- **SECURITY DEFINER 트리거**: RLS 우회하여 오래된 백업 정리

## Test plan
- [ ] Supabase Dashboard에서 SQL 실행하여 테이블 생성
- [ ] RLS 테스트: 인증된 사용자가 본인 데이터만 접근 가능한지 확인
- [ ] 백업 6개 생성 시 가장 오래된 1개 자동 삭제 확인

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)