### PR TITLE
Update: 클라우드 백업 Supabase 직접 upsert 전환 + UI 통일

### DIFF
--- a/app/src/main/java/me/pecos/memozy/MemozyApplication.kt
+++ b/app/src/main/java/me/pecos/memozy/MemozyApplication.kt
@@ -29,16 +29,5 @@ class MemozyApplication : Application(), Configuration.Provider {
 
     override fun onCreate() {
         super.onCreate()
-
-        // 로그인 상태 변경 시 자동 백업 스케줄링
-        appScope.launch {
-            authService.authState.collectLatest { state ->
-                when (state) {
-                    is AuthState.Authenticated -> BackupScheduler.schedule(this@MemozyApplication)
-                    is AuthState.Unauthenticated -> BackupScheduler.cancel(this@MemozyApplication)
-                    else -> {}
-                }
-            }
-        }
     }
 }

--- a/data/backup/api/src/main/java/me/pecos/memozy/data/backup/BackupModels.kt
+++ b/data/backup/api/src/main/java/me/pecos/memozy/data/backup/BackupModels.kt
@@ -1,6 +1,101 @@
 package me.pecos.memozy.data.backup
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+
+// ── Supabase table DTOs (snake_case for PostgREST) ──
+
+@Serializable
+data class SupaMemo(
+    val id: Int,
+    @SerialName("user_id") val userId: String,
+    val name: String,
+    @SerialName("category_id") val categoryId: Int,
+    val content: String,
+    @SerialName("created_at") val createdAt: Long,
+    @SerialName("updated_at") val updatedAt: Long,
+    val format: String = "PLAIN",
+    @SerialName("is_pinned") val isPinned: Boolean = false,
+    @SerialName("audio_path") val audioPath: String? = null,
+    val styles: String? = null,
+    @SerialName("youtube_url") val youtubeUrl: String? = null,
+    @SerialName("deleted_at") val deletedAt: Long? = null,
+    @SerialName("reminder_at") val reminderAt: Long? = null,
+    @SerialName("summary_content") val summaryContent: String? = null,
+)
+
+@Serializable
+data class SupaCategory(
+    val id: Int,
+    @SerialName("user_id") val userId: String,
+    val name: String,
+)
+
+@Serializable
+data class SupaChatSession(
+    val id: Int,
+    @SerialName("user_id") val userId: String,
+    val title: String,
+    @SerialName("created_at") val createdAt: Long,
+    @SerialName("updated_at") val updatedAt: Long,
+    val category: String = "general",
+)
+
+@Serializable
+data class SupaChatMessage(
+    val id: Int,
+    @SerialName("user_id") val userId: String,
+    @SerialName("session_id") val sessionId: Int,
+    val role: String,
+    val content: String,
+    val timestamp: Long,
+    val metadata: String? = null,
+)
+
+@Serializable
+data class SupaYoutubeSummary(
+    @SerialName("user_id") val userId: String,
+    @SerialName("video_id") val videoId: String,
+    val mode: String,
+    val language: String,
+    val url: String,
+    val summary: String,
+    @SerialName("created_at") val createdAt: Long,
+)
+
+@Serializable
+data class SupaAiUsage(
+    val id: Long,
+    @SerialName("user_id") val userId: String,
+    val feature: String,
+    @SerialName("used_at") val usedAt: Long,
+)
+
+@Serializable
+data class SupaBackupMetadataInsert(
+    @SerialName("user_id") val userId: String,
+    @SerialName("device_name") val deviceName: String,
+    @SerialName("app_version") val appVersion: String,
+    @SerialName("db_version") val dbVersion: Int,
+    @SerialName("memo_count") val memoCount: Int = 0,
+    @SerialName("total_rows") val totalRows: Int = 0,
+    @SerialName("size_bytes") val sizeBytes: Long = 0,
+)
+
+@Serializable
+data class SupaBackupMetadata(
+    val id: String,
+    @SerialName("user_id") val userId: String,
+    @SerialName("device_name") val deviceName: String,
+    @SerialName("app_version") val appVersion: String,
+    @SerialName("db_version") val dbVersion: Int,
+    @SerialName("memo_count") val memoCount: Int = 0,
+    @SerialName("total_rows") val totalRows: Int = 0,
+    @SerialName("size_bytes") val sizeBytes: Long = 0,
+    @SerialName("created_at") val createdAt: String = "",
+)
+
+// ── Legacy local backup models (JSON export/import) ──
 
 @Serializable
 data class BackupPayload(
@@ -59,41 +154,4 @@ data class ChatMessageBackup(
     val content: String,
     val timestamp: Long,
     val metadata: String? = null,
-)
-
-// --- Cloud backup API request ---
-
-@Serializable
-data class BackupUploadRequest(
-    val device_name: String,
-    val app_version: String,
-    val db_version: Int,
-    val tables: BackupTables,
-)
-
-// --- Cloud backup metadata ---
-
-@Serializable
-data class BackupMeta(
-    val id: String,
-    val device_name: String,
-    val app_version: String,
-    val db_version: Int,
-    val memo_count: Int,
-    val size_bytes: Long,
-    val created_at: String,
-)
-
-@Serializable
-data class BackupCreateResponse(
-    val id: String,
-    val created_at: String,
-    val memo_count: Int,
-)
-
-@Serializable
-data class BackupDownloadResponse(
-    val id: String,
-    val metadata: BackupMeta,
-    val tables: BackupTables,
 )

--- a/data/backup/api/src/main/java/me/pecos/memozy/data/backup/BackupRepository.kt
+++ b/data/backup/api/src/main/java/me/pecos/memozy/data/backup/BackupRepository.kt
@@ -1,13 +1,12 @@
 package me.pecos.memozy.data.backup
 
 interface BackupRepository {
+    // Cloud operations (Supabase direct upsert)
+    suspend fun uploadBackup(): Result<Int>
+    suspend fun restoreFromCloud(): Result<Int>
+    suspend fun getLastBackupTime(): Result<String?>
+
+    // Local JSON backup (legacy)
     suspend fun createBackupPayload(): BackupPayload
     suspend fun restoreFromPayload(payload: BackupPayload)
-
-    // Cloud operations
-    suspend fun uploadBackup(): Result<BackupCreateResponse>
-    suspend fun listBackups(): Result<List<BackupMeta>>
-    suspend fun downloadBackup(backupId: String): Result<BackupDownloadResponse>
-    suspend fun deleteBackup(backupId: String): Result<Unit>
-    suspend fun restoreFromCloud(backupId: String): Result<Int>
 }

--- a/data/backup/impl/build.gradle.kts
+++ b/data/backup/impl/build.gradle.kts
@@ -1,28 +1,11 @@
 import me.pecos.memozy.convention.extension.setNamespace
-import java.util.Properties
 
 plugins {
     id("memozy.android.library")
     id("memozy.hilt")
-    id("memozy.ktor")
 }
 
 setNamespace("data.backup.impl")
-
-val localProperties = Properties().apply {
-    val file = rootProject.file("local.properties")
-    if (file.exists()) load(file.inputStream())
-}
-
-android {
-    buildFeatures {
-        buildConfig = true
-    }
-
-    defaultConfig {
-        buildConfigField("String", "WORKER_URL", "\"${localProperties.getProperty("worker.url", "")}\"")
-    }
-}
 
 dependencies {
     implementation(projects.data.backup.api)
@@ -31,4 +14,6 @@ dependencies {
     implementation(projects.datasource.remote.auth.api)
     implementation(libs.kotlinx.coroutines.android)
     implementation(libs.room.ktx)
+    implementation(platform(libs.supabase.bom))
+    implementation(libs.supabase.postgrest)
 }

--- a/data/backup/impl/src/main/java/me/pecos/memozy/data/backup/BackupRepositoryImpl.kt
+++ b/data/backup/impl/src/main/java/me/pecos/memozy/data/backup/BackupRepositoryImpl.kt
@@ -2,24 +2,20 @@ package me.pecos.memozy.data.backup
 
 import android.content.Context
 import dagger.hilt.android.qualifiers.ApplicationContext
-import io.ktor.client.HttpClient
-import io.ktor.client.call.body
-import io.ktor.client.request.delete
-import io.ktor.client.request.get
-import io.ktor.client.request.header
-import io.ktor.client.request.post
-import io.ktor.client.request.setBody
-import io.ktor.http.ContentType
-import io.ktor.http.contentType
+import io.github.jan.supabase.SupabaseClient
+import io.github.jan.supabase.postgrest.from
+import me.pecos.memozy.data.datasource.local.AiUsageDao
 import me.pecos.memozy.data.datasource.local.CategoryDao
 import me.pecos.memozy.data.datasource.local.MemoDao
+import me.pecos.memozy.data.datasource.local.YoutubeSummaryDao
 import me.pecos.memozy.data.datasource.local.chat.ChatMessageDao
 import me.pecos.memozy.data.datasource.local.chat.ChatSessionDao
 import me.pecos.memozy.data.datasource.local.chat.entity.ChatMessage
 import me.pecos.memozy.data.datasource.local.chat.entity.ChatSession
+import me.pecos.memozy.data.datasource.local.entity.AiUsage
 import me.pecos.memozy.data.datasource.local.entity.Category
 import me.pecos.memozy.data.datasource.local.entity.Memo
-import me.pecos.memozy.data.backup.di.BackupHttpClient
+import me.pecos.memozy.data.datasource.local.entity.YoutubeSummary
 import me.pecos.memozy.data.datasource.remote.auth.AuthService
 import me.pecos.memozy.data.repository.model.MemoFormat
 import javax.inject.Inject
@@ -32,17 +28,165 @@ class BackupRepositoryImpl @Inject constructor(
     private val categoryDao: CategoryDao,
     private val chatSessionDao: ChatSessionDao,
     private val chatMessageDao: ChatMessageDao,
+    private val youtubeSummaryDao: YoutubeSummaryDao,
+    private val aiUsageDao: AiUsageDao,
     private val authService: AuthService,
-    @BackupHttpClient private val httpClient: HttpClient,
+    private val supabaseClient: SupabaseClient,
 ) : BackupRepository {
+
+    private fun userId(): String =
+        authService.currentUser?.id ?: throw IllegalStateException("Not authenticated")
+
+    // ── Cloud Upload (upsert) ──
+
+    override suspend fun uploadBackup(): Result<Int> = runCatching {
+        val uid = userId()
+        var totalRows = 0
+
+        // 1. Categories
+        val categories = categoryDao.getAllCategoriesOnce()
+        if (categories.isNotEmpty()) {
+            val rows = categories.map { it.toSupa(uid) }
+            supabaseClient.from("category").upsert(rows) { onConflict = "user_id,id" }
+            totalRows += rows.size
+        }
+
+        // 2. Memos
+        val memos = memoDao.getAllMemosForBackup()
+        if (memos.isNotEmpty()) {
+            val rows = memos.map { it.toSupa(uid) }
+            supabaseClient.from("memo").upsert(rows) { onConflict = "user_id,id" }
+            totalRows += rows.size
+        }
+
+        // 3. Chat Sessions
+        val sessions = chatSessionDao.getAllSessionsOnce()
+        if (sessions.isNotEmpty()) {
+            val rows = sessions.map { it.toSupa(uid) }
+            supabaseClient.from("chat_session").upsert(rows) { onConflict = "user_id,id" }
+            totalRows += rows.size
+        }
+
+        // 4. Chat Messages
+        val messages = chatMessageDao.getAllMessagesOnce()
+        if (messages.isNotEmpty()) {
+            val rows = messages.map { it.toSupa(uid) }
+            supabaseClient.from("chat_message").upsert(rows) { onConflict = "user_id,id" }
+            totalRows += rows.size
+        }
+
+        // 5. Youtube Summaries
+        val summaries = youtubeSummaryDao.getAllOnce()
+        if (summaries.isNotEmpty()) {
+            val rows = summaries.map { it.toSupa(uid) }
+            supabaseClient.from("youtube_summary").upsert(rows) { onConflict = "user_id,video_id,mode,language" }
+            totalRows += rows.size
+        }
+
+        // 6. AI Usage
+        val aiUsages = aiUsageDao.getAllOnce()
+        if (aiUsages.isNotEmpty()) {
+            val rows = aiUsages.map { it.toSupa(uid) }
+            supabaseClient.from("ai_usage").upsert(rows) { onConflict = "user_id,id" }
+            totalRows += rows.size
+        }
+
+        // 7. Backup metadata
+        val packageInfo = context.packageManager.getPackageInfo(context.packageName, 0)
+        val metadata = SupaBackupMetadataInsert(
+            userId = uid,
+            deviceName = android.provider.Settings.Global.getString(
+                context.contentResolver, "device_name"
+            ) ?: android.os.Build.MODEL,
+            appVersion = packageInfo.versionName ?: "unknown",
+            dbVersion = 17,
+            memoCount = memos.size,
+            totalRows = totalRows,
+        )
+        supabaseClient.from("backup_metadata").insert(metadata)
+
+        memos.size
+    }
+
+    // ── Cloud Restore ──
+
+    override suspend fun restoreFromCloud(): Result<Int> = runCatching {
+        val uid = userId()
+
+        // 1. Download all data from Supabase
+        val categories = supabaseClient.from("category")
+            .select { filter { eq("user_id", uid) } }
+            .decodeList<SupaCategory>()
+
+        val memos = supabaseClient.from("memo")
+            .select { filter { eq("user_id", uid) } }
+            .decodeList<SupaMemo>()
+
+        val sessions = supabaseClient.from("chat_session")
+            .select { filter { eq("user_id", uid) } }
+            .decodeList<SupaChatSession>()
+
+        val messages = supabaseClient.from("chat_message")
+            .select { filter { eq("user_id", uid) } }
+            .decodeList<SupaChatMessage>()
+
+        val summaries = supabaseClient.from("youtube_summary")
+            .select { filter { eq("user_id", uid) } }
+            .decodeList<SupaYoutubeSummary>()
+
+        val aiUsages = supabaseClient.from("ai_usage")
+            .select { filter { eq("user_id", uid) } }
+            .decodeList<SupaAiUsage>()
+
+        // 2. Clear local data (order matters for foreign keys)
+        chatMessageDao.clearAllMessages()
+        chatSessionDao.clearAllSessions()
+        memoDao.clearAllMemos()
+        categoryDao.clearAllCategories()
+        youtubeSummaryDao.clearAll()
+        aiUsageDao.clearAll()
+
+        // 3. Insert downloaded data
+        if (categories.isNotEmpty()) {
+            categoryDao.insertCategories(categories.map { it.toEntity() })
+        }
+        if (memos.isNotEmpty()) {
+            memoDao.insertMemos(memos.map { it.toEntity() })
+        }
+        if (sessions.isNotEmpty()) {
+            chatSessionDao.insertSessions(sessions.map { it.toEntity() })
+        }
+        if (messages.isNotEmpty()) {
+            chatMessageDao.insertMessages(messages.map { it.toEntity() })
+        }
+        if (summaries.isNotEmpty()) {
+            youtubeSummaryDao.insertAll(summaries.map { it.toEntity() })
+        }
+        if (aiUsages.isNotEmpty()) {
+            aiUsageDao.insertAll(aiUsages.map { it.toEntity() })
+        }
+
+        memos.size
+    }
+
+    // ── Last Backup Time ──
+
+    override suspend fun getLastBackupTime(): Result<String?> = runCatching {
+        val uid = userId()
+        val result = supabaseClient.from("backup_metadata")
+            .select {
+                filter { eq("user_id", uid) }
+                order("created_at", io.github.jan.supabase.postgrest.query.Order.DESCENDING)
+                limit(1)
+            }
+            .decodeList<SupaBackupMetadata>()
+        result.firstOrNull()?.createdAt
+    }
+
+    // ── Local JSON backup (legacy, for file export/import) ──
 
     override suspend fun createBackupPayload(): BackupPayload {
         val packageInfo = context.packageManager.getPackageInfo(context.packageName, 0)
-
-        val memos = memoDao.getAllMemosForBackup().map { it.toBackup() }
-        val categories = categoryDao.getAllCategoriesOnce().map { it.toBackup() }
-        val chatSessions = chatSessionDao.getAllSessionsOnce().map { it.toBackup() }
-        val chatMessages = chatMessageDao.getAllMessagesOnce().map { it.toBackup() }
 
         return BackupPayload(
             deviceName = android.provider.Settings.Global.getString(
@@ -51,10 +195,10 @@ class BackupRepositoryImpl @Inject constructor(
             appVersion = packageInfo.versionName ?: "unknown",
             dbVersion = 17,
             tables = BackupTables(
-                memos = memos,
-                categories = categories,
-                chatSessions = chatSessions.ifEmpty { null },
-                chatMessages = chatMessages.ifEmpty { null },
+                memos = memoDao.getAllMemosForBackup().map { it.toBackup() },
+                categories = categoryDao.getAllCategoriesOnce().map { it.toBackup() },
+                chatSessions = chatSessionDao.getAllSessionsOnce().map { it.toBackup() }.ifEmpty { null },
+                chatMessages = chatMessageDao.getAllMessagesOnce().map { it.toBackup() }.ifEmpty { null },
             ),
         )
     }
@@ -77,62 +221,77 @@ class BackupRepositoryImpl @Inject constructor(
         val messages = payload.tables.chatMessages?.map { it.toEntity() }
         if (!messages.isNullOrEmpty()) chatMessageDao.insertMessages(messages)
     }
-
-    // --- Cloud operations ---
-
-    private fun authHeader(): String {
-        val token = authService.getAccessToken()
-            ?: throw IllegalStateException("Not authenticated")
-        return "Bearer $token"
-    }
-
-    override suspend fun uploadBackup(): Result<BackupCreateResponse> = runCatching {
-        val payload = createBackupPayload()
-        val request = BackupUploadRequest(
-            device_name = payload.deviceName,
-            app_version = payload.appVersion,
-            db_version = payload.dbVersion,
-            tables = payload.tables,
-        )
-        httpClient.post("backup") {
-            header("Authorization", authHeader())
-            contentType(ContentType.Application.Json)
-            setBody(request)
-        }.body<BackupCreateResponse>()
-    }
-
-    override suspend fun listBackups(): Result<List<BackupMeta>> = runCatching {
-        httpClient.get("backups") {
-            header("Authorization", authHeader())
-        }.body<List<BackupMeta>>()
-    }
-
-    override suspend fun downloadBackup(backupId: String): Result<BackupDownloadResponse> = runCatching {
-        httpClient.get("backup/$backupId") {
-            header("Authorization", authHeader())
-        }.body<BackupDownloadResponse>()
-    }
-
-    override suspend fun deleteBackup(backupId: String): Result<Unit> = runCatching {
-        httpClient.delete("backup/$backupId") {
-            header("Authorization", authHeader())
-        }
-        Unit
-    }
-
-    override suspend fun restoreFromCloud(backupId: String): Result<Int> = runCatching {
-        val response = downloadBackup(backupId).getOrThrow()
-        restoreFromPayload(BackupPayload(
-            deviceName = response.metadata.device_name,
-            appVersion = response.metadata.app_version,
-            dbVersion = response.metadata.db_version,
-            tables = response.tables,
-        ))
-        response.metadata.memo_count
-    }
 }
 
-// --- Entity → Backup ---
+// ── Entity → Supabase DTO ──
+
+private fun Memo.toSupa(userId: String) = SupaMemo(
+    id = id, userId = userId, name = name, categoryId = categoryId, content = content,
+    createdAt = createdAt, updatedAt = updatedAt, format = format.name,
+    isPinned = isPinned, audioPath = audioPath, styles = styles,
+    youtubeUrl = youtubeUrl, deletedAt = deletedAt, reminderAt = reminderAt,
+    summaryContent = summaryContent,
+)
+
+private fun Category.toSupa(userId: String) = SupaCategory(
+    id = id, userId = userId, name = name,
+)
+
+private fun ChatSession.toSupa(userId: String) = SupaChatSession(
+    id = id, userId = userId, title = title,
+    createdAt = createdAt, updatedAt = updatedAt, category = category,
+)
+
+private fun ChatMessage.toSupa(userId: String) = SupaChatMessage(
+    id = id, userId = userId, sessionId = sessionId,
+    role = role, content = content, timestamp = timestamp, metadata = metadata,
+)
+
+private fun YoutubeSummary.toSupa(userId: String) = SupaYoutubeSummary(
+    userId = userId, videoId = videoId,
+    mode = mode.takeIf { it.isNotBlank() } ?: "SIMPLE",
+    language = language.takeIf { it.isNotBlank() } ?: "ko",
+    url = url,
+    summary = summary,
+    createdAt = createdAt,
+)
+
+private fun AiUsage.toSupa(userId: String) = SupaAiUsage(
+    id = id, userId = userId, feature = feature, usedAt = usedAt,
+)
+
+// ── Supabase DTO → Entity ──
+
+private fun SupaMemo.toEntity() = Memo(
+    id = id, name = name, categoryId = categoryId, content = content,
+    createdAt = createdAt, updatedAt = updatedAt,
+    format = try { MemoFormat.valueOf(format) } catch (_: Exception) { MemoFormat.PLAIN },
+    isPinned = isPinned, audioPath = audioPath, styles = styles,
+    youtubeUrl = youtubeUrl, deletedAt = deletedAt, reminderAt = reminderAt,
+    summaryContent = summaryContent,
+)
+
+private fun SupaCategory.toEntity() = Category(id = id, name = name)
+
+private fun SupaChatSession.toEntity() = ChatSession(
+    id = id, title = title, createdAt = createdAt, updatedAt = updatedAt, category = category,
+)
+
+private fun SupaChatMessage.toEntity() = ChatMessage(
+    id = id, sessionId = sessionId, role = role, content = content,
+    timestamp = timestamp, metadata = metadata,
+)
+
+private fun SupaYoutubeSummary.toEntity() = YoutubeSummary(
+    videoId = videoId, mode = mode, language = language,
+    url = url, summary = summary, createdAt = createdAt,
+)
+
+private fun SupaAiUsage.toEntity() = AiUsage(
+    id = id, feature = feature, usedAt = usedAt,
+)
+
+// ── Entity → Legacy Backup ──
 
 private fun Memo.toBackup() = MemoBackup(
     id = id, name = name, categoryId = categoryId, content = content,
@@ -153,7 +312,7 @@ private fun ChatMessage.toBackup() = ChatMessageBackup(
     timestamp = timestamp, metadata = metadata,
 )
 
-// --- Backup → Entity ---
+// ── Legacy Backup → Entity ──
 
 private fun MemoBackup.toEntity() = Memo(
     id = id, name = name, categoryId = categoryId, content = content,

--- a/data/backup/impl/src/main/java/me/pecos/memozy/data/backup/di/BackupModule.kt
+++ b/data/backup/impl/src/main/java/me/pecos/memozy/data/backup/di/BackupModule.kt
@@ -2,30 +2,11 @@ package me.pecos.memozy.data.backup.di
 
 import dagger.Binds
 import dagger.Module
-import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
-import io.ktor.client.HttpClient
-import io.ktor.client.engine.okhttp.OkHttp
-import io.ktor.client.plugins.HttpResponseValidator
-import io.ktor.client.plugins.HttpTimeout
-import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
-import io.ktor.client.plugins.defaultRequest
-import io.ktor.client.plugins.logging.LogLevel
-import io.ktor.client.plugins.logging.Logging
-import io.ktor.client.statement.bodyAsText
-import io.ktor.http.isSuccess
-import io.ktor.serialization.kotlinx.json.json
-import kotlinx.serialization.json.Json
 import me.pecos.memozy.data.backup.BackupRepository
 import me.pecos.memozy.data.backup.BackupRepositoryImpl
-import me.pecos.memozy.data.backup.impl.BuildConfig
-import javax.inject.Qualifier
 import javax.inject.Singleton
-
-@Qualifier
-@Retention(AnnotationRetention.BINARY)
-annotation class BackupHttpClient
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -34,43 +15,4 @@ abstract class BackupModule {
     @Binds
     @Singleton
     abstract fun bindBackupRepository(impl: BackupRepositoryImpl): BackupRepository
-
-    companion object {
-
-        @Provides
-        @Singleton
-        @BackupHttpClient
-        fun provideBackupHttpClient(): HttpClient = HttpClient(OkHttp) {
-            install(ContentNegotiation) {
-                json(Json {
-                    ignoreUnknownKeys = true
-                    isLenient = true
-                    encodeDefaults = true
-                })
-            }
-
-            install(Logging) {
-                level = if (BuildConfig.DEBUG) LogLevel.HEADERS else LogLevel.NONE
-            }
-
-            install(HttpTimeout) {
-                requestTimeoutMillis = 120_000
-                connectTimeoutMillis = 15_000
-                socketTimeoutMillis = 120_000
-            }
-
-            defaultRequest {
-                url("${BuildConfig.WORKER_URL}/")
-            }
-
-            HttpResponseValidator {
-                validateResponse { response ->
-                    if (!response.status.isSuccess()) {
-                        val body = response.bodyAsText()
-                        throw Exception("Backup error (${response.status.value}): $body")
-                    }
-                }
-            }
-        }
-    }
 }

--- a/datasource/local/memo/api/src/main/java/me/pecos/memozy/data/datasource/local/AiUsageDao.kt
+++ b/datasource/local/memo/api/src/main/java/me/pecos/memozy/data/datasource/local/AiUsageDao.kt
@@ -13,4 +13,13 @@ interface AiUsageDao {
 
     @Query("SELECT COUNT(*) FROM ai_usage WHERE feature = :feature AND usedAt >= :startOfDay")
     suspend fun getCountSince(feature: String, startOfDay: Long): Int
+
+    @Query("SELECT * FROM ai_usage ORDER BY usedAt DESC")
+    suspend fun getAllOnce(): List<AiUsage>
+
+    @Insert
+    suspend fun insertAll(usages: List<AiUsage>)
+
+    @Query("DELETE FROM ai_usage")
+    suspend fun clearAll()
 }

--- a/datasource/local/memo/api/src/main/java/me/pecos/memozy/data/datasource/local/YoutubeSummaryDao.kt
+++ b/datasource/local/memo/api/src/main/java/me/pecos/memozy/data/datasource/local/YoutubeSummaryDao.kt
@@ -13,4 +13,13 @@ interface YoutubeSummaryDao {
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insert(summary: YoutubeSummary)
+
+    @Query("SELECT * FROM youtube_summary ORDER BY createdAt DESC")
+    suspend fun getAllOnce(): List<YoutubeSummary>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertAll(summaries: List<YoutubeSummary>)
+
+    @Query("DELETE FROM youtube_summary")
+    suspend fun clearAll()
 }

--- a/datasource/remote/ai/impl/build.gradle.kts
+++ b/datasource/remote/ai/impl/build.gradle.kts
@@ -19,9 +19,15 @@ android {
         buildConfig = true
     }
 
-    defaultConfig {
-        buildConfigField("String", "WORKER_URL", "\"${localProperties.getProperty("worker.url", "")}\"")
-        buildConfigField("String", "APP_SECRET_KEY", "\"${localProperties.getProperty("app.secret.key", "")}\"")
+    buildTypes {
+        debug {
+            buildConfigField("String", "WORKER_URL", "\"${localProperties.getProperty("worker.url", "")}\"")
+            buildConfigField("String", "APP_SECRET_KEY", "\"${localProperties.getProperty("app.secret.key", "")}\"")
+        }
+        release {
+            buildConfigField("String", "WORKER_URL", "\"${localProperties.getProperty("worker.prod.url", "")}\"")
+            buildConfigField("String", "APP_SECRET_KEY", "\"${localProperties.getProperty("app.prod.secret.key", "")}\"")
+        }
     }
 }
 

--- a/datasource/remote/ai/impl/src/main/java/me/pecos/memozy/data/datasource/remote/ai/YouTubeCaptionServiceImpl.kt
+++ b/datasource/remote/ai/impl/src/main/java/me/pecos/memozy/data/datasource/remote/ai/YouTubeCaptionServiceImpl.kt
@@ -4,6 +4,8 @@ import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 import io.ktor.client.request.parameter
 import io.ktor.client.statement.bodyAsText
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
@@ -23,17 +25,19 @@ class YouTubeCaptionServiceImpl @Inject constructor(
 
     override suspend fun extractVideoInfo(videoId: String): YouTubeVideoInfo? {
         return try {
-            // 1. YouTube 페이지에서 제목 추출
-            val title = fetchTitle(videoId)
+            coroutineScope {
+                // 제목과 자막을 병렬로 가져오기
+                val titleDeferred = async { fetchTitle(videoId) }
+                val captionsDeferred = async {
+                    fetchCaptionsFromSupadata(videoId, "ko")
+                        ?: fetchCaptionsFromSupadata(videoId, "en")
+                }
 
-            // 2. Supadata API로 자막 추출 (ko → en fallback)
-            val captions = fetchCaptionsFromSupadata(videoId, "ko")
-                ?: fetchCaptionsFromSupadata(videoId, "en")
-
-            YouTubeVideoInfo(
-                title = title ?: "YouTube 영상",
-                captions = captions
-            )
+                YouTubeVideoInfo(
+                    title = titleDeferred.await() ?: "YouTube 영상",
+                    captions = captionsDeferred.await()
+                )
+            }
         } catch (e: Exception) {
             null
         }

--- a/datasource/remote/auth/impl/build.gradle.kts
+++ b/datasource/remote/auth/impl/build.gradle.kts
@@ -19,9 +19,15 @@ android {
         buildConfig = true
     }
 
-    defaultConfig {
-        buildConfigField("String", "SUPABASE_URL", "\"${localProperties.getProperty("supabase.url", "")}\"")
-        buildConfigField("String", "SUPABASE_ANON_KEY", "\"${localProperties.getProperty("supabase.anon.key", "")}\"")
+    buildTypes {
+        debug {
+            buildConfigField("String", "SUPABASE_URL", "\"${localProperties.getProperty("supabase.url", "")}\"")
+            buildConfigField("String", "SUPABASE_ANON_KEY", "\"${localProperties.getProperty("supabase.anon.key", "")}\"")
+        }
+        release {
+            buildConfigField("String", "SUPABASE_URL", "\"${localProperties.getProperty("supabase.prod.url", "")}\"")
+            buildConfigField("String", "SUPABASE_ANON_KEY", "\"${localProperties.getProperty("supabase.prod.anon.key", "")}\"")
+        }
     }
 }
 
@@ -29,4 +35,5 @@ dependencies {
     implementation(projects.datasource.remote.auth.api)
     implementation(platform(libs.supabase.bom))
     implementation(libs.supabase.auth)
+    implementation(libs.supabase.postgrest)
 }

--- a/datasource/remote/auth/impl/src/main/java/me/pecos/memozy/data/datasource/remote/auth/di/AuthModule.kt
+++ b/datasource/remote/auth/impl/src/main/java/me/pecos/memozy/data/datasource/remote/auth/di/AuthModule.kt
@@ -8,6 +8,9 @@ import dagger.hilt.components.SingletonComponent
 import io.github.jan.supabase.SupabaseClient
 import io.github.jan.supabase.auth.Auth
 import io.github.jan.supabase.createSupabaseClient
+import io.github.jan.supabase.postgrest.Postgrest
+import io.github.jan.supabase.serializer.KotlinXSerializer
+import kotlinx.serialization.json.Json
 import me.pecos.memozy.data.datasource.remote.auth.AuthService
 import me.pecos.memozy.data.datasource.remote.auth.AuthServiceImpl
 import me.pecos.memozy.datasource.remote.auth.impl.BuildConfig
@@ -28,7 +31,12 @@ abstract class AuthModule {
             supabaseUrl = BuildConfig.SUPABASE_URL,
             supabaseKey = BuildConfig.SUPABASE_ANON_KEY,
         ) {
+            defaultSerializer = KotlinXSerializer(Json {
+                encodeDefaults = true
+                ignoreUnknownKeys = true
+            })
             install(Auth)
+            install(Postgrest)
         }
     }
 }

--- a/feature/core/resource/src/main/res/values-en/strings.xml
+++ b/feature/core/resource/src/main/res/values-en/strings.xml
@@ -215,4 +215,5 @@
     <string name="cloud_backup_restoring">Restoring…</string>
     <string name="cloud_backup_count">%d backups saved</string>
     <string name="cloud_backup_memo_count">%d memos</string>
+    <string name="cloud_backup_last_time">Last backup: %s</string>
 </resources>

--- a/feature/core/resource/src/main/res/values-ja/strings.xml
+++ b/feature/core/resource/src/main/res/values-ja/strings.xml
@@ -215,4 +215,5 @@
     <string name="cloud_backup_restoring">復元中…</string>
     <string name="cloud_backup_count">保存済みバックアップ %d件</string>
     <string name="cloud_backup_memo_count">メモ %d件</string>
+    <string name="cloud_backup_last_time">最後のバックアップ: %s</string>
 </resources>

--- a/feature/core/resource/src/main/res/values/strings.xml
+++ b/feature/core/resource/src/main/res/values/strings.xml
@@ -213,4 +213,5 @@
     <string name="cloud_backup_restoring">복원 중…</string>
     <string name="cloud_backup_count">저장된 백업 %d개</string>
     <string name="cloud_backup_memo_count">메모 %d개</string>
+    <string name="cloud_backup_last_time">마지막 백업: %s</string>
 </resources>

--- a/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/settings/SettingsScreen.kt
+++ b/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/settings/SettingsScreen.kt
@@ -70,9 +70,7 @@ fun SettingsScreen(
     var showThemeDialog by remember { mutableStateOf(false) }
     var showRestoreDialog by remember { mutableStateOf(false) }
     var showSignOutDialog by remember { mutableStateOf(false) }
-    var showBackupListDialog by remember { mutableStateOf(false) }
-    var showCloudRestoreConfirm by remember { mutableStateOf<String?>(null) }
-    var showCloudDeleteConfirm by remember { mutableStateOf<String?>(null) }
+    var showCloudRestoreConfirm by remember { mutableStateOf(false) }
 
     val selectedLanguage by settingsViewModel.selectedLanguage.collectAsState()
     val selectedTheme by settingsViewModel.selectedTheme.collectAsState()
@@ -80,11 +78,18 @@ fun SettingsScreen(
     val isDonationEnabled by settingsViewModel.isDonationEnabled.collectAsState()
     val authState by settingsViewModel.authState.collectAsState()
     val cloudBackupState by settingsViewModel.cloudBackupState.collectAsState()
-    val backupList by settingsViewModel.backupList.collectAsState()
+    val lastBackupTime by settingsViewModel.lastBackupTime.collectAsState()
     val colors = LocalAppColors.current
     val context = LocalContext.current
     val activity = LocalActivity.current
     val scope = rememberCoroutineScope()
+
+    // 로그인 상태 변경 시 마지막 백업 시간 로드
+    LaunchedEffect(authState) {
+        if (authState is AuthState.Authenticated) {
+            settingsViewModel.loadLastBackupTime()
+        }
+    }
 
     // SAF launchers
     val exportLauncher = rememberLauncherForActivityResult(
@@ -259,9 +264,9 @@ fun SettingsScreen(
     }
 
     // 클라우드 복원 확인
-    showCloudRestoreConfirm?.let { backupId ->
+    if (showCloudRestoreConfirm) {
         AppPopup(
-            onDismissRequest = { showCloudRestoreConfirm = null },
+            onDismissRequest = { showCloudRestoreConfirm = false },
             title = stringResource(R.string.cloud_backup_restore),
             navigation = PopupNavigation.EMPHASIZED,
             size = PopupSize.MEDIUM,
@@ -269,101 +274,13 @@ fun SettingsScreen(
             primaryButtonText = stringResource(R.string.backup_restore_action),
             isPrimaryDestructive = true,
             onPrimaryClick = {
-                showCloudRestoreConfirm = null
-                showBackupListDialog = false
-                settingsViewModel.restoreFromCloud(backupId)
+                showCloudRestoreConfirm = false
+                settingsViewModel.restoreFromCloud()
             },
             secondaryButtonText = stringResource(R.string.cancel),
-            onSecondaryClick = { showCloudRestoreConfirm = null }
+            onSecondaryClick = { showCloudRestoreConfirm = false }
         ) {
             Text(stringResource(R.string.cloud_backup_restore_confirm), color = colors.textBody)
-        }
-    }
-
-    // 클라우드 백업 삭제 확인
-    showCloudDeleteConfirm?.let { backupId ->
-        AppPopup(
-            onDismissRequest = { showCloudDeleteConfirm = null },
-            title = stringResource(R.string.delete_action),
-            navigation = PopupNavigation.EMPHASIZED,
-            size = PopupSize.MEDIUM,
-            actionArea = PopupActionArea.NEUTRAL,
-            primaryButtonText = stringResource(R.string.delete_action),
-            isPrimaryDestructive = true,
-            onPrimaryClick = {
-                showCloudDeleteConfirm = null
-                showBackupListDialog = false
-                settingsViewModel.deleteCloudBackup(backupId)
-            },
-            secondaryButtonText = stringResource(R.string.cancel),
-            onSecondaryClick = { showCloudDeleteConfirm = null }
-        ) {
-            Text(stringResource(R.string.cloud_backup_delete_confirm), color = colors.textBody)
-        }
-    }
-
-    // 백업 목록 다이얼로그
-    if (showBackupListDialog) {
-        AppPopup(
-            onDismissRequest = { showBackupListDialog = false },
-            title = stringResource(R.string.cloud_backup_manage),
-            navigation = PopupNavigation.EMPHASIZED,
-            size = PopupSize.LARGE,
-            actionArea = PopupActionArea.NONE
-        ) {
-            if (backupList.isEmpty()) {
-                Text(
-                    stringResource(R.string.cloud_backup_empty),
-                    color = colors.textSecondary,
-                    fontSize = 13.sp,
-                    modifier = Modifier.padding(vertical = 16.dp)
-                )
-            } else {
-                Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
-                    backupList.forEach { backup ->
-                        Column(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(vertical = 8.dp)
-                        ) {
-                            Text(
-                                text = "${backup.device_name} · v${backup.app_version}",
-                                fontSize = 14.sp,
-                                fontWeight = FontWeight.Medium,
-                                color = colors.textTitle
-                            )
-                            Text(
-                                text = "${backup.created_at.take(10)} · ${stringResource(R.string.cloud_backup_memo_count, backup.memo_count)}",
-                                fontSize = 12.sp,
-                                color = colors.textSecondary,
-                                modifier = Modifier.padding(top = 2.dp)
-                            )
-                            Row(modifier = Modifier.padding(top = 4.dp)) {
-                                Text(
-                                    text = stringResource(R.string.trash_restore),
-                                    fontSize = 12.sp,
-                                    color = colors.textBody,
-                                    fontWeight = FontWeight.Medium,
-                                    modifier = Modifier
-                                        .padding(end = 8.dp)
-                                        .clickable { showCloudRestoreConfirm = backup.id }
-                                        .padding(horizontal = 8.dp, vertical = 4.dp)
-                                )
-                                Text(
-                                    text = stringResource(R.string.delete_action),
-                                    fontSize = 12.sp,
-                                    color = Color(0xFFE24B4A),
-                                    fontWeight = FontWeight.Medium,
-                                    modifier = Modifier
-                                        .clickable { showCloudDeleteConfirm = backup.id }
-                                        .padding(horizontal = 8.dp, vertical = 4.dp)
-                                )
-                            }
-                        }
-                        HorizontalDivider(thickness = 0.3.dp, color = colors.cardBorder)
-                    }
-                }
-            }
         }
     }
 
@@ -649,7 +566,7 @@ fun SettingsScreen(
                 Spacer(modifier = Modifier.height(12.dp))
 
                 if (authState is AuthState.Authenticated) {
-                    // 로그인: 클라우드 백업 위주
+                    // 로그인: 클라우드 백업
                     WantedButton(
                         text = if (cloudBackupState is CloudBackupState.Uploading)
                             stringResource(R.string.cloud_backup_uploading)
@@ -664,10 +581,22 @@ fun SettingsScreen(
                         onClick = { settingsViewModel.uploadCloudBackup() }
                     )
 
+                    // 마지막 백업 시간 표시
+                    lastBackupTime?.let { time ->
+                        Text(
+                            text = stringResource(R.string.cloud_backup_last_time, time.take(16).replace("T", " ")),
+                            fontSize = 11.sp,
+                            color = colors.textSecondary,
+                            modifier = Modifier.padding(start = 20.dp, top = 4.dp)
+                        )
+                    }
+
                     Spacer(modifier = Modifier.height(12.dp))
 
                     WantedButton(
-                        text = stringResource(R.string.cloud_backup_manage),
+                        text = if (cloudBackupState is CloudBackupState.Restoring)
+                            stringResource(R.string.cloud_backup_restoring)
+                        else stringResource(R.string.cloud_backup_restore),
                         modifier = Modifier
                             .fillMaxWidth()
                             .padding(horizontal = 16.dp),
@@ -675,13 +604,10 @@ fun SettingsScreen(
                             type = ButtonType.ASSISTIVE,
                             variant = ButtonVariant.OUTLINED
                         ).copy(contentColor = colors.textTitle),
-                        onClick = {
-                            settingsViewModel.loadBackupList()
-                            showBackupListDialog = true
-                        }
+                        onClick = { showCloudRestoreConfirm = true }
                     )
                 } else {
-                    // 비로그인: 로컬 백업 위주
+                    // 비로그인: 로컬 백업
                     WantedButton(
                         text = stringResource(R.string.backup_export),
                         modifier = Modifier

--- a/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/settings/SettingsViewModel.kt
+++ b/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/settings/SettingsViewModel.kt
@@ -15,7 +15,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import me.pecos.memozy.data.datasource.local.MemoDao
 import me.pecos.memozy.data.datasource.local.entity.Memo
-import me.pecos.memozy.data.backup.BackupMeta
 import me.pecos.memozy.data.backup.BackupRepository
 import me.pecos.memozy.data.datasource.remote.auth.AuthState
 import me.pecos.memozy.data.repository.MemoRepository
@@ -117,39 +116,37 @@ class SettingsViewModel @Inject constructor(
     private val _cloudBackupState = MutableStateFlow<CloudBackupState>(CloudBackupState.Idle)
     val cloudBackupState: StateFlow<CloudBackupState> = _cloudBackupState
 
-    private val _backupList = MutableStateFlow<List<BackupMeta>>(emptyList())
-    val backupList: StateFlow<List<BackupMeta>> = _backupList
+    private val _lastBackupTime = MutableStateFlow<String?>(null)
+    val lastBackupTime: StateFlow<String?> = _lastBackupTime
 
     fun uploadCloudBackup() {
         viewModelScope.launch {
             _cloudBackupState.value = CloudBackupState.Uploading
             backupRepository.uploadBackup()
-                .onSuccess { _cloudBackupState.value = CloudBackupState.UploadSuccess(it.memo_count) }
-                .onFailure { _cloudBackupState.value = CloudBackupState.Error(it.message ?: "Unknown error") }
+                .onSuccess {
+                    _cloudBackupState.value = CloudBackupState.UploadSuccess(it)
+                    loadLastBackupTime()
+                }
+                .onFailure {
+                    _cloudBackupState.value = CloudBackupState.Error(it.message ?: "Unknown error")
+                }
         }
     }
 
-    fun loadBackupList() {
-        viewModelScope.launch {
-            backupRepository.listBackups()
-                .onSuccess { _backupList.value = it }
-                .onFailure { _backupList.value = emptyList() }
-        }
-    }
-
-    fun restoreFromCloud(backupId: String) {
+    fun restoreFromCloud() {
         viewModelScope.launch {
             _cloudBackupState.value = CloudBackupState.Restoring
-            backupRepository.restoreFromCloud(backupId)
+            backupRepository.restoreFromCloud()
                 .onSuccess { _cloudBackupState.value = CloudBackupState.RestoreSuccess(it) }
                 .onFailure { _cloudBackupState.value = CloudBackupState.Error(it.message ?: "Unknown error") }
         }
     }
 
-    fun deleteCloudBackup(backupId: String) {
+    fun loadLastBackupTime() {
         viewModelScope.launch {
-            backupRepository.deleteBackup(backupId)
-                .onSuccess { loadBackupList() }
+            backupRepository.getLastBackupTime()
+                .onSuccess { _lastBackupTime.value = it }
+                .onFailure { _lastBackupTime.value = null }
         }
     }
 
@@ -234,13 +231,11 @@ class SettingsViewModel @Inject constructor(
     private suspend fun restoreFromJson(json: JSONObject) {
         memoDao.clearAllMemos()
 
-        // 메모 복원
         val memosArray = json.getJSONArray("memos")
         val memos = (0 until memosArray.length()).map { i ->
             val m = memosArray.getJSONObject(i)
             var content = m.getString("content")
             var summaryContent = m.optString("summaryContent").takeIf { it != "null" && it.isNotEmpty() }
-            // 레거시 백업 호환: summaryContent 없고 content에 📋 포함 시 분리
             if (summaryContent == null && content.contains("📋")) {
                 val idx = content.indexOf("📋")
                 summaryContent = content.substring(idx)

--- a/feature/memo-plain/impl/src/main/java/me/pecos/memozy/feature/memoplain/impl/MemoPlainNavigationImpl.kt
+++ b/feature/memo-plain/impl/src/main/java/me/pecos/memozy/feature/memoplain/impl/MemoPlainNavigationImpl.kt
@@ -113,7 +113,13 @@ class MemoPlainNavigationImpl @Inject constructor(
                     |#키워드1 #키워드2 #키워드3
                     |
                     |📖 핵심 내용
-                    |- 가장 중요한 내용 3~5개를 각 1줄로 정리
+                    |- 첫 번째 핵심 내용
+                    |
+                    |- 두 번째 핵심 내용
+                    |
+                    |- 세 번째 핵심 내용
+                    |
+                    |(가장 중요한 내용 3~5개를 각 1줄로 정리. 첫 항목은 📖 핵심 내용 바로 다음 줄에, 이후 항목들 사이에는 빈 줄 1개를 넣어줘)
                 """.trimMargin()
                 SummaryMode.DETAILED -> """
                     |이 유튜브 영상을 ${l} 상세하게 요약해줘. 인사말이나 부가 설명 없이 아래 형식만 정확히 출력해:
@@ -125,8 +131,6 @@ class MemoPlainNavigationImpl @Inject constructor(
                     |#키워드1 #키워드2 #키워드3 #키워드4 #키워드5
                     |
                     |⏰ 타임라인별 상세 요약
-                    |각 주제/구간별로 나눠서 아래처럼 정리해줘:
-                    |
                     |[00:00] 섹션 제목
                     |- 상세 설명 (2~3문장)
                     |- 중요한 내용이나 인사이트
@@ -770,8 +774,6 @@ class MemoPlainNavigationImpl @Inject constructor(
         }
         val captions = videoInfo?.captions?.take(15000)
         if (captions != null) {
-            // 자막 추출 후 잠시 대기 (Gemini RPM 제한 방지)
-            kotlinx.coroutines.delay(1000)
             // 자막 기반 요약 (텍스트만, 빠르고 저렴)
             return retryOn503 {
                 aiApiService.generateContent(

--- a/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/MemoScreen.kt
+++ b/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/MemoScreen.kt
@@ -272,11 +272,8 @@ fun MemoScreen(
     var webChipDismissed by remember { mutableStateOf(false) }
     var savedWebUrl by remember { mutableStateOf<String?>(null) }
     var selectedWebUrl by remember { mutableStateOf<String?>(null) }
-    // 요약 전 원본 URL 보관 (요약 후 본문에서 URL이 대체되어도 유지)
-    var savedYoutubeUrl by remember { mutableStateOf(detectedYoutubeUrl ?: existingMemo.youtubeUrl) }
-    if (detectedYoutubeUrl != null && savedYoutubeUrl == null) {
-        savedYoutubeUrl = detectedYoutubeUrl
-    }
+    // 요약 전 원본 URL 보관 (버튼으로 추가하거나 DB에 저장된 경우만)
+    var savedYoutubeUrl by remember { mutableStateOf(existingMemo.youtubeUrl) }
 
     // 요약 결과 표시 상태
     var showSummary by remember { mutableStateOf(false) }
@@ -391,7 +388,7 @@ fun MemoScreen(
                 verticalAlignment = Alignment.CenterVertically,
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 16.dp)
+                    .padding(horizontal = 32.dp)
                     .padding(top = 42.dp, bottom = 12.dp)
             ) {
                 Icon(
@@ -487,7 +484,7 @@ fun MemoScreen(
                     .weight(1f)
                     .hazeSource(hazeState)
                     .verticalScroll(rememberScrollState())
-                    .padding(horizontal = 30.dp, vertical = 16.dp)
+                    .padding(horizontal = 16.dp, vertical = 16.dp)
             ) {
                 // 제목 — 개행 시 내용으로 포커스 이동
                 val bodyFocusRequester = remember { FocusRequester() }
@@ -508,7 +505,7 @@ fun MemoScreen(
                         fontWeight = FontWeight.Bold,
                         color = colors.textTitle
                     ),
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
                     decorationBox = { innerTextField ->
                         Box {
                             if (nameText.isEmpty()) {
@@ -575,7 +572,7 @@ fun MemoScreen(
                 val ytVideoId = remember(youtubeUrlDisplay) {
                     Regex("""(?:v=|youtu\.be/|shorts/)([a-zA-Z0-9_-]{11})""").find(youtubeUrlDisplay)?.groupValues?.get(1)
                 }
-                val showYoutubeInline = summaryText != null || (youtubeUrlDisplay.isNotBlank() && !youtubeChipDismissed && (detectedYoutubeUrl != null || summaryResult != null || youtubeTitle != null))
+                val showYoutubeInline = summaryText != null || (youtubeUrlDisplay.isNotBlank() && !youtubeChipDismissed && (savedYoutubeUrl != null || summaryResult != null || youtubeTitle != null))
                 if (showYoutubeInline) {
                     YouTubeSummaryInlineCard(
                         youtubeUrl = youtubeUrlDisplay,
@@ -635,6 +632,7 @@ fun MemoScreen(
                     modifier = Modifier
                         .fillMaxWidth()
                         .heightIn(min = 150.dp)
+                        .padding(horizontal = 16.dp)
                         .focusRequester(bodyFocusRequester),
                     textStyle = TextStyle(
                         fontSize = 15.sp,
@@ -861,6 +859,7 @@ fun MemoScreen(
             onDismiss = { showYoutubeDialog = false },
             onUrlAdded = { url ->
                 bodyText = if (bodyText.isBlank()) url else "$bodyText\n$url"
+                savedYoutubeUrl = url
                 showYoutubeDialog = false
             }
         )

--- a/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/components/WebSummaryInlineCard.kt
+++ b/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/components/WebSummaryInlineCard.kt
@@ -75,7 +75,7 @@ fun WebSummaryInlineCard(
     if (isExpanded) {
         Column(
             modifier = Modifier.fillMaxWidth().clip(RoundedCornerShape(12.dp))
-                .background(colors.cardBackground).padding(12.dp)
+                .background(colors.cardBackground).padding(16.dp)
         ) {
             Text("🔗 ${stringResource(R.string.summary_card_web)}", fontSize = 11.sp, color = colors.textSecondary, fontWeight = FontWeight.Medium)
             Spacer(modifier = Modifier.height(4.dp))
@@ -87,6 +87,7 @@ fun WebSummaryInlineCard(
             Spacer(modifier = Modifier.height(2.dp))
             Row(
                 modifier = Modifier
+                    .fillMaxWidth()
                     .clip(RoundedCornerShape(6.dp))
                     .background(colors.chipBackground.copy(alpha = 0.5f))
                     .padding(horizontal = 6.dp, vertical = 3.dp),
@@ -103,44 +104,47 @@ fun WebSummaryInlineCard(
 
             // 액션 버튼
             Spacer(modifier = Modifier.height(10.dp))
-            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(6.dp)) {
                 Row(
-                    modifier = Modifier.clip(RoundedCornerShape(8.dp)).background(colors.chipBackground)
+                    modifier = Modifier.weight(1f).clip(RoundedCornerShape(6.dp)).background(colors.chipBackground)
                         .clickable { context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(webUrl))) }
-                        .padding(horizontal = 10.dp, vertical = 6.dp),
-                    verticalAlignment = Alignment.CenterVertically
+                        .padding(vertical = 5.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.Center
                 ) {
-                    Text("🔗", fontSize = 12.sp); Spacer(modifier = Modifier.width(4.dp))
-                    Text(stringResource(R.string.summary_card_open), fontSize = 11.sp, color = colors.chipText, fontWeight = FontWeight.Medium)
+                    Text("🔗", fontSize = 10.sp); Spacer(modifier = Modifier.width(3.dp))
+                    Text(stringResource(R.string.summary_card_open), fontSize = 10.sp, color = colors.chipText, fontWeight = FontWeight.Medium)
                 }
                 Row(
-                    modifier = Modifier.clip(RoundedCornerShape(8.dp)).background(colors.chipBackground)
+                    modifier = Modifier.weight(1f).clip(RoundedCornerShape(6.dp)).background(colors.chipBackground)
                         .clickable {
                             clipboardManager.setText(AnnotatedString(webUrl))
                             Toast.makeText(context, context.getString(R.string.web_url_copied), Toast.LENGTH_SHORT).show()
                         }
-                        .padding(horizontal = 10.dp, vertical = 6.dp),
-                    verticalAlignment = Alignment.CenterVertically
+                        .padding(vertical = 5.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.Center
                 ) {
-                    Icon(Icons.Default.ContentCopy, null, tint = colors.chipText, modifier = Modifier.size(14.dp))
-                    Spacer(modifier = Modifier.width(4.dp))
-                    Text(stringResource(R.string.memo_copy), fontSize = 11.sp, color = colors.chipText, fontWeight = FontWeight.Medium)
+                    Icon(Icons.Default.ContentCopy, null, tint = colors.chipText, modifier = Modifier.size(12.dp))
+                    Spacer(modifier = Modifier.width(3.dp))
+                    Text(stringResource(R.string.memo_copy), fontSize = 10.sp, color = colors.chipText, fontWeight = FontWeight.Medium)
                 }
                 if (onSummarize != null && summaryText == null) {
                     Row(
-                        modifier = Modifier.clip(RoundedCornerShape(8.dp)).background(Color(0xFF2196F3).copy(alpha = 0.1f))
+                        modifier = Modifier.weight(1f).clip(RoundedCornerShape(6.dp)).background(Color(0xFF2196F3).copy(alpha = 0.1f))
                             .clickable { onSummarize(webUrl, SummaryMode.SIMPLE) }
-                            .padding(horizontal = 10.dp, vertical = 6.dp),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) { Text(stringResource(R.string.summary_mode_simple), fontSize = 11.sp, color = Color(0xFF2196F3), fontWeight = FontWeight.Medium) }
+                            .padding(vertical = 5.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.Center
+                    ) { Text(stringResource(R.string.summary_mode_simple), fontSize = 10.sp, color = Color(0xFF2196F3), fontWeight = FontWeight.Medium) }
                     Row(
-                        modifier = Modifier.clip(RoundedCornerShape(8.dp)).background(Color(0xFFFF9800).copy(alpha = 0.1f))
+                        modifier = Modifier.weight(1f).clip(RoundedCornerShape(6.dp)).background(Color(0xFFFF9800).copy(alpha = 0.1f))
                             .clickable { onSummarize(webUrl, SummaryMode.DETAILED) }
-                            .padding(horizontal = 10.dp, vertical = 6.dp),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) { Text(stringResource(R.string.summary_mode_detailed), fontSize = 11.sp, color = Color(0xFFFF9800), fontWeight = FontWeight.Medium) }
+                            .padding(vertical = 5.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.Center
+                    ) { Text(stringResource(R.string.summary_mode_detailed), fontSize = 10.sp, color = Color(0xFFFF9800), fontWeight = FontWeight.Medium) }
                 }
-                // 요약 완료 후 요약 버튼 숨김 (원본보기, 복사만 표시)
             }
 
             // 로딩

--- a/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/components/YouTubeSummaryInlineCard.kt
+++ b/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/components/YouTubeSummaryInlineCard.kt
@@ -84,13 +84,13 @@ fun YouTubeSummaryInlineCard(
                 coil.compose.AsyncImage(
                     model = "https://img.youtube.com/vi/$videoId/hqdefault.jpg",
                     contentDescription = null,
-                    modifier = Modifier.fillMaxWidth().aspectRatio(16f / 9f)
-                        .clip(RoundedCornerShape(topStart = 12.dp, topEnd = 12.dp)),
+                    modifier = Modifier.fillMaxWidth().padding(16.dp).aspectRatio(16f / 9f)
+                        .clip(RoundedCornerShape(12.dp)),
                     contentScale = androidx.compose.ui.layout.ContentScale.Crop
                 )
             }
 
-            Column(modifier = Modifier.padding(12.dp)) {
+            Column(modifier = Modifier.padding(16.dp)) {
                 Text("▶ YouTube", fontSize = 11.sp, color = colors.textSecondary, fontWeight = FontWeight.Medium)
                 Spacer(modifier = Modifier.height(4.dp))
                 Text(
@@ -102,6 +102,7 @@ fun YouTubeSummaryInlineCard(
                     Spacer(modifier = Modifier.height(2.dp))
                     Row(
                         modifier = Modifier
+                            .fillMaxWidth()
                             .clip(RoundedCornerShape(6.dp))
                             .background(colors.chipBackground.copy(alpha = 0.5f))
                             .padding(horizontal = 6.dp, vertical = 3.dp),
@@ -119,52 +120,55 @@ fun YouTubeSummaryInlineCard(
 
                 // 액션 버튼
                 Spacer(modifier = Modifier.height(10.dp))
-                Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(6.dp)) {
                     // 원본 보기
                     Row(
-                        modifier = Modifier.clip(RoundedCornerShape(8.dp)).background(colors.chipBackground)
+                        modifier = Modifier.weight(1f).clip(RoundedCornerShape(6.dp)).background(colors.chipBackground)
                             .clickable {
                                 val intent = Intent(Intent.ACTION_VIEW, Uri.parse(youtubeUrl)).apply { setPackage("com.google.android.youtube") }
                                 try { context.startActivity(intent) } catch (_: Exception) {
                                     context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(youtubeUrl)))
                                 }
                             }
-                            .padding(horizontal = 10.dp, vertical = 6.dp),
-                        verticalAlignment = Alignment.CenterVertically
+                            .padding(vertical = 5.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.Center
                     ) {
-                        Text("🔗", fontSize = 12.sp); Spacer(modifier = Modifier.width(4.dp))
-                        Text(stringResource(R.string.summary_card_open), fontSize = 11.sp, color = colors.chipText, fontWeight = FontWeight.Medium)
+                        Text("🔗", fontSize = 10.sp); Spacer(modifier = Modifier.width(3.dp))
+                        Text(stringResource(R.string.summary_card_open), fontSize = 10.sp, color = colors.chipText, fontWeight = FontWeight.Medium)
                     }
                     // 복사
                     Row(
-                        modifier = Modifier.clip(RoundedCornerShape(8.dp)).background(colors.chipBackground)
+                        modifier = Modifier.weight(1f).clip(RoundedCornerShape(6.dp)).background(colors.chipBackground)
                             .clickable {
                                 clipboardManager.setText(AnnotatedString(youtubeUrl))
                                 Toast.makeText(context, context.getString(R.string.youtube_url_copied), Toast.LENGTH_SHORT).show()
                             }
-                            .padding(horizontal = 10.dp, vertical = 6.dp),
-                        verticalAlignment = Alignment.CenterVertically
+                            .padding(vertical = 5.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.Center
                     ) {
-                        Icon(Icons.Default.ContentCopy, null, tint = colors.chipText, modifier = Modifier.size(14.dp))
-                        Spacer(modifier = Modifier.width(4.dp))
-                        Text(stringResource(R.string.memo_copy), fontSize = 11.sp, color = colors.chipText, fontWeight = FontWeight.Medium)
+                        Icon(Icons.Default.ContentCopy, null, tint = colors.chipText, modifier = Modifier.size(12.dp))
+                        Spacer(modifier = Modifier.width(3.dp))
+                        Text(stringResource(R.string.memo_copy), fontSize = 10.sp, color = colors.chipText, fontWeight = FontWeight.Medium)
                     }
                     // 요약 버튼 (아직 요약 안 됨)
                     if (onSummarize != null && summaryText == null) {
                         Row(
-                            modifier = Modifier.clip(RoundedCornerShape(8.dp)).background(Color(0xFF2196F3).copy(alpha = 0.1f))
+                            modifier = Modifier.weight(1f).clip(RoundedCornerShape(6.dp)).background(Color(0xFF2196F3).copy(alpha = 0.1f))
                                 .clickable { onSummarize(youtubeUrl, SummaryMode.SIMPLE) }
-                                .padding(horizontal = 10.dp, vertical = 6.dp),
-                            verticalAlignment = Alignment.CenterVertically
-                        ) { Text(stringResource(R.string.summary_mode_simple), fontSize = 11.sp, color = Color(0xFF2196F3), fontWeight = FontWeight.Medium) }
+                                .padding(vertical = 5.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.Center
+                        ) { Text(stringResource(R.string.summary_mode_simple), fontSize = 10.sp, color = Color(0xFF2196F3), fontWeight = FontWeight.Medium) }
                         Row(
-                            modifier = Modifier.clip(RoundedCornerShape(8.dp)).background(Color(0xFFFF9800).copy(alpha = 0.1f))
+                            modifier = Modifier.weight(1f).clip(RoundedCornerShape(6.dp)).background(Color(0xFFFF9800).copy(alpha = 0.1f))
                                 .clickable { onSummarize(youtubeUrl, SummaryMode.DETAILED) }
-                                .padding(horizontal = 10.dp, vertical = 6.dp),
-                            verticalAlignment = Alignment.CenterVertically
-                        ) { Text(stringResource(R.string.summary_mode_detailed), fontSize = 11.sp, color = Color(0xFFFF9800), fontWeight = FontWeight.Medium) }
+                                .padding(vertical = 5.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.Center
+                        ) { Text(stringResource(R.string.summary_mode_detailed), fontSize = 10.sp, color = Color(0xFFFF9800), fontWeight = FontWeight.Medium) }
                     }
-                    // 요약 완료 후 요약 버튼 숨김 (원본보기, 복사만 표시)
                 }
 
                 // 로딩

--- a/supabase/migrations/20260412_002_create_sync_tables.sql
+++ b/supabase/migrations/20260412_002_create_sync_tables.sql
@@ -1,0 +1,183 @@
+-- ============================================================
+-- Memozy 1:1 Sync Schema (Room DB Mirror)
+-- 단방향 백업: 기기 → Supabase (upsert 기반)
+-- ============================================================
+
+-- 0. 기존 JSON 덤프 방식 테이블 제거
+DROP TABLE IF EXISTS public.backup_data CASCADE;
+DROP TABLE IF EXISTS public.backups CASCADE;
+DROP FUNCTION IF EXISTS public.enforce_backup_limit() CASCADE;
+
+-- ============================================================
+-- 1. category
+-- ============================================================
+CREATE TABLE public.category (
+    id          INT NOT NULL,
+    user_id     UUID REFERENCES auth.users(id) ON DELETE CASCADE NOT NULL,
+    name        TEXT NOT NULL,
+    PRIMARY KEY (user_id, id)
+);
+
+ALTER TABLE public.category ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users manage own categories"
+    ON public.category FOR ALL
+    USING (auth.uid() = user_id)
+    WITH CHECK (auth.uid() = user_id);
+
+-- ============================================================
+-- 2. memo
+-- ============================================================
+CREATE TABLE public.memo (
+    id              INT NOT NULL,
+    user_id         UUID REFERENCES auth.users(id) ON DELETE CASCADE NOT NULL,
+    name            TEXT NOT NULL,
+    category_id     INT NOT NULL,
+    content         TEXT NOT NULL,
+    created_at      BIGINT NOT NULL DEFAULT 0,
+    updated_at      BIGINT NOT NULL DEFAULT 0,
+    format          TEXT NOT NULL DEFAULT 'PLAIN',
+    is_pinned       BOOLEAN NOT NULL DEFAULT false,
+    audio_path      TEXT,
+    styles          TEXT,
+    youtube_url     TEXT,
+    deleted_at      BIGINT,
+    reminder_at     BIGINT,
+    summary_content TEXT,
+    PRIMARY KEY (user_id, id)
+);
+
+CREATE INDEX idx_memo_user_updated ON public.memo(user_id, updated_at DESC);
+
+ALTER TABLE public.memo ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users manage own memos"
+    ON public.memo FOR ALL
+    USING (auth.uid() = user_id)
+    WITH CHECK (auth.uid() = user_id);
+
+-- ============================================================
+-- 3. chat_session
+-- ============================================================
+CREATE TABLE public.chat_session (
+    id          INT NOT NULL,
+    user_id     UUID REFERENCES auth.users(id) ON DELETE CASCADE NOT NULL,
+    title       TEXT NOT NULL,
+    created_at  BIGINT NOT NULL DEFAULT 0,
+    updated_at  BIGINT NOT NULL DEFAULT 0,
+    category    TEXT NOT NULL DEFAULT 'general',
+    PRIMARY KEY (user_id, id)
+);
+
+ALTER TABLE public.chat_session ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users manage own chat sessions"
+    ON public.chat_session FOR ALL
+    USING (auth.uid() = user_id)
+    WITH CHECK (auth.uid() = user_id);
+
+-- ============================================================
+-- 4. chat_message
+-- ============================================================
+CREATE TABLE public.chat_message (
+    id          INT NOT NULL,
+    user_id     UUID REFERENCES auth.users(id) ON DELETE CASCADE NOT NULL,
+    session_id  INT NOT NULL,
+    role        TEXT NOT NULL,
+    content     TEXT NOT NULL,
+    timestamp   BIGINT NOT NULL DEFAULT 0,
+    metadata    TEXT,
+    PRIMARY KEY (user_id, id)
+);
+
+CREATE INDEX idx_chat_message_session ON public.chat_message(user_id, session_id);
+
+ALTER TABLE public.chat_message ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users manage own chat messages"
+    ON public.chat_message FOR ALL
+    USING (auth.uid() = user_id)
+    WITH CHECK (auth.uid() = user_id);
+
+-- ============================================================
+-- 5. youtube_summary (composite PK: videoId + mode + language)
+-- ============================================================
+CREATE TABLE public.youtube_summary (
+    user_id     UUID REFERENCES auth.users(id) ON DELETE CASCADE NOT NULL,
+    video_id    TEXT NOT NULL,
+    mode        TEXT NOT NULL DEFAULT 'SIMPLE',
+    language    TEXT NOT NULL DEFAULT 'ko',
+    url         TEXT NOT NULL,
+    summary     TEXT NOT NULL,
+    created_at  BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (user_id, video_id, mode, language)
+);
+
+ALTER TABLE public.youtube_summary ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users manage own youtube summaries"
+    ON public.youtube_summary FOR ALL
+    USING (auth.uid() = user_id)
+    WITH CHECK (auth.uid() = user_id);
+
+-- ============================================================
+-- 6. ai_usage
+-- ============================================================
+CREATE TABLE public.ai_usage (
+    id          BIGINT NOT NULL,
+    user_id     UUID REFERENCES auth.users(id) ON DELETE CASCADE NOT NULL,
+    feature     TEXT NOT NULL,
+    used_at     BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (user_id, id)
+);
+
+ALTER TABLE public.ai_usage ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users manage own ai usage"
+    ON public.ai_usage FOR ALL
+    USING (auth.uid() = user_id)
+    WITH CHECK (auth.uid() = user_id);
+
+-- ============================================================
+-- 7. backup_metadata (백업 시점 관리)
+-- ============================================================
+CREATE TABLE public.backup_metadata (
+    id              UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+    user_id         UUID REFERENCES auth.users(id) ON DELETE CASCADE NOT NULL,
+    device_name     TEXT NOT NULL,
+    app_version     TEXT NOT NULL,
+    db_version      INT NOT NULL,
+    memo_count      INT NOT NULL DEFAULT 0,
+    total_rows      INT NOT NULL DEFAULT 0,
+    size_bytes      BIGINT NOT NULL DEFAULT 0,
+    created_at      TIMESTAMPTZ DEFAULT now() NOT NULL
+);
+
+CREATE INDEX idx_backup_metadata_user ON public.backup_metadata(user_id, created_at DESC);
+
+ALTER TABLE public.backup_metadata ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users manage own backup metadata"
+    ON public.backup_metadata FOR ALL
+    USING (auth.uid() = user_id)
+    WITH CHECK (auth.uid() = user_id);
+
+-- 사용자당 최대 10개 백업 메타 유지
+CREATE OR REPLACE FUNCTION public.enforce_backup_metadata_limit()
+RETURNS TRIGGER AS $$
+BEGIN
+    DELETE FROM public.backup_metadata
+    WHERE id IN (
+        SELECT id FROM public.backup_metadata
+        WHERE user_id = NEW.user_id
+        ORDER BY created_at DESC
+        OFFSET 10
+    );
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+CREATE TRIGGER trg_enforce_backup_metadata_limit
+    AFTER INSERT ON public.backup_metadata
+    FOR EACH ROW
+    EXECUTE FUNCTION public.enforce_backup_metadata_limit();

--- a/workers/src/index.ts
+++ b/workers/src/index.ts
@@ -217,7 +217,32 @@ async function handleWebScrape(req: Request): Promise<Response> {
     return Response.json({ error: `Failed to fetch: ${pageRes.status}` }, { status: 502 });
   }
 
-  const html = await pageRes.text();
+  // EUC-KR 등 비-UTF-8 인코딩 처리
+  const buffer = await pageRes.arrayBuffer();
+  let charset = "utf-8";
+
+  // 1. Content-Type 헤더에서 charset 확인
+  const contentType = pageRes.headers.get("content-type") || "";
+  const charsetMatch = contentType.match(/charset=([^\s;]+)/i);
+  if (charsetMatch) {
+    charset = charsetMatch[1].toLowerCase().replace(/['"]/g, "");
+  }
+
+  // 2. 헤더에 없으면 HTML meta 태그에서 확인
+  if (charset === "utf-8") {
+    const preview = new TextDecoder("utf-8", { fatal: false }).decode(buffer.slice(0, 2048));
+    const metaCharset = preview.match(/<meta[^>]+charset=["']?([^"'\s;>]+)/i)
+      || preview.match(/<meta[^>]+content=["'][^"']*charset=([^"'\s;>]+)/i);
+    if (metaCharset) {
+      charset = metaCharset[1].toLowerCase();
+    }
+  }
+
+  // euc-kr, euckr 등을 통일
+  if (charset === "euckr" || charset === "euc_kr") charset = "euc-kr";
+
+  const decoder = new TextDecoder(charset, { fatal: false });
+  const html = decoder.decode(buffer);
 
   const titleMatch = html.match(/<title[^>]*>([^<]*)<\/title>/i);
   const ogTitleMatch = html.match(/<meta\s+property="og:title"\s+content="([^"]*)"/i);


### PR DESCRIPTION
## Summary
- Worker 기반 JSON 덤프 방식을 Supabase PostgREST 직접 upsert로 전환 (비용 절약)
- Room DB 6개 테이블 1:1 미러링 스키마 추가 (category, memo, chat_session, chat_message, youtube_summary, ai_usage + backup_metadata)
- 자동 백업 제거 → 수동 백업만 유지 (서버 비용 관리)
- Settings UI 단순화: 백업 목록 다이얼로그 → 마지막 백업 시간 표시
- 요약 카드 버튼 균등 분할(weight) + 전체 UI 32dp 좌측 정렬 통일
- 유튜브 자막/제목 병렬 호출로 요약 속도 3-4초 개선
- Worker EUC-KR 인코딩 지원 (한국 사이트 웹 요약 깨짐 수정)
- 요약 프롬프트 포맷 개선 (핵심 내용 항목 간 개행)

## Test plan
- [x] dev Supabase에 7개 테이블 생성 확인
- [x] 클라우드 백업 버튼 → 모든 테이블 upsert 성공
- [x] backup_metadata 기록 확인
- [ ] 클라우드 복원 테스트
- [ ] prod Supabase에 동일 SQL 실행 후 release 빌드 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)