### PR TITLE
Add: #123 클라우드 백업/복원 기능 완성

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -34,7 +34,9 @@ dependencies {
     implementation(projects.datasource.local.memo.api) // 위젯에서 Memo 엔티티 참조
     implementation(projects.datasource.local.chat.impl)
     implementation(projects.datasource.remote.ai.impl)
+    implementation(projects.datasource.remote.auth.api)
     implementation(projects.datasource.remote.auth.impl)
+    implementation(projects.data.backup.api)
     implementation(projects.data.repository.memo.impl)
     implementation(projects.data.repository.memo.api) // 위젯에서 MemoRepository 참조
     implementation(projects.data.repository.chat.impl)
@@ -50,6 +52,11 @@ dependencies {
 
     // MemozyApplication
     implementation(libs.android.joda)
+
+    // work manager
+    implementation(libs.work.runtime)
+    implementation(libs.work.hilt)
+    ksp(libs.work.hilt.compiler)
 
     // glance widget
     implementation(libs.glance.appwidget)

--- a/app/src/main/java/me/pecos/memozy/MemozyApplication.kt
+++ b/app/src/main/java/me/pecos/memozy/MemozyApplication.kt
@@ -1,8 +1,44 @@
 package me.pecos.memozy
 
 import android.app.Application
+import androidx.hilt.work.HiltWorkerFactory
+import androidx.work.Configuration
 import dagger.hilt.android.HiltAndroidApp
+import me.pecos.memozy.data.datasource.remote.auth.AuthService
+import me.pecos.memozy.data.datasource.remote.auth.AuthState
+import me.pecos.memozy.worker.BackupScheduler
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+import javax.inject.Inject
 
 @HiltAndroidApp
-class MemozyApplication : Application()
+class MemozyApplication : Application(), Configuration.Provider {
 
+    @Inject lateinit var workerFactory: HiltWorkerFactory
+    @Inject lateinit var authService: AuthService
+
+    private val appScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+
+    override val workManagerConfiguration: Configuration
+        get() = Configuration.Builder()
+            .setWorkerFactory(workerFactory)
+            .build()
+
+    override fun onCreate() {
+        super.onCreate()
+
+        // 로그인 상태 변경 시 자동 백업 스케줄링
+        appScope.launch {
+            authService.authState.collectLatest { state ->
+                when (state) {
+                    is AuthState.Authenticated -> BackupScheduler.schedule(this@MemozyApplication)
+                    is AuthState.Unauthenticated -> BackupScheduler.cancel(this@MemozyApplication)
+                    else -> {}
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/me/pecos/memozy/worker/BackupScheduler.kt
+++ b/app/src/main/java/me/pecos/memozy/worker/BackupScheduler.kt
@@ -1,0 +1,36 @@
+package me.pecos.memozy.worker
+
+import android.content.Context
+import androidx.work.Constraints
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import java.util.concurrent.TimeUnit
+
+object BackupScheduler {
+
+    fun schedule(context: Context) {
+        val constraints = Constraints.Builder()
+            .setRequiredNetworkType(NetworkType.UNMETERED) // Wi-Fi only
+            .setRequiresBatteryNotLow(true)
+            .build()
+
+        val request = PeriodicWorkRequestBuilder<BackupWorker>(
+            24, TimeUnit.HOURS
+        )
+            .setConstraints(constraints)
+            .setInitialDelay(1, TimeUnit.HOURS)
+            .build()
+
+        WorkManager.getInstance(context).enqueueUniquePeriodicWork(
+            BackupWorker.WORK_NAME,
+            ExistingPeriodicWorkPolicy.KEEP,
+            request
+        )
+    }
+
+    fun cancel(context: Context) {
+        WorkManager.getInstance(context).cancelUniqueWork(BackupWorker.WORK_NAME)
+    }
+}

--- a/app/src/main/java/me/pecos/memozy/worker/BackupWorker.kt
+++ b/app/src/main/java/me/pecos/memozy/worker/BackupWorker.kt
@@ -1,0 +1,42 @@
+package me.pecos.memozy.worker
+
+import android.content.Context
+import android.util.Log
+import androidx.hilt.work.HiltWorker
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+import me.pecos.memozy.data.backup.BackupRepository
+import me.pecos.memozy.data.datasource.remote.auth.AuthService
+
+@HiltWorker
+class BackupWorker @AssistedInject constructor(
+    @Assisted context: Context,
+    @Assisted params: WorkerParameters,
+    private val backupRepository: BackupRepository,
+    private val authService: AuthService,
+) : CoroutineWorker(context, params) {
+
+    override suspend fun doWork(): Result {
+        // 로그인 안 되어있으면 스킵
+        if (authService.currentUser == null) {
+            Log.d(TAG, "Skipping auto backup: not authenticated")
+            return Result.success()
+        }
+
+        return try {
+            backupRepository.uploadBackup().getOrThrow()
+            Log.d(TAG, "Auto backup completed successfully")
+            Result.success()
+        } catch (e: Exception) {
+            Log.e(TAG, "Auto backup failed", e)
+            Result.retry()
+        }
+    }
+
+    companion object {
+        const val TAG = "BackupWorker"
+        const val WORK_NAME = "auto_backup"
+    }
+}

--- a/data/backup/api/src/main/java/me/pecos/memozy/data/backup/BackupModels.kt
+++ b/data/backup/api/src/main/java/me/pecos/memozy/data/backup/BackupModels.kt
@@ -61,6 +61,16 @@ data class ChatMessageBackup(
     val metadata: String? = null,
 )
 
+// --- Cloud backup API request ---
+
+@Serializable
+data class BackupUploadRequest(
+    val device_name: String,
+    val app_version: String,
+    val db_version: Int,
+    val tables: BackupTables,
+)
+
 // --- Cloud backup metadata ---
 
 @Serializable

--- a/data/backup/api/src/main/java/me/pecos/memozy/data/backup/BackupModels.kt
+++ b/data/backup/api/src/main/java/me/pecos/memozy/data/backup/BackupModels.kt
@@ -60,3 +60,30 @@ data class ChatMessageBackup(
     val timestamp: Long,
     val metadata: String? = null,
 )
+
+// --- Cloud backup metadata ---
+
+@Serializable
+data class BackupMeta(
+    val id: String,
+    val device_name: String,
+    val app_version: String,
+    val db_version: Int,
+    val memo_count: Int,
+    val size_bytes: Long,
+    val created_at: String,
+)
+
+@Serializable
+data class BackupCreateResponse(
+    val id: String,
+    val created_at: String,
+    val memo_count: Int,
+)
+
+@Serializable
+data class BackupDownloadResponse(
+    val id: String,
+    val metadata: BackupMeta,
+    val tables: BackupTables,
+)

--- a/data/backup/api/src/main/java/me/pecos/memozy/data/backup/BackupRepository.kt
+++ b/data/backup/api/src/main/java/me/pecos/memozy/data/backup/BackupRepository.kt
@@ -3,4 +3,11 @@ package me.pecos.memozy.data.backup
 interface BackupRepository {
     suspend fun createBackupPayload(): BackupPayload
     suspend fun restoreFromPayload(payload: BackupPayload)
+
+    // Cloud operations
+    suspend fun uploadBackup(): Result<BackupCreateResponse>
+    suspend fun listBackups(): Result<List<BackupMeta>>
+    suspend fun downloadBackup(backupId: String): Result<BackupDownloadResponse>
+    suspend fun deleteBackup(backupId: String): Result<Unit>
+    suspend fun restoreFromCloud(backupId: String): Result<Int>
 }

--- a/data/backup/impl/build.gradle.kts
+++ b/data/backup/impl/build.gradle.kts
@@ -3,7 +3,7 @@ import me.pecos.memozy.convention.extension.setNamespace
 plugins {
     id("memozy.android.library")
     id("memozy.hilt")
-    alias(libs.plugins.kotlin.serialization)
+    id("memozy.ktor")
 }
 
 setNamespace("data.backup.impl")
@@ -12,7 +12,7 @@ dependencies {
     implementation(projects.data.backup.api)
     implementation(projects.datasource.local.memo.api)
     implementation(projects.datasource.local.chat.api)
+    implementation(projects.datasource.remote.auth.api)
     implementation(libs.kotlinx.coroutines.android)
-    implementation(libs.kotlinx.serialization.json)
     implementation(libs.room.ktx)
 }

--- a/data/backup/impl/build.gradle.kts
+++ b/data/backup/impl/build.gradle.kts
@@ -1,4 +1,5 @@
 import me.pecos.memozy.convention.extension.setNamespace
+import java.util.Properties
 
 plugins {
     id("memozy.android.library")
@@ -7,6 +8,21 @@ plugins {
 }
 
 setNamespace("data.backup.impl")
+
+val localProperties = Properties().apply {
+    val file = rootProject.file("local.properties")
+    if (file.exists()) load(file.inputStream())
+}
+
+android {
+    buildFeatures {
+        buildConfig = true
+    }
+
+    defaultConfig {
+        buildConfigField("String", "WORKER_URL", "\"${localProperties.getProperty("worker.url", "")}\"")
+    }
+}
 
 dependencies {
     implementation(projects.data.backup.api)

--- a/data/backup/impl/src/main/java/me/pecos/memozy/data/backup/BackupRepositoryImpl.kt
+++ b/data/backup/impl/src/main/java/me/pecos/memozy/data/backup/BackupRepositoryImpl.kt
@@ -19,6 +19,7 @@ import me.pecos.memozy.data.datasource.local.chat.entity.ChatMessage
 import me.pecos.memozy.data.datasource.local.chat.entity.ChatSession
 import me.pecos.memozy.data.datasource.local.entity.Category
 import me.pecos.memozy.data.datasource.local.entity.Memo
+import me.pecos.memozy.data.backup.di.BackupHttpClient
 import me.pecos.memozy.data.datasource.remote.auth.AuthService
 import me.pecos.memozy.data.repository.model.MemoFormat
 import javax.inject.Inject
@@ -32,7 +33,7 @@ class BackupRepositoryImpl @Inject constructor(
     private val chatSessionDao: ChatSessionDao,
     private val chatMessageDao: ChatMessageDao,
     private val authService: AuthService,
-    private val httpClient: HttpClient,
+    @BackupHttpClient private val httpClient: HttpClient,
 ) : BackupRepository {
 
     override suspend fun createBackupPayload(): BackupPayload {
@@ -85,15 +86,16 @@ class BackupRepositoryImpl @Inject constructor(
 
     override suspend fun uploadBackup(): Result<BackupCreateResponse> = runCatching {
         val payload = createBackupPayload()
+        val request = BackupUploadRequest(
+            device_name = payload.deviceName,
+            app_version = payload.appVersion,
+            db_version = payload.dbVersion,
+            tables = payload.tables,
+        )
         httpClient.post("backup") {
             header("Authorization", authHeader())
             contentType(ContentType.Application.Json)
-            setBody(mapOf(
-                "device_name" to payload.deviceName,
-                "app_version" to payload.appVersion,
-                "db_version" to payload.dbVersion,
-                "tables" to payload.tables,
-            ))
+            setBody(request)
         }.body<BackupCreateResponse>()
     }
 

--- a/data/backup/impl/src/main/java/me/pecos/memozy/data/backup/BackupRepositoryImpl.kt
+++ b/data/backup/impl/src/main/java/me/pecos/memozy/data/backup/BackupRepositoryImpl.kt
@@ -2,14 +2,24 @@ package me.pecos.memozy.data.backup
 
 import android.content.Context
 import dagger.hilt.android.qualifiers.ApplicationContext
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.delete
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
 import me.pecos.memozy.data.datasource.local.CategoryDao
 import me.pecos.memozy.data.datasource.local.MemoDao
 import me.pecos.memozy.data.datasource.local.chat.ChatMessageDao
 import me.pecos.memozy.data.datasource.local.chat.ChatSessionDao
+import me.pecos.memozy.data.datasource.local.chat.entity.ChatMessage
+import me.pecos.memozy.data.datasource.local.chat.entity.ChatSession
 import me.pecos.memozy.data.datasource.local.entity.Category
 import me.pecos.memozy.data.datasource.local.entity.Memo
-import me.pecos.memozy.data.datasource.local.chat.entity.ChatSession
-import me.pecos.memozy.data.datasource.local.chat.entity.ChatMessage
+import me.pecos.memozy.data.datasource.remote.auth.AuthService
 import me.pecos.memozy.data.repository.model.MemoFormat
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -21,6 +31,8 @@ class BackupRepositoryImpl @Inject constructor(
     private val categoryDao: CategoryDao,
     private val chatSessionDao: ChatSessionDao,
     private val chatMessageDao: ChatMessageDao,
+    private val authService: AuthService,
+    private val httpClient: HttpClient,
 ) : BackupRepository {
 
     override suspend fun createBackupPayload(): BackupPayload {
@@ -45,32 +57,78 @@ class BackupRepositoryImpl @Inject constructor(
     }
 
     override suspend fun restoreFromPayload(payload: BackupPayload) {
-        // 복원 순서: FK 의존성 고려
-        // 1. 기존 데이터 삭제 (역순)
         chatMessageDao.clearAllMessages()
         chatSessionDao.clearAllSessions()
         memoDao.clearAllMemos()
         categoryDao.clearAllCategories()
 
-        // 2. 카테고리 먼저
         val categories = payload.tables.categories.map { it.toEntity() }
         if (categories.isNotEmpty()) categoryDao.insertCategories(categories)
 
-        // 3. 메모
         val memos = payload.tables.memos.map { it.toEntity() }
         if (memos.isNotEmpty()) memoDao.insertMemos(memos)
 
-        // 4. 채팅 세션
         val sessions = payload.tables.chatSessions?.map { it.toEntity() }
         if (!sessions.isNullOrEmpty()) chatSessionDao.insertSessions(sessions)
 
-        // 5. 채팅 메시지
         val messages = payload.tables.chatMessages?.map { it.toEntity() }
         if (!messages.isNullOrEmpty()) chatMessageDao.insertMessages(messages)
     }
+
+    // --- Cloud operations ---
+
+    private fun authHeader(): String {
+        val token = authService.getAccessToken()
+            ?: throw IllegalStateException("Not authenticated")
+        return "Bearer $token"
+    }
+
+    override suspend fun uploadBackup(): Result<BackupCreateResponse> = runCatching {
+        val payload = createBackupPayload()
+        httpClient.post("backup") {
+            header("Authorization", authHeader())
+            contentType(ContentType.Application.Json)
+            setBody(mapOf(
+                "device_name" to payload.deviceName,
+                "app_version" to payload.appVersion,
+                "db_version" to payload.dbVersion,
+                "tables" to payload.tables,
+            ))
+        }.body<BackupCreateResponse>()
+    }
+
+    override suspend fun listBackups(): Result<List<BackupMeta>> = runCatching {
+        httpClient.get("backups") {
+            header("Authorization", authHeader())
+        }.body<List<BackupMeta>>()
+    }
+
+    override suspend fun downloadBackup(backupId: String): Result<BackupDownloadResponse> = runCatching {
+        httpClient.get("backup/$backupId") {
+            header("Authorization", authHeader())
+        }.body<BackupDownloadResponse>()
+    }
+
+    override suspend fun deleteBackup(backupId: String): Result<Unit> = runCatching {
+        httpClient.delete("backup/$backupId") {
+            header("Authorization", authHeader())
+        }
+        Unit
+    }
+
+    override suspend fun restoreFromCloud(backupId: String): Result<Int> = runCatching {
+        val response = downloadBackup(backupId).getOrThrow()
+        restoreFromPayload(BackupPayload(
+            deviceName = response.metadata.device_name,
+            appVersion = response.metadata.app_version,
+            dbVersion = response.metadata.db_version,
+            tables = response.tables,
+        ))
+        response.metadata.memo_count
+    }
 }
 
-// --- Entity → Backup 변환 ---
+// --- Entity → Backup ---
 
 private fun Memo.toBackup() = MemoBackup(
     id = id, name = name, categoryId = categoryId, content = content,
@@ -91,7 +149,7 @@ private fun ChatMessage.toBackup() = ChatMessageBackup(
     timestamp = timestamp, metadata = metadata,
 )
 
-// --- Backup → Entity 변환 ---
+// --- Backup → Entity ---
 
 private fun MemoBackup.toEntity() = Memo(
     id = id, name = name, categoryId = categoryId, content = content,

--- a/data/backup/impl/src/main/java/me/pecos/memozy/data/backup/BackupRepositoryImpl.kt
+++ b/data/backup/impl/src/main/java/me/pecos/memozy/data/backup/BackupRepositoryImpl.kt
@@ -45,7 +45,9 @@ class BackupRepositoryImpl @Inject constructor(
         val chatMessages = chatMessageDao.getAllMessagesOnce().map { it.toBackup() }
 
         return BackupPayload(
-            deviceName = android.os.Build.MODEL,
+            deviceName = android.provider.Settings.Global.getString(
+                context.contentResolver, "device_name"
+            ) ?: android.os.Build.MODEL,
             appVersion = packageInfo.versionName ?: "unknown",
             dbVersion = 17,
             tables = BackupTables(

--- a/data/backup/impl/src/main/java/me/pecos/memozy/data/backup/di/BackupModule.kt
+++ b/data/backup/impl/src/main/java/me/pecos/memozy/data/backup/di/BackupModule.kt
@@ -2,11 +2,30 @@ package me.pecos.memozy.data.backup.di
 
 import dagger.Binds
 import dagger.Module
+import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.okhttp.OkHttp
+import io.ktor.client.plugins.HttpResponseValidator
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.defaultRequest
+import io.ktor.client.plugins.logging.LogLevel
+import io.ktor.client.plugins.logging.Logging
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.isSuccess
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.serialization.json.Json
 import me.pecos.memozy.data.backup.BackupRepository
 import me.pecos.memozy.data.backup.BackupRepositoryImpl
+import me.pecos.memozy.data.backup.impl.BuildConfig
+import javax.inject.Qualifier
 import javax.inject.Singleton
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class BackupHttpClient
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -15,4 +34,43 @@ abstract class BackupModule {
     @Binds
     @Singleton
     abstract fun bindBackupRepository(impl: BackupRepositoryImpl): BackupRepository
+
+    companion object {
+
+        @Provides
+        @Singleton
+        @BackupHttpClient
+        fun provideBackupHttpClient(): HttpClient = HttpClient(OkHttp) {
+            install(ContentNegotiation) {
+                json(Json {
+                    ignoreUnknownKeys = true
+                    isLenient = true
+                    encodeDefaults = true
+                })
+            }
+
+            install(Logging) {
+                level = if (BuildConfig.DEBUG) LogLevel.HEADERS else LogLevel.NONE
+            }
+
+            install(HttpTimeout) {
+                requestTimeoutMillis = 120_000
+                connectTimeoutMillis = 15_000
+                socketTimeoutMillis = 120_000
+            }
+
+            defaultRequest {
+                url("${BuildConfig.WORKER_URL}/")
+            }
+
+            HttpResponseValidator {
+                validateResponse { response ->
+                    if (!response.status.isSuccess()) {
+                        val body = response.bodyAsText()
+                        throw Exception("Backup error (${response.status.value}): $body")
+                    }
+                }
+            }
+        }
+    }
 }

--- a/datasource/local/memo/impl/schemas/me.pecos.memozy.data.datasource.local.MemoDatabase/13.json
+++ b/datasource/local/memo/impl/schemas/me.pecos.memozy.data.datasource.local.MemoDatabase/13.json
@@ -1,0 +1,401 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 13,
+    "identityHash": "e8107bf8073344f06b5ec408135756e4",
+    "entities": [
+      {
+        "tableName": "memo",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `categoryId` INTEGER NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `format` TEXT NOT NULL, `isPinned` INTEGER NOT NULL, `audioPath` TEXT, `styles` TEXT, `youtubeUrl` TEXT, `deletedAt` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "categoryId",
+            "columnName": "categoryId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "format",
+            "columnName": "format",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isPinned",
+            "columnName": "isPinned",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "audioPath",
+            "columnName": "audioPath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "styles",
+            "columnName": "styles",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "youtubeUrl",
+            "columnName": "youtubeUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "category",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "chat_session",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `title` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `category` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "chat_message",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sessionId` INTEGER NOT NULL, `role` TEXT NOT NULL, `content` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, `metadata` TEXT, FOREIGN KEY(`sessionId`) REFERENCES `chat_session`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadata",
+            "columnName": "metadata",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_chat_message_sessionId",
+            "unique": false,
+            "columnNames": [
+              "sessionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chat_message_sessionId` ON `${TABLE_NAME}` (`sessionId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "chat_session",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sessionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "youtube_summary",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`videoId` TEXT NOT NULL, `url` TEXT NOT NULL, `summary` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`videoId`))",
+        "fields": [
+          {
+            "fieldPath": "videoId",
+            "columnName": "videoId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "summary",
+            "columnName": "summary",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "videoId"
+          ]
+        }
+      },
+      {
+        "tableName": "ai_usage",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `feature` TEXT NOT NULL, `usedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "feature",
+            "columnName": "feature",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "usedAt",
+            "columnName": "usedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "tag",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `emoji` TEXT NOT NULL, `createdAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "emoji",
+            "columnName": "emoji",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "memo_tag",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`memoId` INTEGER NOT NULL, `tagId` INTEGER NOT NULL, PRIMARY KEY(`memoId`, `tagId`), FOREIGN KEY(`memoId`) REFERENCES `memo`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`tagId`) REFERENCES `tag`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "memoId",
+            "columnName": "memoId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tagId",
+            "columnName": "tagId",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "memoId",
+            "tagId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_memo_tag_memoId",
+            "unique": false,
+            "columnNames": [
+              "memoId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_memo_tag_memoId` ON `${TABLE_NAME}` (`memoId`)"
+          },
+          {
+            "name": "index_memo_tag_tagId",
+            "unique": false,
+            "columnNames": [
+              "tagId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_memo_tag_tagId` ON `${TABLE_NAME}` (`tagId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "memo",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "memoId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "tag",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "tagId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'e8107bf8073344f06b5ec408135756e4')"
+    ]
+  }
+}

--- a/datasource/local/memo/impl/src/main/java/me/pecos/memozy/data/datasource/local/di/DatabaseModule.kt
+++ b/datasource/local/memo/impl/src/main/java/me/pecos/memozy/data/datasource/local/di/DatabaseModule.kt
@@ -26,6 +26,7 @@ import me.pecos.memozy.data.datasource.local.MIGRATION_14_15
 import me.pecos.memozy.data.datasource.local.MIGRATION_15_16
 import me.pecos.memozy.data.datasource.local.MIGRATION_16_17
 import me.pecos.memozy.data.datasource.local.AiUsageDao
+import me.pecos.memozy.data.datasource.local.CategoryDao
 import me.pecos.memozy.data.datasource.local.MemoDao
 import me.pecos.memozy.data.datasource.local.MemoDatabase
 import me.pecos.memozy.data.datasource.local.YoutubeSummaryDao
@@ -58,6 +59,11 @@ object DatabaseModule {
     @Provides
     fun provideMemoDao(database: MemoDatabase): MemoDao {
         return database.memoDao()
+    }
+
+    @Provides
+    fun provideCategoryDao(database: MemoDatabase): CategoryDao {
+        return database.categoryDao()
     }
 
     @Provides

--- a/datasource/remote/ai/impl/src/main/java/me/pecos/memozy/data/datasource/remote/ai/di/AINetworkModule.kt
+++ b/datasource/remote/ai/impl/src/main/java/me/pecos/memozy/data/datasource/remote/ai/di/AINetworkModule.kt
@@ -34,6 +34,7 @@ import javax.inject.Singleton
 @Retention(AnnotationRetention.BINARY)
 annotation class YouTubeHttpClient
 
+
 @Module
 @InstallIn(SingletonComponent::class)
 abstract class AINetworkModule {

--- a/feature/core/resource/src/main/res/drawable/ic_google.xml
+++ b/feature/core/resource/src/main/res/drawable/ic_google.xml
@@ -1,0 +1,18 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#4285F4"
+        android:pathData="M22.56,12.25c0,-0.78 -0.07,-1.53 -0.2,-2.25L12,10l0,4.26l5.92,0c-0.26,1.37 -1.04,2.53 -2.21,3.31l0,2.77l3.57,0c2.08,-1.92 3.28,-4.74 3.28,-8.09z"/>
+    <path
+        android:fillColor="#34A853"
+        android:pathData="M12,23c2.97,0 5.46,-0.98 7.28,-2.66l-3.57,-2.77c-0.98,0.66 -2.23,1.06 -3.71,1.06 -2.86,0 -5.29,-1.93 -6.16,-4.53L2.18,14.1l0,2.84C3.99,20.53 7.7,23 12,23z"/>
+    <path
+        android:fillColor="#FBBC05"
+        android:pathData="M5.84,14.09c-0.22,-0.66 -0.35,-1.36 -0.35,-2.09s0.13,-1.43 0.35,-2.09L5.84,9.91L2.18,7.07C1.43,8.55 1,10.22 1,12s0.43,3.45 1.18,4.93l2.85,-2.22 1.81,-0.62z"/>
+    <path
+        android:fillColor="#EA4335"
+        android:pathData="M12,5.38c1.62,0 3.06,0.56 4.21,1.64l3.15,-3.15C17.45,2.09 14.97,1 12,1 7.7,1 3.99,3.47 2.18,7.07l3.66,2.84c0.87,-2.6 3.3,-4.53 6.16,-4.53z"/>
+</vector>

--- a/feature/core/resource/src/main/res/values-en/strings.xml
+++ b/feature/core/resource/src/main/res/values-en/strings.xml
@@ -190,7 +190,7 @@
 
     <!-- Auth -->
     <string name="section_account">Account</string>
-    <string name="sign_in_google">Sign in with Google</string>
+    <string name="sign_in_google">Sign in with Google Account</string>
     <string name="sign_out">Sign Out</string>
     <string name="sign_in_error">Sign in failed</string>
     <string name="sign_out_confirm">Are you sure you want to sign out?</string>

--- a/feature/core/resource/src/main/res/values-en/strings.xml
+++ b/feature/core/resource/src/main/res/values-en/strings.xml
@@ -195,4 +195,22 @@
     <string name="sign_in_error">Sign in failed</string>
     <string name="sign_out_confirm">Are you sure you want to sign out?</string>
     <string name="sign_in_loading">Signing in…</string>
+
+    <!-- Cloud Backup -->
+    <string name="section_cloud_backup">Cloud Backup</string>
+    <string name="cloud_backup_now">Backup to Cloud</string>
+    <string name="cloud_backup_restore">Restore from Cloud</string>
+    <string name="cloud_backup_manage">Manage Backups</string>
+    <string name="cloud_backup_uploading">Uploading backup…</string>
+    <string name="cloud_backup_success">Backup completed (%d memos)</string>
+    <string name="cloud_backup_error">Backup failed</string>
+    <string name="cloud_backup_restore_confirm">Restoring this backup will replace all current data.\nThis action cannot be undone.</string>
+    <string name="cloud_backup_restore_success">Restored successfully (%d memos)</string>
+    <string name="cloud_backup_restore_error">Restore failed</string>
+    <string name="cloud_backup_delete_confirm">Delete this backup?</string>
+    <string name="cloud_backup_empty">No backups saved</string>
+    <string name="cloud_backup_login_required">Sign in to use cloud backup</string>
+    <string name="cloud_backup_restoring">Restoring…</string>
+    <string name="cloud_backup_count">%d backups saved</string>
+    <string name="cloud_backup_memo_count">%d memos</string>
 </resources>

--- a/feature/core/resource/src/main/res/values-en/strings.xml
+++ b/feature/core/resource/src/main/res/values-en/strings.xml
@@ -195,6 +195,8 @@
     <string name="sign_in_error">Sign in failed</string>
     <string name="sign_out_confirm">Are you sure you want to sign out?</string>
     <string name="sign_in_loading">Signing in…</string>
+    <string name="login_subtitle">Keep your memos safe with cloud backup</string>
+    <string name="login_skip">Start without account</string>
 
     <!-- Cloud Backup -->
     <string name="section_cloud_backup">Cloud Backup</string>

--- a/feature/core/resource/src/main/res/values-ja/strings.xml
+++ b/feature/core/resource/src/main/res/values-ja/strings.xml
@@ -190,7 +190,7 @@
 
     <!-- Auth -->
     <string name="section_account">アカウント</string>
-    <string name="sign_in_google">Googleでログイン</string>
+    <string name="sign_in_google">Googleアカウントでログイン</string>
     <string name="sign_out">ログアウト</string>
     <string name="sign_in_error">ログインに失敗しました</string>
     <string name="sign_out_confirm">ログアウトしますか？</string>

--- a/feature/core/resource/src/main/res/values-ja/strings.xml
+++ b/feature/core/resource/src/main/res/values-ja/strings.xml
@@ -195,4 +195,22 @@
     <string name="sign_in_error">ログインに失敗しました</string>
     <string name="sign_out_confirm">ログアウトしますか？</string>
     <string name="sign_in_loading">ログイン中…</string>
+
+    <!-- Cloud Backup -->
+    <string name="section_cloud_backup">クラウドバックアップ</string>
+    <string name="cloud_backup_now">クラウドにバックアップ</string>
+    <string name="cloud_backup_restore">クラウドから復元</string>
+    <string name="cloud_backup_manage">バックアップ管理</string>
+    <string name="cloud_backup_uploading">バックアップ中…</string>
+    <string name="cloud_backup_success">バックアップ完了 (メモ %d件)</string>
+    <string name="cloud_backup_error">バックアップに失敗しました</string>
+    <string name="cloud_backup_restore_confirm">このバックアップで復元すると、現在のデータが置き換えられます。\nこの操作は元に戻せません。</string>
+    <string name="cloud_backup_restore_success">復元が完了しました (メモ %d件)</string>
+    <string name="cloud_backup_restore_error">復元に失敗しました</string>
+    <string name="cloud_backup_delete_confirm">このバックアップを削除しますか？</string>
+    <string name="cloud_backup_empty">保存されたバックアップはありません</string>
+    <string name="cloud_backup_login_required">ログインしてからご利用ください</string>
+    <string name="cloud_backup_restoring">復元中…</string>
+    <string name="cloud_backup_count">保存済みバックアップ %d件</string>
+    <string name="cloud_backup_memo_count">メモ %d件</string>
 </resources>

--- a/feature/core/resource/src/main/res/values-ja/strings.xml
+++ b/feature/core/resource/src/main/res/values-ja/strings.xml
@@ -195,6 +195,8 @@
     <string name="sign_in_error">ログインに失敗しました</string>
     <string name="sign_out_confirm">ログアウトしますか？</string>
     <string name="sign_in_loading">ログイン中…</string>
+    <string name="login_subtitle">クラウドバックアップでメモを安全に保管</string>
+    <string name="login_skip">アカウントなしで始める</string>
 
     <!-- Cloud Backup -->
     <string name="section_cloud_backup">クラウドバックアップ</string>

--- a/feature/core/resource/src/main/res/values/strings.xml
+++ b/feature/core/resource/src/main/res/values/strings.xml
@@ -193,6 +193,8 @@
     <string name="sign_in_error">로그인에 실패했습니다</string>
     <string name="sign_out_confirm">로그아웃하시겠습니까?</string>
     <string name="sign_in_loading">로그인 중…</string>
+    <string name="login_subtitle">클라우드 백업으로 메모를 안전하게 보관하세요</string>
+    <string name="login_skip">연결 없이 시작</string>
 
     <!-- Cloud Backup -->
     <string name="section_cloud_backup">클라우드 백업</string>

--- a/feature/core/resource/src/main/res/values/strings.xml
+++ b/feature/core/resource/src/main/res/values/strings.xml
@@ -193,4 +193,22 @@
     <string name="sign_in_error">로그인에 실패했습니다</string>
     <string name="sign_out_confirm">로그아웃하시겠습니까?</string>
     <string name="sign_in_loading">로그인 중…</string>
+
+    <!-- Cloud Backup -->
+    <string name="section_cloud_backup">클라우드 백업</string>
+    <string name="cloud_backup_now">클라우드에 백업</string>
+    <string name="cloud_backup_restore">클라우드에서 복원</string>
+    <string name="cloud_backup_manage">백업 관리</string>
+    <string name="cloud_backup_uploading">백업 업로드 중…</string>
+    <string name="cloud_backup_success">백업이 완료되었습니다 (메모 %d개)</string>
+    <string name="cloud_backup_error">백업에 실패했습니다</string>
+    <string name="cloud_backup_restore_confirm">이 백업으로 복원하면 현재 데이터가 대체됩니다.\n이 작업은 되돌릴 수 없습니다.</string>
+    <string name="cloud_backup_restore_success">복원이 완료되었습니다 (메모 %d개)</string>
+    <string name="cloud_backup_restore_error">복원에 실패했습니다</string>
+    <string name="cloud_backup_delete_confirm">이 백업을 삭제하시겠습니까?</string>
+    <string name="cloud_backup_empty">저장된 백업이 없습니다</string>
+    <string name="cloud_backup_login_required">로그인 후 사용할 수 있습니다</string>
+    <string name="cloud_backup_restoring">복원 중…</string>
+    <string name="cloud_backup_count">저장된 백업 %d개</string>
+    <string name="cloud_backup_memo_count">메모 %d개</string>
 </resources>

--- a/feature/core/resource/src/main/res/values/strings.xml
+++ b/feature/core/resource/src/main/res/values/strings.xml
@@ -4,7 +4,7 @@
     <string name="section_theme">테마</string>
     <string name="section_data">데이터</string>
     <string name="section_other">기타</string>
-    <string name="language_settings">언어설정</string>
+    <string name="language_settings">언어 설정</string>
     <string name="open_source_license">오픈 소스 라이센스</string>
     <string name="reset_memos">메모 초기화</string>
     <string name="reset_confirm">저장된 모든 메모가 삭제됩니다.\n정말 초기화하시겠습니까?</string>
@@ -188,7 +188,7 @@
 
     <!-- Auth -->
     <string name="section_account">계정</string>
-    <string name="sign_in_google">Google로 로그인</string>
+    <string name="sign_in_google">Google 계정 로그인</string>
     <string name="sign_out">로그아웃</string>
     <string name="sign_in_error">로그인에 실패했습니다</string>
     <string name="sign_out_confirm">로그아웃하시겠습니까?</string>

--- a/feature/home/api/src/main/java/me/pecos/memozy/feature/home/api/HomeNavigation.kt
+++ b/feature/home/api/src/main/java/me/pecos/memozy/feature/home/api/HomeNavigation.kt
@@ -6,6 +6,7 @@ import androidx.navigation.NavGraphBuilder
  * 홈 화면으로 진입하기 위한 네비게이션 정의
  */
 object HomeRoute {
+    const val LOGIN = "login"
     const val MAIN = "main"
     const val SETTINGS = "settings"
     const val TRASH = "trash"

--- a/feature/home/impl/build.gradle.kts
+++ b/feature/home/impl/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
     implementation(projects.data.repository.user.api)
     implementation(projects.datasource.remote.auth.api)
     implementation(projects.datasource.remote.ai.api)
+    implementation(projects.data.backup.api)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.appcompat)

--- a/feature/home/impl/src/main/java/me/pecos/memozy/MainActivity.kt
+++ b/feature/home/impl/src/main/java/me/pecos/memozy/MainActivity.kt
@@ -65,6 +65,7 @@ import me.pecos.memozy.presentation.components.FloatingNavPill
 import me.pecos.memozy.presentation.screen.donation.DonationScreen
 import me.pecos.memozy.presentation.screen.home.HomeScreen
 import me.pecos.memozy.presentation.screen.home.MainViewModel
+import me.pecos.memozy.presentation.screen.login.LoginScreen
 import me.pecos.memozy.presentation.screen.settings.SettingsScreen
 import me.pecos.memozy.presentation.screen.settings.SettingsViewModel
 import me.pecos.memozy.presentation.screen.settings.ThemeMode
@@ -152,7 +153,7 @@ class MainActivity : AppCompatActivity() {
                         val showBottomNav = remember(currentRoute) {
                             currentRoute?.destination?.route in listOf(
                                 HomeRoute.MAIN, HomeRoute.SETTINGS
-                            )
+                            ) && currentRoute?.destination?.route != HomeRoute.LOGIN
                         }
 
                         // ACTION_SEND 공유 수신 처리 (onNewIntent 대응)
@@ -203,6 +204,12 @@ class MainActivity : AppCompatActivity() {
                             }
                         }
 
+                        val prefs = remember {
+                            applicationContext.getSharedPreferences("settings", Context.MODE_PRIVATE)
+                        }
+                        val onboardingDone = remember { prefs.getBoolean("onboarding_done", false) }
+                        val startDest = if (onboardingDone) HomeRoute.MAIN else HomeRoute.LOGIN
+
                         val hazeState = rememberHazeState()
                         val navBg = appColors.navBackground
                         val glassStyle = remember(navBg) {
@@ -220,13 +227,30 @@ class MainActivity : AppCompatActivity() {
                         ) {
                             NavHost(
                                 navController = navController,
-                                startDestination = HomeRoute.MAIN,
+                                startDestination = startDest,
                                 modifier = Modifier.fillMaxSize().hazeSource(state = hazeState),
                                 enterTransition = { fadeIn(tween(150)) },
                                 exitTransition = { fadeOut(tween(150)) },
                                 popEnterTransition = { fadeIn(tween(150)) },
                                 popExitTransition = { fadeOut(tween(150)) }
                             ) {
+                                composable(HomeRoute.LOGIN) {
+                                    LoginScreen(
+                                        onSignIn = { idToken ->
+                                            settingsViewModel.signInWithGoogle(idToken)
+                                            prefs.edit().putBoolean("onboarding_done", true).apply()
+                                            navController.navigate(HomeRoute.MAIN) {
+                                                popUpTo(HomeRoute.LOGIN) { inclusive = true }
+                                            }
+                                        },
+                                        onSkip = {
+                                            prefs.edit().putBoolean("onboarding_done", true).apply()
+                                            navController.navigate(HomeRoute.MAIN) {
+                                                popUpTo(HomeRoute.LOGIN) { inclusive = true }
+                                            }
+                                        }
+                                    )
+                                }
                                 composable(HomeRoute.MAIN) {
                                     HomeScreen(
                                         onDelete = { id -> viewModel.deleteMemo(id) },

--- a/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/login/LoginScreen.kt
+++ b/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/login/LoginScreen.kt
@@ -1,0 +1,126 @@
+package me.pecos.memozy.presentation.screen.login
+
+import android.widget.Toast
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.credentials.CredentialManager
+import androidx.credentials.GetCredentialRequest
+import com.google.android.libraries.identity.googleid.GetGoogleIdOption
+import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential
+import com.wanted.android.wanted.design.actions.button.WantedButton
+import com.wanted.android.wanted.design.actions.button.config.WantedButtonDefaults
+import com.wanted.android.wanted.design.util.ButtonType
+import com.wanted.android.wanted.design.util.ButtonVariant
+import kotlinx.coroutines.launch
+import me.pecos.memozy.feature.core.resource.R
+import me.pecos.memozy.feature.home.impl.BuildConfig
+import me.pecos.memozy.presentation.theme.LocalActivity
+import me.pecos.memozy.presentation.theme.LocalAppColors
+
+@Composable
+fun LoginScreen(
+    onSignIn: (idToken: String) -> Unit,
+    onSkip: () -> Unit,
+) {
+    val colors = LocalAppColors.current
+    val context = LocalContext.current
+    val activity = LocalActivity.current
+    val scope = rememberCoroutineScope()
+
+    Scaffold(
+        containerColor = colors.screenBackground
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .padding(horizontal = 32.dp),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(
+                text = "Memozy",
+                fontSize = 32.sp,
+                fontWeight = FontWeight.Bold,
+                color = colors.topbarTitle
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            Text(
+                text = stringResource(R.string.login_subtitle),
+                fontSize = 14.sp,
+                color = colors.textSecondary,
+                textAlign = TextAlign.Center
+            )
+
+            Spacer(modifier = Modifier.height(48.dp))
+
+            WantedButton(
+                text = stringResource(R.string.sign_in_google),
+                modifier = Modifier.fillMaxWidth(),
+                buttonDefault = WantedButtonDefaults.getDefault(
+                    type = ButtonType.ASSISTIVE,
+                    variant = ButtonVariant.OUTLINED
+                ),
+                onClick = {
+                    scope.launch {
+                        try {
+                            val credentialManager = CredentialManager.create(context)
+                            val googleIdOption = GetGoogleIdOption.Builder()
+                                .setServerClientId(BuildConfig.GOOGLE_WEB_CLIENT_ID)
+                                .setFilterByAuthorizedAccounts(false)
+                                .build()
+                            val request = GetCredentialRequest.Builder()
+                                .addCredentialOption(googleIdOption)
+                                .build()
+                            val result = credentialManager.getCredential(
+                                context = activity ?: context,
+                                request = request,
+                            )
+                            val googleIdToken = GoogleIdTokenCredential
+                                .createFrom(result.credential.data)
+                                .idToken
+                            onSignIn(googleIdToken)
+                        } catch (e: Exception) {
+                            Toast.makeText(
+                                context,
+                                context.getString(R.string.sign_in_error),
+                                Toast.LENGTH_SHORT
+                            ).show()
+                        }
+                    }
+                }
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            WantedButton(
+                text = stringResource(R.string.login_skip),
+                modifier = Modifier.fillMaxWidth(),
+                buttonDefault = WantedButtonDefaults.getDefault(
+                    type = ButtonType.ASSISTIVE,
+                    variant = ButtonVariant.OUTLINED
+                ).copy(contentColor = colors.textSecondary),
+                onClick = onSkip
+            )
+        }
+    }
+}

--- a/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/login/LoginScreen.kt
+++ b/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/login/LoginScreen.kt
@@ -75,6 +75,7 @@ fun LoginScreen(
 
             WantedButton(
                 text = stringResource(R.string.sign_in_google),
+                leadingDrawable = R.drawable.ic_google,
                 modifier = Modifier.fillMaxWidth(),
                 buttonDefault = WantedButtonDefaults.getDefault(
                     type = ButtonType.ASSISTIVE,
@@ -99,7 +100,10 @@ fun LoginScreen(
                                 .createFrom(result.credential.data)
                                 .idToken
                             onSignIn(googleIdToken)
+                        } catch (e: androidx.credentials.exceptions.GetCredentialCancellationException) {
+                            // 사용자가 취소 — 무시
                         } catch (e: Exception) {
+                            android.util.Log.e("LoginScreen", "Sign-in failed", e)
                             Toast.makeText(
                                 context,
                                 context.getString(R.string.sign_in_error),

--- a/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/settings/SettingsScreen.kt
+++ b/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/settings/SettingsScreen.kt
@@ -4,6 +4,7 @@ import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -291,6 +292,7 @@ fun SettingsScreen(
             isPrimaryDestructive = true,
             onPrimaryClick = {
                 showCloudDeleteConfirm = null
+                showBackupListDialog = false
                 settingsViewModel.deleteCloudBackup(backupId)
             },
             secondaryButtonText = stringResource(R.string.cancel),
@@ -340,11 +342,12 @@ fun SettingsScreen(
                                 Text(
                                     text = stringResource(R.string.trash_restore),
                                     fontSize = 12.sp,
-                                    color = colors.textTitle,
+                                    color = colors.textBody,
                                     fontWeight = FontWeight.Medium,
                                     modifier = Modifier
+                                        .padding(end = 8.dp)
                                         .clickable { showCloudRestoreConfirm = backup.id }
-                                        .padding(end = 16.dp, top = 4.dp, bottom = 4.dp)
+                                        .padding(horizontal = 8.dp, vertical = 4.dp)
                                 )
                                 Text(
                                     text = stringResource(R.string.delete_action),
@@ -353,7 +356,7 @@ fun SettingsScreen(
                                     fontWeight = FontWeight.Medium,
                                     modifier = Modifier
                                         .clickable { showCloudDeleteConfirm = backup.id }
-                                        .padding(top = 4.dp, bottom = 4.dp)
+                                        .padding(horizontal = 8.dp, vertical = 4.dp)
                                 )
                             }
                         }
@@ -473,6 +476,7 @@ fun SettingsScreen(
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
+                    .verticalScroll(rememberScrollState())
                     .padding(horizontal = 16.dp, vertical = 24.dp)
             ) {
                 Text(
@@ -520,6 +524,7 @@ fun SettingsScreen(
                     is AuthState.Unauthenticated -> {
                         WantedButton(
                             text = stringResource(R.string.sign_in_google),
+                            leadingDrawable = R.drawable.ic_google,
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .padding(horizontal = 16.dp),
@@ -546,7 +551,10 @@ fun SettingsScreen(
                                             .createFrom(result.credential.data)
                                             .idToken
                                         settingsViewModel.signInWithGoogle(googleIdToken)
+                                    } catch (e: androidx.credentials.exceptions.GetCredentialCancellationException) {
+                                        // 사용자가 취소 — 무시
                                     } catch (e: Exception) {
+                                        android.util.Log.e("SettingsAuth", "Sign-in failed", e)
                                         Toast.makeText(
                                             context,
                                             context.getString(R.string.sign_in_error),
@@ -558,26 +566,27 @@ fun SettingsScreen(
                         )
                     }
                     is AuthState.Authenticated -> {
-                        Text(
-                            text = state.user.email ?: "",
-                            fontSize = 13.sp,
-                            color = colors.textBody,
-                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp)
-                        )
-
-                        Spacer(modifier = Modifier.height(8.dp))
-
-                        WantedButton(
-                            text = stringResource(R.string.sign_out),
+                        Row(
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .padding(horizontal = 16.dp),
-                            buttonDefault = WantedButtonDefaults.getDefault(
-                                type = ButtonType.ASSISTIVE,
-                                variant = ButtonVariant.OUTLINED
-                            ).copy(contentColor = colors.textTitle),
-                            onClick = { showSignOutDialog = true }
-                        )
+                                .padding(horizontal = 16.dp, vertical = 8.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.SpaceBetween
+                        ) {
+                            Text(
+                                text = state.user.email ?: "",
+                                fontSize = 13.sp,
+                                color = colors.textBody,
+                            )
+                            Text(
+                                text = stringResource(R.string.sign_out),
+                                fontSize = 12.sp,
+                                color = colors.textSecondary,
+                                modifier = Modifier
+                                    .clickable { showSignOutDialog = true }
+                                    .padding(8.dp)
+                            )
+                        }
                     }
                 }
 
@@ -639,71 +648,8 @@ fun SettingsScreen(
 
                 Spacer(modifier = Modifier.height(12.dp))
 
-                WantedButton(
-                    text = stringResource(R.string.trash_title),
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 16.dp),
-                    buttonDefault = WantedButtonDefaults.getDefault(
-                        type = ButtonType.ASSISTIVE,
-                        variant = ButtonVariant.OUTLINED
-                    ).copy(contentColor = colors.textTitle),
-                    onClick = { onTrash() }
-                )
-
-                Spacer(modifier = Modifier.height(12.dp))
-
-                WantedButton(
-                    text = stringResource(R.string.backup_export),
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 16.dp),
-                    buttonDefault = WantedButtonDefaults.getDefault(
-                        type = ButtonType.ASSISTIVE,
-                        variant = ButtonVariant.OUTLINED
-                    ).copy(contentColor = colors.textTitle),
-                    onClick = {
-                        val fileName = "memozy_backup_${
-                            java.text.SimpleDateFormat(
-                                "yyyyMMdd_HHmm",
-                                java.util.Locale.getDefault()
-                            ).format(java.util.Date())
-                        }.json"
-                        exportLauncher.launch(fileName)
-                    }
-                )
-
-                Spacer(modifier = Modifier.height(12.dp))
-
-                WantedButton(
-                    text = stringResource(R.string.backup_restore),
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 16.dp),
-                    buttonDefault = WantedButtonDefaults.getDefault(
-                        type = ButtonType.ASSISTIVE,
-                        variant = ButtonVariant.OUTLINED
-                    ).copy(contentColor = colors.textTitle),
-                    onClick = { showRestoreDialog = true }
-                )
-
-                // 클라우드 백업 섹션 (로그인 시에만 표시)
                 if (authState is AuthState.Authenticated) {
-                    Spacer(modifier = Modifier.height(12.dp))
-
-                    HorizontalDivider(
-                        thickness = 0.3.dp,
-                        modifier = Modifier.padding(horizontal = 16.dp)
-                    )
-
-                    Text(
-                        text = stringResource(R.string.section_cloud_backup),
-                        fontSize = 12.sp,
-                        fontWeight = FontWeight.Bold,
-                        color = colors.topbarTitle,
-                        modifier = Modifier.padding(start = 16.dp, bottom = 8.dp, top = 12.dp)
-                    )
-
+                    // 로그인: 클라우드 백업 위주
                     WantedButton(
                         text = if (cloudBackupState is CloudBackupState.Uploading)
                             stringResource(R.string.cloud_backup_uploading)
@@ -715,7 +661,6 @@ fun SettingsScreen(
                             type = ButtonType.ASSISTIVE,
                             variant = ButtonVariant.OUTLINED
                         ).copy(contentColor = colors.textTitle),
-
                         onClick = { settingsViewModel.uploadCloudBackup() }
                     )
 
@@ -730,13 +675,61 @@ fun SettingsScreen(
                             type = ButtonType.ASSISTIVE,
                             variant = ButtonVariant.OUTLINED
                         ).copy(contentColor = colors.textTitle),
-
                         onClick = {
                             settingsViewModel.loadBackupList()
                             showBackupListDialog = true
                         }
                     )
+                } else {
+                    // 비로그인: 로컬 백업 위주
+                    WantedButton(
+                        text = stringResource(R.string.backup_export),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp),
+                        buttonDefault = WantedButtonDefaults.getDefault(
+                            type = ButtonType.ASSISTIVE,
+                            variant = ButtonVariant.OUTLINED
+                        ).copy(contentColor = colors.textTitle),
+                        onClick = {
+                            val fileName = "memozy_backup_${
+                                java.text.SimpleDateFormat(
+                                    "yyyyMMdd_HHmm",
+                                    java.util.Locale.getDefault()
+                                ).format(java.util.Date())
+                            }.json"
+                            exportLauncher.launch(fileName)
+                        }
+                    )
+
+                    Spacer(modifier = Modifier.height(12.dp))
+
+                    WantedButton(
+                        text = stringResource(R.string.backup_restore),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp),
+                        buttonDefault = WantedButtonDefaults.getDefault(
+                            type = ButtonType.ASSISTIVE,
+                            variant = ButtonVariant.OUTLINED
+                        ).copy(contentColor = colors.textTitle),
+                        onClick = { showRestoreDialog = true }
+                    )
                 }
+
+                Spacer(modifier = Modifier.height(12.dp))
+
+                WantedButton(
+                    text = stringResource(R.string.trash_title),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp),
+                    buttonDefault = WantedButtonDefaults.getDefault(
+                        type = ButtonType.ASSISTIVE,
+                        variant = ButtonVariant.OUTLINED
+                    ).copy(contentColor = colors.textTitle),
+                    onClick = { onTrash() }
+                )
 
                 if (isDonationEnabled) {
                     Spacer(modifier = Modifier.height(12.dp))
@@ -801,6 +794,9 @@ fun SettingsScreen(
                         .padding(top = 12.dp)
                         .align(alignment = Alignment.CenterHorizontally)
                 )
+
+                // 하단 여유 공간 (네비게이션 바에 가리지 않도록)
+                Spacer(modifier = Modifier.height(80.dp))
             }
         }
     }

--- a/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/settings/SettingsScreen.kt
+++ b/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/settings/SettingsScreen.kt
@@ -489,47 +489,6 @@ fun SettingsScreen(
                 )
 
                 Text(
-                    text = stringResource(R.string.section_theme),
-                    fontSize = 12.sp,
-                    fontWeight = FontWeight.Bold,
-                    color = colors.topbarTitle,
-                    modifier = Modifier.padding(start = 16.dp, bottom = 8.dp, top = 12.dp)
-                )
-
-                WantedButton(
-                    text = stringResource(R.string.language_settings),
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 16.dp),
-                    buttonDefault = WantedButtonDefaults.getDefault(
-                        type = ButtonType.ASSISTIVE,
-                        variant = ButtonVariant.OUTLINED
-                    ).copy(contentColor = colors.textTitle),
-                    onClick = { showLanguageDialog = true }
-                )
-
-                Spacer(modifier = Modifier.height(12.dp))
-
-                WantedButton(
-                    text = stringResource(R.string.theme_settings),
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 16.dp),
-                    buttonDefault = WantedButtonDefaults.getDefault(
-                        type = ButtonType.ASSISTIVE,
-                        variant = ButtonVariant.OUTLINED
-                    ).copy(contentColor = colors.textTitle),
-                    onClick = { showThemeDialog = true }
-                )
-
-                Spacer(modifier = Modifier.height(12.dp))
-
-                HorizontalDivider(
-                    thickness = 0.3.dp,
-                    modifier = Modifier.padding(horizontal = 16.dp)
-                )
-
-                Text(
                     text = stringResource(R.string.section_account),
                     fontSize = 12.sp,
                     fontWeight = FontWeight.Bold,
@@ -621,6 +580,47 @@ fun SettingsScreen(
                         )
                     }
                 }
+
+                Spacer(modifier = Modifier.height(12.dp))
+
+                HorizontalDivider(
+                    thickness = 0.3.dp,
+                    modifier = Modifier.padding(horizontal = 16.dp)
+                )
+
+                Text(
+                    text = stringResource(R.string.section_theme),
+                    fontSize = 12.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = colors.topbarTitle,
+                    modifier = Modifier.padding(start = 16.dp, bottom = 8.dp, top = 12.dp)
+                )
+
+                WantedButton(
+                    text = stringResource(R.string.language_settings),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp),
+                    buttonDefault = WantedButtonDefaults.getDefault(
+                        type = ButtonType.ASSISTIVE,
+                        variant = ButtonVariant.OUTLINED
+                    ).copy(contentColor = colors.textTitle),
+                    onClick = { showLanguageDialog = true }
+                )
+
+                Spacer(modifier = Modifier.height(12.dp))
+
+                WantedButton(
+                    text = stringResource(R.string.theme_settings),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp),
+                    buttonDefault = WantedButtonDefaults.getDefault(
+                        type = ButtonType.ASSISTIVE,
+                        variant = ButtonVariant.OUTLINED
+                    ).copy(contentColor = colors.textTitle),
+                    onClick = { showThemeDialog = true }
+                )
 
                 Spacer(modifier = Modifier.height(12.dp))
 

--- a/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/settings/SettingsScreen.kt
+++ b/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/settings/SettingsScreen.kt
@@ -69,12 +69,17 @@ fun SettingsScreen(
     var showThemeDialog by remember { mutableStateOf(false) }
     var showRestoreDialog by remember { mutableStateOf(false) }
     var showSignOutDialog by remember { mutableStateOf(false) }
+    var showBackupListDialog by remember { mutableStateOf(false) }
+    var showCloudRestoreConfirm by remember { mutableStateOf<String?>(null) }
+    var showCloudDeleteConfirm by remember { mutableStateOf<String?>(null) }
 
     val selectedLanguage by settingsViewModel.selectedLanguage.collectAsState()
     val selectedTheme by settingsViewModel.selectedTheme.collectAsState()
     val backupResult by settingsViewModel.backupResult.collectAsState()
     val isDonationEnabled by settingsViewModel.isDonationEnabled.collectAsState()
     val authState by settingsViewModel.authState.collectAsState()
+    val cloudBackupState by settingsViewModel.cloudBackupState.collectAsState()
+    val backupList by settingsViewModel.backupList.collectAsState()
     val colors = LocalAppColors.current
     val context = LocalContext.current
     val activity = LocalActivity.current
@@ -110,6 +115,33 @@ fun SettingsScreen(
                 settingsViewModel.clearBackupResult()
             }
 
+            else -> {}
+        }
+    }
+
+    // 클라우드 백업 결과 토스트
+    LaunchedEffect(cloudBackupState) {
+        when (val state = cloudBackupState) {
+            is CloudBackupState.UploadSuccess -> {
+                Toast.makeText(
+                    context,
+                    context.getString(R.string.cloud_backup_success, state.memoCount),
+                    Toast.LENGTH_SHORT
+                ).show()
+                settingsViewModel.clearCloudBackupState()
+            }
+            is CloudBackupState.RestoreSuccess -> {
+                Toast.makeText(
+                    context,
+                    context.getString(R.string.cloud_backup_restore_success, state.memoCount),
+                    Toast.LENGTH_SHORT
+                ).show()
+                settingsViewModel.clearCloudBackupState()
+            }
+            is CloudBackupState.Error -> {
+                Toast.makeText(context, state.message, Toast.LENGTH_SHORT).show()
+                settingsViewModel.clearCloudBackupState()
+            }
             else -> {}
         }
     }
@@ -222,6 +254,113 @@ fun SettingsScreen(
             onSecondaryClick = { showRestoreDialog = false }
         ) {
             Text(stringResource(R.string.backup_restore_confirm), color = colors.textBody)
+        }
+    }
+
+    // 클라우드 복원 확인
+    showCloudRestoreConfirm?.let { backupId ->
+        AppPopup(
+            onDismissRequest = { showCloudRestoreConfirm = null },
+            title = stringResource(R.string.cloud_backup_restore),
+            navigation = PopupNavigation.EMPHASIZED,
+            size = PopupSize.MEDIUM,
+            actionArea = PopupActionArea.NEUTRAL,
+            primaryButtonText = stringResource(R.string.backup_restore_action),
+            isPrimaryDestructive = true,
+            onPrimaryClick = {
+                showCloudRestoreConfirm = null
+                showBackupListDialog = false
+                settingsViewModel.restoreFromCloud(backupId)
+            },
+            secondaryButtonText = stringResource(R.string.cancel),
+            onSecondaryClick = { showCloudRestoreConfirm = null }
+        ) {
+            Text(stringResource(R.string.cloud_backup_restore_confirm), color = colors.textBody)
+        }
+    }
+
+    // 클라우드 백업 삭제 확인
+    showCloudDeleteConfirm?.let { backupId ->
+        AppPopup(
+            onDismissRequest = { showCloudDeleteConfirm = null },
+            title = stringResource(R.string.delete_action),
+            navigation = PopupNavigation.EMPHASIZED,
+            size = PopupSize.MEDIUM,
+            actionArea = PopupActionArea.NEUTRAL,
+            primaryButtonText = stringResource(R.string.delete_action),
+            isPrimaryDestructive = true,
+            onPrimaryClick = {
+                showCloudDeleteConfirm = null
+                settingsViewModel.deleteCloudBackup(backupId)
+            },
+            secondaryButtonText = stringResource(R.string.cancel),
+            onSecondaryClick = { showCloudDeleteConfirm = null }
+        ) {
+            Text(stringResource(R.string.cloud_backup_delete_confirm), color = colors.textBody)
+        }
+    }
+
+    // 백업 목록 다이얼로그
+    if (showBackupListDialog) {
+        AppPopup(
+            onDismissRequest = { showBackupListDialog = false },
+            title = stringResource(R.string.cloud_backup_manage),
+            navigation = PopupNavigation.EMPHASIZED,
+            size = PopupSize.LARGE,
+            actionArea = PopupActionArea.NONE
+        ) {
+            if (backupList.isEmpty()) {
+                Text(
+                    stringResource(R.string.cloud_backup_empty),
+                    color = colors.textSecondary,
+                    fontSize = 13.sp,
+                    modifier = Modifier.padding(vertical = 16.dp)
+                )
+            } else {
+                Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
+                    backupList.forEach { backup ->
+                        Column(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(vertical = 8.dp)
+                        ) {
+                            Text(
+                                text = "${backup.device_name} · v${backup.app_version}",
+                                fontSize = 14.sp,
+                                fontWeight = FontWeight.Medium,
+                                color = colors.textTitle
+                            )
+                            Text(
+                                text = "${backup.created_at.take(10)} · ${stringResource(R.string.cloud_backup_memo_count, backup.memo_count)}",
+                                fontSize = 12.sp,
+                                color = colors.textSecondary,
+                                modifier = Modifier.padding(top = 2.dp)
+                            )
+                            Row(modifier = Modifier.padding(top = 4.dp)) {
+                                Text(
+                                    text = stringResource(R.string.trash_restore),
+                                    fontSize = 12.sp,
+                                    color = colors.textTitle,
+                                    fontWeight = FontWeight.Medium,
+                                    modifier = Modifier
+                                        .clickable { showCloudRestoreConfirm = backup.id }
+                                        .padding(end = 16.dp, top = 4.dp, bottom = 4.dp)
+                                )
+                                Text(
+                                    text = stringResource(R.string.delete_action),
+                                    fontSize = 12.sp,
+                                    color = Color(0xFFE24B4A),
+                                    fontWeight = FontWeight.Medium,
+                                    modifier = Modifier
+                                        .clickable { showCloudDeleteConfirm = backup.id }
+                                        .padding(top = 4.dp, bottom = 4.dp)
+                                )
+                            }
+                        }
+                        HorizontalDivider(thickness = 0.3.dp, color = colors.cardBorder)
+                    }
+                }
+            }
         }
     }
 
@@ -547,6 +686,57 @@ fun SettingsScreen(
                     ).copy(contentColor = colors.textTitle),
                     onClick = { showRestoreDialog = true }
                 )
+
+                // 클라우드 백업 섹션 (로그인 시에만 표시)
+                if (authState is AuthState.Authenticated) {
+                    Spacer(modifier = Modifier.height(12.dp))
+
+                    HorizontalDivider(
+                        thickness = 0.3.dp,
+                        modifier = Modifier.padding(horizontal = 16.dp)
+                    )
+
+                    Text(
+                        text = stringResource(R.string.section_cloud_backup),
+                        fontSize = 12.sp,
+                        fontWeight = FontWeight.Bold,
+                        color = colors.topbarTitle,
+                        modifier = Modifier.padding(start = 16.dp, bottom = 8.dp, top = 12.dp)
+                    )
+
+                    WantedButton(
+                        text = if (cloudBackupState is CloudBackupState.Uploading)
+                            stringResource(R.string.cloud_backup_uploading)
+                        else stringResource(R.string.cloud_backup_now),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp),
+                        buttonDefault = WantedButtonDefaults.getDefault(
+                            type = ButtonType.ASSISTIVE,
+                            variant = ButtonVariant.OUTLINED
+                        ).copy(contentColor = colors.textTitle),
+
+                        onClick = { settingsViewModel.uploadCloudBackup() }
+                    )
+
+                    Spacer(modifier = Modifier.height(12.dp))
+
+                    WantedButton(
+                        text = stringResource(R.string.cloud_backup_manage),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp),
+                        buttonDefault = WantedButtonDefaults.getDefault(
+                            type = ButtonType.ASSISTIVE,
+                            variant = ButtonVariant.OUTLINED
+                        ).copy(contentColor = colors.textTitle),
+
+                        onClick = {
+                            settingsViewModel.loadBackupList()
+                            showBackupListDialog = true
+                        }
+                    )
+                }
 
                 if (isDonationEnabled) {
                     Spacer(modifier = Modifier.height(12.dp))

--- a/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/settings/SettingsViewModel.kt
+++ b/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/settings/SettingsViewModel.kt
@@ -15,6 +15,8 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import me.pecos.memozy.data.datasource.local.MemoDao
 import me.pecos.memozy.data.datasource.local.entity.Memo
+import me.pecos.memozy.data.backup.BackupMeta
+import me.pecos.memozy.data.backup.BackupRepository
 import me.pecos.memozy.data.datasource.remote.auth.AuthState
 import me.pecos.memozy.data.repository.MemoRepository
 import me.pecos.memozy.data.repository.model.MemoFormat
@@ -31,6 +33,15 @@ val LANGUAGES = listOf(
     Language("日本語", "ja"),
 )
 
+sealed class CloudBackupState {
+    data object Idle : CloudBackupState()
+    data object Uploading : CloudBackupState()
+    data object Restoring : CloudBackupState()
+    data class UploadSuccess(val memoCount: Int) : CloudBackupState()
+    data class RestoreSuccess(val memoCount: Int) : CloudBackupState()
+    data class Error(val message: String) : CloudBackupState()
+}
+
 sealed class BackupResult {
     data object Idle : BackupResult()
     data object Loading : BackupResult()
@@ -44,6 +55,7 @@ class SettingsViewModel @Inject constructor(
     private val repository: MemoRepository,
     private val memoDao: MemoDao,
     private val authRepository: AuthRepository,
+    private val backupRepository: BackupRepository,
 ) : ViewModel() {
 
     private val prefs = context.getSharedPreferences("settings", Context.MODE_PRIVATE)
@@ -98,6 +110,51 @@ class SettingsViewModel @Inject constructor(
         viewModelScope.launch {
             authRepository.signOut()
         }
+    }
+
+    // --- Cloud Backup ---
+
+    private val _cloudBackupState = MutableStateFlow<CloudBackupState>(CloudBackupState.Idle)
+    val cloudBackupState: StateFlow<CloudBackupState> = _cloudBackupState
+
+    private val _backupList = MutableStateFlow<List<BackupMeta>>(emptyList())
+    val backupList: StateFlow<List<BackupMeta>> = _backupList
+
+    fun uploadCloudBackup() {
+        viewModelScope.launch {
+            _cloudBackupState.value = CloudBackupState.Uploading
+            backupRepository.uploadBackup()
+                .onSuccess { _cloudBackupState.value = CloudBackupState.UploadSuccess(it.memo_count) }
+                .onFailure { _cloudBackupState.value = CloudBackupState.Error(it.message ?: "Unknown error") }
+        }
+    }
+
+    fun loadBackupList() {
+        viewModelScope.launch {
+            backupRepository.listBackups()
+                .onSuccess { _backupList.value = it }
+                .onFailure { _backupList.value = emptyList() }
+        }
+    }
+
+    fun restoreFromCloud(backupId: String) {
+        viewModelScope.launch {
+            _cloudBackupState.value = CloudBackupState.Restoring
+            backupRepository.restoreFromCloud(backupId)
+                .onSuccess { _cloudBackupState.value = CloudBackupState.RestoreSuccess(it) }
+                .onFailure { _cloudBackupState.value = CloudBackupState.Error(it.message ?: "Unknown error") }
+        }
+    }
+
+    fun deleteCloudBackup(backupId: String) {
+        viewModelScope.launch {
+            backupRepository.deleteBackup(backupId)
+                .onSuccess { loadBackupList() }
+        }
+    }
+
+    fun clearCloudBackupState() {
+        _cloudBackupState.value = CloudBackupState.Idle
     }
 
     // ── Backup (Export) ──

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,6 +25,7 @@ kotlinxSerialization = "1.8.1"
 richeditor = "1.0.0-rc11"
 glance = "1.1.1"
 coil = "2.7.0"
+work = "2.10.1"
 supabase = "3.2.3"
 credentialManager = "1.5.0"
 googleIdIdentity = "1.1.1"
@@ -86,6 +87,9 @@ supabase-postgrest = { group = "io.github.jan-tennert.supabase", name = "postgre
 credential-manager = { group = "androidx.credentials", name = "credentials", version.ref = "credentialManager" }
 credential-manager-play = { group = "androidx.credentials", name = "credentials-play-services-auth", version.ref = "credentialManager" }
 google-id-identity = { group = "com.google.android.libraries.identity.googleid", name = "googleid", version.ref = "googleIdIdentity" }
+work-runtime = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "work" }
+work-hilt = { group = "androidx.hilt", name = "hilt-work", version.ref = "hiltNavigationCompose" }
+work-hilt-compiler = { group = "androidx.hilt", name = "hilt-compiler", version.ref = "hiltNavigationCompose" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/workers/package-lock.json
+++ b/workers/package-lock.json
@@ -693,9 +693,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -713,9 +710,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -733,9 +727,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -753,9 +744,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -773,9 +761,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -793,9 +778,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -813,9 +795,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -833,9 +812,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -853,9 +829,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -879,9 +852,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -905,9 +875,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -931,9 +898,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -957,9 +921,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -983,9 +944,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1009,9 +967,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1035,9 +990,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [

--- a/workers/src/index.ts
+++ b/workers/src/index.ts
@@ -27,39 +27,27 @@ async function verifyJwt(req: Request, env: Env): Promise<{ userId: string } | R
   if (!authHeader?.startsWith("Bearer ")) {
     return Response.json({ error: "Missing Authorization header" }, { status: 401 });
   }
-  const token = authHeader.slice(7);
   try {
-    const [headerB64, payloadB64] = token.split(".");
-    const payload = JSON.parse(atob(payloadB64.replace(/-/g, "+").replace(/_/g, "/")));
-
-    // Verify expiration
-    if (payload.exp && payload.exp < Math.floor(Date.now() / 1000)) {
-      return Response.json({ error: "Token expired" }, { status: 401 });
+    // Verify token via Supabase Auth API
+    const url = `${env.SUPABASE_URL}/auth/v1/user`;
+    console.log("Verifying JWT via:", url);
+    const userRes = await fetch(url, {
+      headers: {
+        "Authorization": authHeader,
+        "apikey": env.SUPABASE_SERVICE_KEY,
+      },
+    });
+    if (!userRes.ok) {
+      const err = await userRes.text();
+      console.log("Supabase auth failed:", userRes.status, err);
+      return Response.json({ error: "Auth failed", detail: err }, { status: 401 });
     }
-
-    // Verify signature using HMAC-SHA256 with Supabase JWT secret
-    const encoder = new TextEncoder();
-    const key = await crypto.subtle.importKey(
-      "raw",
-      encoder.encode(env.SUPABASE_JWT_SECRET),
-      { name: "HMAC", hash: "SHA-256" },
-      false,
-      ["verify"]
-    );
-    const signatureInput = encoder.encode(`${headerB64}.${payloadB64}`);
-    const signatureB64 = token.split(".")[2];
-    const signature = Uint8Array.from(
-      atob(signatureB64.replace(/-/g, "+").replace(/_/g, "/")),
-      (c) => c.charCodeAt(0)
-    );
-    const valid = await crypto.subtle.verify("HMAC", key, signature, signatureInput);
-    if (!valid) {
-      return Response.json({ error: "Invalid token signature" }, { status: 401 });
-    }
-
-    return { userId: payload.sub };
-  } catch {
-    return Response.json({ error: "Invalid token" }, { status: 401 });
+    const user = await userRes.json<{ id: string }>();
+    console.log("Auth OK, userId:", user.id);
+    return { userId: user.id };
+  } catch (e) {
+    console.log("JWT verify exception:", (e as Error).message);
+    return Response.json({ error: "Token verify failed", detail: (e as Error).message }, { status: 401 });
   }
 }
 
@@ -270,9 +258,14 @@ interface BackupRequest {
 
 async function handleBackupCreate(req: Request, env: Env): Promise<Response> {
   const auth = await verifyJwt(req, env);
-  if (auth instanceof Response) return auth;
+  if (auth instanceof Response) {
+    console.log("JWT auth failed");
+    return auth;
+  }
+  console.log("JWT auth OK, userId:", auth.userId);
 
   const body = await req.json<BackupRequest>();
+  console.log("Request body keys:", Object.keys(body));
 
   if (!body.device_name || !body.app_version || !body.tables) {
     return Response.json({ error: "Missing required fields" }, { status: 400 });
@@ -303,18 +296,22 @@ async function handleBackupCreate(req: Request, env: Env): Promise<Response> {
 
   if (!metaRes.ok) {
     const err = await metaRes.text();
+    console.log("Supabase meta insert failed:", metaRes.status, err);
     return Response.json({ error: "Failed to create backup", detail: err }, { status: 500 });
   }
+  console.log("Supabase meta insert OK");
 
   const [backup] = await metaRes.json<{ id: string; created_at: string }[]>();
 
-  // 2. Insert backup data per table
-  const dataRows = Object.entries(body.tables).map(([tableName, rows]) => ({
-    backup_id: backup.id,
-    table_name: tableName,
-    data: rows,
-    row_count: Array.isArray(rows) ? rows.length : 0,
-  }));
+  // 2. Insert backup data per table (skip null/empty tables)
+  const dataRows = Object.entries(body.tables)
+    .filter(([, rows]) => rows != null)
+    .map(([tableName, rows]) => ({
+      backup_id: backup.id,
+      table_name: tableName,
+      data: rows,
+      row_count: Array.isArray(rows) ? rows.length : 0,
+    }));
 
   const dataRes = await supabaseRest(env, "backup_data", {
     method: "POST",
@@ -325,8 +322,10 @@ async function handleBackupCreate(req: Request, env: Env): Promise<Response> {
     // Rollback: delete the backup metadata
     await supabaseRest(env, `backups?id=eq.${backup.id}`, { method: "DELETE" });
     const err = await dataRes.text();
+    console.log("Backup data insert failed:", dataRes.status, err);
     return Response.json({ error: "Failed to save backup data", detail: err }, { status: 500 });
   }
+  console.log("Backup data insert OK, tables:", dataRows.length);
 
   return Response.json(
     { id: backup.id, created_at: backup.created_at, memo_count: memoCount },


### PR DESCRIPTION
## Summary
Closes #123 — Supabase + Cloudflare Workers 기반 클라우드 백업/복원 기능 구현 완료

### 하위 이슈 체크
- [x] #124 Supabase Auth 연동 (Google 로그인)
- [x] #125 Supabase PostgreSQL 백업 스키마 설계
- [x] #126 Cloudflare Workers 백업 API 구현
- [x] #127 Android 백업 데이터 직렬화/역직렬화
- [x] #128 Android 백업/복원 UI 및 자동 백업

---

## Before → After

### 1. JWT 인증 구조

**Before**
```
Android App → Cloudflare Worker (HMAC-SHA256 수동 검증)
                  └─ SUPABASE_JWT_SECRET으로 직접 서명 검증
                  └─ Supabase ECC(P-256) 키 전환 후 검증 실패
```

**After**
```
Android App → Cloudflare Worker → Supabase Auth API (/auth/v1/user)
                  └─ Supabase가 자체적으로 토큰 검증
                  └─ 키 알고리즘(HS256/ES256) 변경에 영향받지 않음
```

### 2. HttpClient 구조

**Before**
```
AINetworkModule (HttpClient - 싱글톤)
  ├─ AI API 호출 (Gemini, YouTube 등)
  ├─ Backup API 호출  ← 공유
  └─ HttpResponseValidator
       └─ 401 → AIException("Invalid or missing API key.")  ← 실제 에러 숨김
```

**After**
```
AINetworkModule (HttpClient)                 BackupModule (@BackupHttpClient)
  ├─ AI API 호출 전용                          ├─ Backup API 호출 전용
  └─ x-app-key 헤더 포함                      ├─ x-app-key 헤더 없음
                                              └─ HttpResponseValidator
                                                   └─ 실제 에러 바디 그대로 전달
```

### 3. Worker 백업 데이터 저장

**Before**
```
tables: { memos: [...], categories: [...], chatSessions: null, chatMessages: null }
         → backup_data INSERT → NOT NULL 제약 위반 → 500 에러
```

**After**
```
tables: { memos: [...], categories: [...], chatSessions: null, chatMessages: null }
         → null 테이블 필터링 → memos, categories만 INSERT → 성공
```

### 4. 자동 백업

**Before**: 수동 백업만 가능

**After**:
```
MemozyApplication
  └─ authState 관찰
       ├─ Authenticated → BackupScheduler.schedule() (24시간 주기)
       └─ Unauthenticated → BackupScheduler.cancel()
```

### 5. Settings UI

**Before**: 로그인 없이 로컬 백업만 지원

**After**:
- 계정 섹션 최상단 배치 (Google 로그인 / 이메일 표시 / 로그아웃)
- 로그인 시: 클라우드 백업/복원 UI 표시
- 비로그인 시: 로컬 백업(JSON export/import) 유지
- 백업 관리 팝업: 복원/삭제 버튼 스타일 통일, ripple 영역 통일, 팝업 잔상 제거

---

## 변경 파일 요약

| 영역 | 파일 | 변경 내용 |
|------|------|----------|
| Worker | `workers/src/index.ts` | JWT 검증을 Supabase Auth API로 전환, null 테이블 필터링 |
| DI | `BackupModule.kt` (신규) | `@BackupHttpClient` qualifier + 전용 HttpClient 제공 |
| DI | `AINetworkModule.kt` | 기존 HttpClient는 AI 전용으로 유지 |
| 네트워크 | `BackupRepositoryImpl.kt` | `@BackupHttpClient` 주입, 클라우드 CRUD |
| 모델 | `BackupModels.kt` | 클라우드 API 요청/응답 모델 추가 |
| Worker | `BackupWorker.kt` (신규) | WorkManager 기반 자동 백업 |
| Worker | `BackupScheduler.kt` (신규) | 24시간 주기 백업 스케줄링 |
| App | `MemozyApplication.kt` | 인증 상태 관찰 → 자동 백업 스케줄 관리 |
| UI | `SettingsScreen.kt` | 계정 섹션, 클라우드 백업 UI, 팝업 개선 |
| UI | `LoginScreen.kt` | 첫 실행 로그인 화면 |
| 리소스 | `strings.xml` (ko/en/ja) | 백업/로그인 관련 문자열 추가 |

## Test plan
- [x] Google 로그인 → Supabase Auth 토큰 발급 확인
- [x] 클라우드 백업 생성 → Supabase에 데이터 저장 확인
- [x] 백업 목록 조회 → 기기명, 버전, 날짜, 메모 개수 표시 확인
- [x] 백업 복원 → 로컬 DB 덮어쓰기 확인
- [x] 백업 삭제 → Supabase에서 제거 확인
- [x] 팝업 잔상 없이 정상 닫힘 확인
- [ ] 자동 백업 (24시간 주기) 동작 확인
- [ ] 로그아웃 후 클라우드 백업 UI 숨김 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)