### PR TITLE
Fix: 설정 UI 개선 + 커서 정렬 + 클립보드 URL 필터링

### DIFF
--- a/feature/core/resource/src/main/java/me/pecos/memozy/presentation/components/AppPopup.kt
+++ b/feature/core/resource/src/main/java/me/pecos/memozy/presentation/components/AppPopup.kt
@@ -88,7 +88,7 @@ fun AppPopup(
     val contentMaxHeight = when (size) {
         PopupSize.MEDIUM -> 300.dp
         PopupSize.LARGE -> 380.dp
-        PopupSize.XLARGE -> 460.dp
+        PopupSize.XLARGE -> 520.dp
     }
     val primaryColor = if (isPrimaryDestructive) Color(0xFFE24B4A) else colors.chipText
 

--- a/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/settings/SettingsScreen.kt
+++ b/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/settings/SettingsScreen.kt
@@ -277,10 +277,10 @@ fun SettingsScreen(
                     Text(stringResource(R.string.font_size_normal), fontSize = fontSettings.scaled(12), color = colors.textSecondary)
                     Text(stringResource(R.string.font_size_large), fontSize = fontSettings.scaled(12), color = colors.textSecondary)
                 }
-                // 커스텀 3단 슬라이더 (원티드 디자인 스타일)
+                // 커스텀 슬라이더 (원티드 디자인 스타일)
                 val trackHeight = 6.dp
                 val thumbSize = 14.dp
-                val stepCount = 3
+                val stepCount = FontSizeLevel.entries.size
                 val currentStep = selectedFontSize.ordinal
                 val density = LocalDensity.current
                 val thumbSizePx = with(density) { thumbSize.toPx() }
@@ -289,14 +289,14 @@ fun SettingsScreen(
                     modifier = Modifier
                         .fillMaxWidth()
                         .height(thumbSize)
-                        .pointerInput(Unit) {
+                        .pointerInput(stepCount) {
                             detectTapGestures { offset ->
                                 val stepWidth = size.width.toFloat() / stepCount
                                 val tappedStep = (offset.x / stepWidth).toInt().coerceIn(0, stepCount - 1)
                                 settingsViewModel.selectFontSize(FontSizeLevel.entries[tappedStep])
                             }
                         }
-                        .pointerInput(Unit) {
+                        .pointerInput(stepCount) {
                             detectHorizontalDragGestures { change, _ ->
                                 change.consume()
                                 val stepWidth = size.width.toFloat() / stepCount

--- a/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/settings/SettingsScreen.kt
+++ b/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/settings/SettingsScreen.kt
@@ -42,12 +42,17 @@ import androidx.credentials.GetCredentialRequest
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.google.android.libraries.identity.googleid.GetGoogleIdOption
 import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential
+import androidx.compose.foundation.background
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
+import androidx.compose.material3.LocalRippleConfiguration
 import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.RippleConfiguration
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.res.painterResource
 import kotlinx.coroutines.launch
 import me.pecos.memozy.data.datasource.remote.auth.AuthState
@@ -57,7 +62,15 @@ import me.pecos.memozy.presentation.components.AppPopup
 import me.pecos.memozy.presentation.components.PopupActionArea
 import me.pecos.memozy.presentation.components.PopupNavigation
 import me.pecos.memozy.presentation.components.PopupSize
-import androidx.compose.material3.Slider
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.gestures.detectHorizontalDragGestures
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.offset
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalDensity
 import kotlin.math.roundToInt
 import me.pecos.memozy.presentation.theme.AppFontFamily
 import me.pecos.memozy.presentation.theme.FontSizeLevel
@@ -65,6 +78,7 @@ import me.pecos.memozy.presentation.theme.LocalActivity
 import me.pecos.memozy.presentation.theme.LocalAppColors
 import me.pecos.memozy.presentation.theme.LocalFontSettings
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SettingsScreen(
     onBack: () -> Unit = {},
@@ -234,7 +248,7 @@ fun SettingsScreen(
                             onClick = { settingsViewModel.selectFontFamily(family) }
                         )
                         Text(
-                            text = family.displayName,
+                            text = if (family == AppFontFamily.SYSTEM) stringResource(R.string.font_system) else family.displayName,
                             color = colors.textBody,
                             fontFamily = family.fontFamily,
                             modifier = Modifier.padding(start = 8.dp)
@@ -263,12 +277,70 @@ fun SettingsScreen(
                     Text(stringResource(R.string.font_size_normal), fontSize = fontSettings.scaled(12), color = colors.textSecondary)
                     Text(stringResource(R.string.font_size_large), fontSize = fontSettings.scaled(12), color = colors.textSecondary)
                 }
-                Slider(
-                    value = selectedFontSize.ordinal.toFloat(),
-                    onValueChange = { settingsViewModel.selectFontSize(FontSizeLevel.entries[it.roundToInt()]) },
-                    valueRange = 0f..2f,
-                    steps = 1
-                )
+                // 커스텀 3단 슬라이더 (원티드 디자인 스타일)
+                val trackHeight = 6.dp
+                val thumbSize = 14.dp
+                val stepCount = 3
+                val currentStep = selectedFontSize.ordinal
+                val density = LocalDensity.current
+                val thumbSizePx = with(density) { thumbSize.toPx() }
+
+                BoxWithConstraints(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(thumbSize)
+                        .pointerInput(Unit) {
+                            detectTapGestures { offset ->
+                                val stepWidth = size.width.toFloat() / stepCount
+                                val tappedStep = (offset.x / stepWidth).toInt().coerceIn(0, stepCount - 1)
+                                settingsViewModel.selectFontSize(FontSizeLevel.entries[tappedStep])
+                            }
+                        }
+                        .pointerInput(Unit) {
+                            detectHorizontalDragGestures { change, _ ->
+                                change.consume()
+                                val stepWidth = size.width.toFloat() / stepCount
+                                val draggedStep = (change.position.x / stepWidth).toInt().coerceIn(0, stepCount - 1)
+                                settingsViewModel.selectFontSize(FontSizeLevel.entries[draggedStep])
+                            }
+                        },
+                    contentAlignment = Alignment.CenterStart
+                ) {
+                    val totalWidthPx = constraints.maxWidth.toFloat()
+                    val thumbCenterPx = when (currentStep) {
+                        0 -> thumbSizePx / 2f
+                        stepCount - 1 -> totalWidthPx - thumbSizePx / 2f
+                        else -> totalWidthPx / 2f
+                    }
+                    val thumbLeftPx = thumbCenterPx - thumbSizePx / 2f
+                    val thumbLeftDp = with(density) { thumbLeftPx.toDp() }
+                    val activeFraction = (thumbCenterPx / totalWidthPx).coerceIn(0f, 1f)
+
+                    // 트랙 배경 (전체)
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(trackHeight)
+                            .clip(RoundedCornerShape(trackHeight / 2))
+                            .background(colors.chipText.copy(alpha = 0.15f))
+                    )
+                    // 트랙 활성 영역
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth(activeFraction)
+                            .height(trackHeight)
+                            .clip(RoundedCornerShape(trackHeight / 2))
+                            .background(colors.chipText)
+                    )
+                    // 구슬 (thumb)
+                    Box(
+                        modifier = Modifier
+                            .offset(x = thumbLeftDp)
+                            .size(thumbSize)
+                            .clip(CircleShape)
+                            .background(colors.chipText)
+                    )
+                }
 
                 HorizontalDivider(
                     modifier = Modifier.padding(vertical = 12.dp),
@@ -468,6 +540,13 @@ fun SettingsScreen(
                 )
 
                 LicenseItem("[6] Firebase (Crashlytics & Analytics)\n출처: https://firebase.google.com\n라이선스: Apache License 2.0\nCopyright (c) Google LLC\n\n$apacheLicense")
+
+                HorizontalDivider(
+                    modifier = Modifier.padding(vertical = 12.dp),
+                    color = colors.cardBorder
+                )
+
+                LicenseItem("[7] Shadcn Compose\n출처: https://shadcn-compose.site\n라이선스: MIT License\nCopyright (c) Shadcn Compose Contributors\n\nPermission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the \"Software\"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.")
             }
         }
     }
@@ -476,6 +555,9 @@ fun SettingsScreen(
     Scaffold(
         containerColor = colors.screenBackground
     ) { innerPadding ->
+        CompositionLocalProvider(
+            LocalRippleConfiguration provides RippleConfiguration(color = colors.textTitle)
+        ) {
         Box(
             modifier = Modifier
                 .fillMaxSize()
@@ -827,6 +909,7 @@ fun SettingsScreen(
                 // 하단 여유 공간 (네비게이션 바에 가리지 않도록)
                 Spacer(modifier = Modifier.height(80.dp))
             }
+        }
         }
     }
 }

--- a/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/MemoScreen.kt
+++ b/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/MemoScreen.kt
@@ -479,7 +479,12 @@ fun MemoScreen(
                         fontSize = fontSettings.titleSize,
                         fontWeight = FontWeight.Bold,
                         color = colors.textTitle,
-                        fontFamily = fontSettings.fontFamily
+                        fontFamily = fontSettings.fontFamily,
+                        lineHeight = (fontSettings.titleSize.value * 1.45f).sp,
+                        lineHeightStyle = LineHeightStyle(
+                            alignment = LineHeightStyle.Alignment.Bottom,
+                            trim = LineHeightStyle.Trim.None
+                        )
                     ),
                     modifier = Modifier.fillMaxWidth(),
                     decorationBox = { innerTextField ->
@@ -490,7 +495,8 @@ fun MemoScreen(
                                     fontSize = fontSettings.titleSize,
                                     fontWeight = FontWeight.Bold,
                                     fontFamily = fontSettings.fontFamily,
-                                    color = colors.textSecondary.copy(alpha = 0.4f)
+                                    color = colors.textSecondary.copy(alpha = 0.4f),
+                                    lineHeight = (fontSettings.titleSize.value * 1.45f).sp
                                 )
                             }
                             innerTextField()
@@ -612,7 +618,7 @@ fun MemoScreen(
                         .focusRequester(bodyFocusRequester),
                     textStyle = TextStyle(
                         fontSize = fontSettings.bodySize,
-                        lineHeight = (fontSettings.bodySize.value * 1.6f).sp,
+                        lineHeight = (fontSettings.bodySize.value * 1.8f).sp,
                         color = colors.textBody,
                         fontFamily = fontSettings.fontFamily,
                         lineHeightStyle = LineHeightStyle(

--- a/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/components/MemoDialogs.kt
+++ b/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/components/MemoDialogs.kt
@@ -82,7 +82,7 @@ fun YouTubeUrlDialog(
             placeholder = { Text("https://youtu.be/...", fontSize = fontSettings.scaled(14)) },
             singleLine = true, modifier = Modifier.fillMaxWidth()
         )
-        if (clipText.isNotBlank() && urlInput.isBlank()) {
+        if (clipText.isNotBlank() && urlInput.isBlank() && YOUTUBE_URL_REGEX.containsMatchIn(clipText)) {
             Spacer(modifier = Modifier.height(8.dp))
             Row(
                 modifier = Modifier
@@ -139,7 +139,7 @@ fun WebUrlDialog(
             placeholder = { Text("https://...", fontSize = fontSettings.scaled(14)) },
             singleLine = true, modifier = Modifier.fillMaxWidth()
         )
-        if (clipText.isNotBlank() && webUrlInput.isBlank()) {
+        if (clipText.isNotBlank() && webUrlInput.isBlank() && clipText.trimStart().startsWith("http")) {
             Spacer(modifier = Modifier.height(8.dp))
             Row(
                 modifier = Modifier


### PR DESCRIPTION
## Summary
- Shadcn Compose 오픈소스 라이선스 추가 (closes #147)
- 설정 OutlinedButton 녹색 리플 플래시 제거 (closes #148)
- 폰트 크기 슬라이더를 커스텀 3단 슬라이더로 교체 (원티드 디자인 스타일, 블루 컬러, 레이블 정렬)
- 폰트 설정 팝업 XLARGE 높이 증가 (큰 폰트 미리보기 잘림 방지)
- "시스템 기본" 폰트명 다국어 적용 (EN/JA/KO)
- 메모 제목/본문 커서 높이 정렬 (lineHeight + LineHeightStyle 조정)
- 유튜브/웹 요약 팝업: 클립보드에 URL 형태일 때만 링크 칩 표시

## Test plan
- [ ] 설정 > 라이선스 다이얼로그에서 Shadcn Compose 항목 확인
- [ ] 설정 버튼 클릭 시 녹색 리플 없이 정상 동작
- [ ] 폰트 크기 슬라이더: 작게/보통/크게 각 레이블 아래에 구슬 정확히 위치
- [ ] 폰트 설정 팝업에서 큰 폰트 선택 시 미리보기 텍스트 잘리지 않음
- [ ] 영어/일본어 언어 설정 시 "System Default" / "システムデフォルト" 표시
- [ ] 메모 추가/수정 화면에서 제목/본문 커서가 텍스트와 높이 맞음
- [ ] 클립보드에 일반 텍스트 복사 후 유튜브/웹 요약 팝업 열면 파란 링크 칩 안 뜸
- [ ] 클립보드에 URL 복사 후 열면 정상적으로 파란 링크 칩 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)