### PR TITLE
Add: #149 구독 시스템 + 티어별 AI 한도 + Pro UI

### DIFF
--- a/datasource/local/memo/api/src/main/java/me/pecos/memozy/data/datasource/local/AiUsageDao.kt
+++ b/datasource/local/memo/api/src/main/java/me/pecos/memozy/data/datasource/local/AiUsageDao.kt
@@ -14,6 +14,9 @@ interface AiUsageDao {
     @Query("SELECT COUNT(*) FROM ai_usage WHERE feature = :feature AND usedAt >= :startOfDay")
     suspend fun getCountSince(feature: String, startOfDay: Long): Int
 
+    @Query("SELECT COUNT(*) FROM ai_usage WHERE usedAt >= :startOfDay")
+    suspend fun getTotalCountSince(startOfDay: Long): Int
+
     @Query("SELECT * FROM ai_usage ORDER BY usedAt DESC")
     suspend fun getAllOnce(): List<AiUsage>
 

--- a/feature/core/resource/src/main/java/me/pecos/memozy/presentation/theme/SubscriptionTier.kt
+++ b/feature/core/resource/src/main/java/me/pecos/memozy/presentation/theme/SubscriptionTier.kt
@@ -1,6 +1,6 @@
 package me.pecos.memozy.presentation.theme
 
-import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.runtime.compositionLocalOf
 
 enum class SubscriptionTier {
     FREE, PRO;
@@ -14,4 +14,4 @@ enum class SubscriptionTier {
     val isPro: Boolean get() = this == PRO
 }
 
-val LocalSubscriptionTier = staticCompositionLocalOf { SubscriptionTier.FREE }
+val LocalSubscriptionTier = compositionLocalOf { SubscriptionTier.FREE }

--- a/feature/core/resource/src/main/java/me/pecos/memozy/presentation/theme/SubscriptionTier.kt
+++ b/feature/core/resource/src/main/java/me/pecos/memozy/presentation/theme/SubscriptionTier.kt
@@ -1,0 +1,17 @@
+package me.pecos.memozy.presentation.theme
+
+import androidx.compose.runtime.staticCompositionLocalOf
+
+enum class SubscriptionTier {
+    FREE, PRO;
+
+    val dailyAiLimit: Int
+        get() = when (this) {
+            FREE -> 2
+            PRO -> 15
+        }
+
+    val isPro: Boolean get() = this == PRO
+}
+
+val LocalSubscriptionTier = staticCompositionLocalOf { SubscriptionTier.FREE }

--- a/feature/core/resource/src/main/res/values-en/strings.xml
+++ b/feature/core/resource/src/main/res/values-en/strings.xml
@@ -227,4 +227,27 @@
     <string name="font_preview_title">Title Preview</string>
     <string name="font_preview_body">This is a body text preview. This font will be applied to your memos.</string>
     <string name="font_system">System Default</string>
+
+    <!-- AI Limit -->
+    <string name="ai_limit_title">Daily AI limit reached</string>
+    <string name="ai_limit_free_message">Free users can use AI features up to %d times per day.</string>
+    <string name="ai_limit_pro_message">Pro users can use AI features up to %d times per day.\nYou can use it again tomorrow.</string>
+    <string name="ai_limit_upgrade">Upgrade to Pro</string>
+    <string name="ai_limit_upgrade_desc">More AI summaries + all premium features</string>
+    <string name="ai_limit_close">Close</string>
+
+    <!-- Subscription -->
+    <string name="subscription_title">Memozy Pro</string>
+    <string name="subscription_desc">Use AI features more generously</string>
+    <string name="subscription_monthly">Monthly</string>
+    <string name="subscription_yearly">Yearly</string>
+    <string name="subscription_yearly_discount">30%% off</string>
+    <string name="subscription_feature_youtube">YouTube summary</string>
+    <string name="subscription_feature_web">Web page summary</string>
+    <string name="subscription_feature_ocr">Photo summary</string>
+    <string name="subscription_feature_more">More summaries available</string>
+    <string name="subscription_feature_no_ads">No ads</string>
+    <string name="subscription_current_plan">Current plan</string>
+    <string name="subscription_manage">Manage subscription</string>
+    <string name="subscription_restore">Restore purchases</string>
 </resources>

--- a/feature/core/resource/src/main/res/values-ja/strings.xml
+++ b/feature/core/resource/src/main/res/values-ja/strings.xml
@@ -227,4 +227,27 @@
     <string name="font_preview_title">タイトルプレビュー</string>
     <string name="font_preview_body">本文プレビューテキストです。このフォントがメモに適用されます。</string>
     <string name="font_system">システムデフォルト</string>
+
+    <!-- AI Limit -->
+    <string name="ai_limit_title">本日のAI使用回数に達しました</string>
+    <string name="ai_limit_free_message">無料ユーザーは1日%d回までAI機能を使用できます。</string>
+    <string name="ai_limit_pro_message">Proユーザーは1日%d回までAI機能を使用できます。\n明日また使用できます。</string>
+    <string name="ai_limit_upgrade">Proにアップグレード</string>
+    <string name="ai_limit_upgrade_desc">より多くのAI要約 + すべてのプレミアム機能</string>
+    <string name="ai_limit_close">閉じる</string>
+
+    <!-- Subscription -->
+    <string name="subscription_title">Memozy Pro</string>
+    <string name="subscription_desc">AI機能をもっと使いましょう</string>
+    <string name="subscription_monthly">月額</string>
+    <string name="subscription_yearly">年額</string>
+    <string name="subscription_yearly_discount">30%%オフ</string>
+    <string name="subscription_feature_youtube">YouTube要約</string>
+    <string name="subscription_feature_web">Webページ要約</string>
+    <string name="subscription_feature_ocr">写真要約</string>
+    <string name="subscription_feature_more">より多くの要約が可能</string>
+    <string name="subscription_feature_no_ads">広告なし</string>
+    <string name="subscription_current_plan">現在のプラン</string>
+    <string name="subscription_manage">サブスクリプション管理</string>
+    <string name="subscription_restore">購入を復元</string>
 </resources>

--- a/feature/core/resource/src/main/res/values/strings.xml
+++ b/feature/core/resource/src/main/res/values/strings.xml
@@ -225,4 +225,27 @@
     <string name="font_preview_title">제목 미리보기</string>
     <string name="font_preview_body">본문 미리보기 텍스트입니다. 이 글꼴이 메모에 적용됩니다.</string>
     <string name="font_system">시스템 기본</string>
+
+    <!-- AI Limit -->
+    <string name="ai_limit_title">오늘 AI 사용 한도에 도달했어요</string>
+    <string name="ai_limit_free_message">무료 사용자는 하루 %d회까지 AI 기능을 사용할 수 있어요.</string>
+    <string name="ai_limit_pro_message">Pro 사용자는 하루 %d회까지 AI 기능을 사용할 수 있어요.\n내일 다시 사용할 수 있어요.</string>
+    <string name="ai_limit_upgrade">Pro로 업그레이드</string>
+    <string name="ai_limit_upgrade_desc">더 많은 AI 요약 + 모든 프리미엄 기능</string>
+    <string name="ai_limit_close">닫기</string>
+
+    <!-- Subscription -->
+    <string name="subscription_title">Memozy Pro</string>
+    <string name="subscription_desc">AI 기능을 더 넉넉하게 사용하세요</string>
+    <string name="subscription_monthly">월간 구독</string>
+    <string name="subscription_yearly">연간 구독</string>
+    <string name="subscription_yearly_discount">30%% 할인</string>
+    <string name="subscription_feature_youtube">유튜브 요약</string>
+    <string name="subscription_feature_web">웹페이지 요약</string>
+    <string name="subscription_feature_ocr">사진 요약</string>
+    <string name="subscription_feature_more">더 많은 요약 가능</string>
+    <string name="subscription_feature_no_ads">광고 없음</string>
+    <string name="subscription_current_plan">현재 이용 중</string>
+    <string name="subscription_manage">구독 관리</string>
+    <string name="subscription_restore">구매 복원</string>
 </resources>

--- a/feature/home/impl/src/main/AndroidManifest.xml
+++ b/feature/home/impl/src/main/AndroidManifest.xml
@@ -7,7 +7,8 @@
             android:exported="true"
             android:launchMode="singleTask"
             android:label="@string/app_name"
-            android:theme="@style/Theme.Memozy">
+            android:theme="@style/Theme.Memozy"
+            android:windowSoftInputMode="adjustNothing">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/feature/home/impl/src/main/java/me/pecos/memozy/MainActivity.kt
+++ b/feature/home/impl/src/main/java/me/pecos/memozy/MainActivity.kt
@@ -58,11 +58,13 @@ import dev.chrisbanes.haze.hazeEffect
 import dev.chrisbanes.haze.hazeSource
 import dev.chrisbanes.haze.rememberHazeState
 import me.pecos.memozy.data.billing.BillingManager
+import me.pecos.memozy.presentation.theme.LocalSubscriptionTier
 import me.pecos.memozy.feature.home.api.HomeRoute
 import me.pecos.memozy.feature.memoplain.api.MemoPlainNavigation
 import me.pecos.memozy.feature.memoplain.api.MemoPlainRoute
 import me.pecos.memozy.presentation.components.FloatingNavPill
 import me.pecos.memozy.presentation.screen.donation.DonationScreen
+import me.pecos.memozy.presentation.screen.subscription.SubscriptionScreen
 import me.pecos.memozy.presentation.screen.home.HomeScreen
 import me.pecos.memozy.presentation.screen.home.MainViewModel
 import me.pecos.memozy.presentation.screen.login.LoginScreen
@@ -132,6 +134,7 @@ class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
+        billingManager.connect()
 
         setContent {
             val settingsViewModel: SettingsViewModel = viewModel()
@@ -155,8 +158,11 @@ class MainActivity : AppCompatActivity() {
                 appFontFamily = selectedFontFamily
             )
 
+            val currentTier by billingManager.subscriptionTier.collectAsState()
+
             CompositionLocalProvider(
-                LocalActivity provides this@MainActivity
+                LocalActivity provides this@MainActivity,
+                LocalSubscriptionTier provides currentTier
             ) {
             OverrideNightMode(isDarkTheme = isDarkTheme) {
                 CompositionLocalProvider(
@@ -306,6 +312,7 @@ class MainActivity : AppCompatActivity() {
                                     SettingsScreen(
                                         onBack = { navController.popBackStack() },
                                         onDonation = { navController.navigate("donation") },
+                                        onSubscription = { navController.navigate("subscription") },
                                         onTrash = { navController.navigate(HomeRoute.TRASH) },
                                         settingsViewModel = settingsViewModel
                                     )
@@ -319,6 +326,12 @@ class MainActivity : AppCompatActivity() {
                                 }
                                 composable("donation") {
                                     DonationScreen(
+                                        onBack = { navController.popBackStack() },
+                                        billingManager = this@MainActivity.billingManager
+                                    )
+                                }
+                                composable("subscription") {
+                                    SubscriptionScreen(
                                         onBack = { navController.popBackStack() },
                                         billingManager = this@MainActivity.billingManager
                                     )

--- a/feature/home/impl/src/main/java/me/pecos/memozy/data/billing/BillingManager.kt
+++ b/feature/home/impl/src/main/java/me/pecos/memozy/data/billing/BillingManager.kt
@@ -2,6 +2,7 @@ package me.pecos.memozy.data.billing
 
 import android.app.Activity
 import android.content.Context
+import com.android.billingclient.api.AcknowledgePurchaseParams
 import com.android.billingclient.api.BillingClient
 import com.android.billingclient.api.BillingClientStateListener
 import com.android.billingclient.api.BillingFlowParams
@@ -12,14 +13,24 @@ import com.android.billingclient.api.ProductDetails
 import com.android.billingclient.api.Purchase
 import com.android.billingclient.api.PurchasesUpdatedListener
 import com.android.billingclient.api.QueryProductDetailsParams
+import com.android.billingclient.api.QueryPurchasesParams
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import me.pecos.memozy.presentation.theme.SubscriptionTier
 
 data class DonationProduct(
     val productId: String,
     val name: String,
     val description: String,
     val formattedPrice: String
+)
+
+data class SubscriptionProduct(
+    val productId: String,
+    val name: String,
+    val description: String,
+    val formattedPrice: String,
+    val billingPeriod: String
 )
 
 sealed class PurchaseState {
@@ -40,6 +51,9 @@ class BillingManager(
         private const val PRODUCT_RICE_4 = "donation_rice_4"
         private const val PRODUCT_RICE_5 = "donation_rice_5"
 
+        const val SUB_PRO_MONTHLY = "pro_monthly"
+        const val SUB_PRO_YEARLY = "pro_yearly"
+
         val PRODUCT_IDS = listOf(
             PRODUCT_RICE_1,
             PRODUCT_RICE_2,
@@ -47,6 +61,8 @@ class BillingManager(
             PRODUCT_RICE_4,
             PRODUCT_RICE_5
         )
+
+        val SUBSCRIPTION_IDS = listOf(SUB_PRO_MONTHLY, SUB_PRO_YEARLY)
     }
 
     private val billingClient: BillingClient = BillingClient.newBuilder(context.applicationContext)
@@ -54,20 +70,28 @@ class BillingManager(
         .enablePendingPurchases(
             PendingPurchasesParams.newBuilder()
                 .enableOneTimeProducts()
+                .enablePrepaidPlans()
                 .build()
         )
         .build()
 
     private val productDetailsMap = mutableMapOf<String, ProductDetails>()
+    private val subscriptionDetailsMap = mutableMapOf<String, ProductDetails>()
 
     private val _products = MutableStateFlow<List<DonationProduct>>(emptyList())
     val products: StateFlow<List<DonationProduct>> = _products
+
+    private val _subscriptionProducts = MutableStateFlow<List<SubscriptionProduct>>(emptyList())
+    val subscriptionProducts: StateFlow<List<SubscriptionProduct>> = _subscriptionProducts
 
     private val _purchaseState = MutableStateFlow<PurchaseState>(PurchaseState.Idle)
     val purchaseState: StateFlow<PurchaseState> = _purchaseState
 
     private val _isConnected = MutableStateFlow(false)
     val isConnected: StateFlow<Boolean> = _isConnected
+
+    private val _subscriptionTier = MutableStateFlow(SubscriptionTier.FREE)
+    val subscriptionTier: StateFlow<SubscriptionTier> = _subscriptionTier
 
     fun connect() {
         if (billingClient.isReady) return
@@ -77,6 +101,8 @@ class BillingManager(
                 if (billingResult.responseCode == BillingClient.BillingResponseCode.OK) {
                     _isConnected.value = true
                     queryProducts()
+                    querySubscriptions()
+                    queryExistingSubscriptions()
                 } else {
                     _isConnected.value = false
                 }
@@ -88,6 +114,8 @@ class BillingManager(
             }
         })
     }
+
+    // ── 소비형 상품 (후원) ──
 
     private fun queryProducts() {
         val productList = PRODUCT_IDS.map { productId ->
@@ -140,6 +168,83 @@ class BillingManager(
 
     fun isProductAvailable(productId: String): Boolean = productDetailsMap.containsKey(productId)
 
+    // ── 구독 상품 ──
+
+    private fun querySubscriptions() {
+        val subList = SUBSCRIPTION_IDS.map { subId ->
+            QueryProductDetailsParams.Product.newBuilder()
+                .setProductId(subId)
+                .setProductType(BillingClient.ProductType.SUBS)
+                .build()
+        }
+
+        val params = QueryProductDetailsParams.newBuilder()
+            .setProductList(subList)
+            .build()
+
+        billingClient.queryProductDetailsAsync(params) { billingResult, productDetailsList ->
+            if (billingResult.responseCode == BillingClient.BillingResponseCode.OK) {
+                subscriptionDetailsMap.clear()
+                productDetailsList.forEach { subscriptionDetailsMap[it.productId] = it }
+
+                val subProducts = SUBSCRIPTION_IDS.mapNotNull { id ->
+                    subscriptionDetailsMap[id]?.let { details ->
+                        val offerDetails = details.subscriptionOfferDetails?.firstOrNull()
+                        val pricingPhase = offerDetails?.pricingPhases?.pricingPhaseList?.firstOrNull()
+                        SubscriptionProduct(
+                            productId = details.productId,
+                            name = details.name,
+                            description = details.description,
+                            formattedPrice = pricingPhase?.formattedPrice ?: "",
+                            billingPeriod = pricingPhase?.billingPeriod ?: ""
+                        )
+                    }
+                }
+                _subscriptionProducts.value = subProducts
+            }
+        }
+    }
+
+    fun launchSubscriptionFlow(activity: Activity, productId: String) {
+        val details = subscriptionDetailsMap[productId] ?: return
+        val offerToken = details.subscriptionOfferDetails?.firstOrNull()?.offerToken ?: return
+        _purchaseState.value = PurchaseState.Loading
+
+        val productDetailsParams = BillingFlowParams.ProductDetailsParams.newBuilder()
+            .setProductDetails(details)
+            .setOfferToken(offerToken)
+            .build()
+
+        val billingFlowParams = BillingFlowParams.newBuilder()
+            .setProductDetailsParamsList(listOf(productDetailsParams))
+            .build()
+
+        billingClient.launchBillingFlow(activity, billingFlowParams)
+    }
+
+    fun queryExistingSubscriptions() {
+        billingClient.queryPurchasesAsync(
+            QueryPurchasesParams.newBuilder()
+                .setProductType(BillingClient.ProductType.SUBS)
+                .build()
+        ) { billingResult, purchases ->
+            if (billingResult.responseCode == BillingClient.BillingResponseCode.OK) {
+                val hasActiveSub = purchases.any { purchase ->
+                    purchase.purchaseState == Purchase.PurchaseState.PURCHASED &&
+                        purchase.products.any { it in SUBSCRIPTION_IDS }
+                }
+                _subscriptionTier.value = if (hasActiveSub) SubscriptionTier.PRO else SubscriptionTier.FREE
+
+                // acknowledge 안 된 구독 처리
+                purchases.filter {
+                    it.purchaseState == Purchase.PurchaseState.PURCHASED && !it.isAcknowledged
+                }.forEach { acknowledgePurchase(it) }
+            }
+        }
+    }
+
+    // ── 결제 콜백 ──
+
     override fun onPurchasesUpdated(
         billingResult: BillingResult,
         purchases: MutableList<Purchase>?
@@ -148,7 +253,14 @@ class BillingManager(
             BillingClient.BillingResponseCode.OK -> {
                 purchases?.forEach { purchase ->
                     if (purchase.purchaseState == Purchase.PurchaseState.PURCHASED) {
-                        consumePurchase(purchase)
+                        val isSubscription = purchase.products.any { it in SUBSCRIPTION_IDS }
+                        if (isSubscription) {
+                            acknowledgePurchase(purchase)
+                            _subscriptionTier.value = SubscriptionTier.PRO
+                            _purchaseState.value = PurchaseState.Success
+                        } else {
+                            consumePurchase(purchase)
+                        }
                     }
                 }
             }
@@ -175,6 +287,14 @@ class BillingManager(
                 _purchaseState.value = PurchaseState.Error(billingResult.debugMessage)
             }
         }
+    }
+
+    private fun acknowledgePurchase(purchase: Purchase) {
+        if (purchase.isAcknowledged) return
+        val params = AcknowledgePurchaseParams.newBuilder()
+            .setPurchaseToken(purchase.purchaseToken)
+            .build()
+        billingClient.acknowledgePurchase(params) { /* no-op */ }
     }
 
     fun resetPurchaseState() {

--- a/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/settings/SettingsScreen.kt
+++ b/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/settings/SettingsScreen.kt
@@ -4,6 +4,7 @@ import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.clickable
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -48,6 +49,9 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LocalRippleConfiguration
 import androidx.compose.material3.OutlinedButton
@@ -76,6 +80,7 @@ import me.pecos.memozy.presentation.theme.AppFontFamily
 import me.pecos.memozy.presentation.theme.FontSizeLevel
 import me.pecos.memozy.presentation.theme.LocalActivity
 import me.pecos.memozy.presentation.theme.LocalAppColors
+import me.pecos.memozy.presentation.theme.LocalSubscriptionTier
 import me.pecos.memozy.presentation.theme.LocalFontSettings
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -83,6 +88,7 @@ import me.pecos.memozy.presentation.theme.LocalFontSettings
 fun SettingsScreen(
     onBack: () -> Unit = {},
     onDonation: () -> Unit = {},
+    onSubscription: () -> Unit = {},
     onTrash: () -> Unit = {},
     settingsViewModel: SettingsViewModel = viewModel()
 ) {
@@ -690,7 +696,134 @@ fun SettingsScreen(
                     }
                 }
 
-                Spacer(modifier = Modifier.height(6.dp))
+                Spacer(modifier = Modifier.height(12.dp))
+
+                // ── Memozy Pro 카드 ──
+                val currentTier = LocalSubscriptionTier.current
+                val isSystemDark = colors.screenBackground == Color(0xFF1C1C1E)
+                val proGradient = if (isSystemDark) {
+                    Brush.linearGradient(listOf(Color(0xFF1A3A5C), Color(0xFF2A1A4E)))
+                } else {
+                    Brush.linearGradient(listOf(Color(0xFF4A90D9), Color(0xFF7B5EA7)))
+                }
+
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp)
+                        .clip(RoundedCornerShape(16.dp))
+                        .background(proGradient)
+                        .clickable { onSubscription() }
+                        .padding(20.dp)
+                ) {
+                    Column {
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Text(
+                                text = "Memozy Pro",
+                                fontSize = fontSettings.scaled(18),
+                                fontWeight = FontWeight.Bold,
+                                color = Color.White
+                            )
+                            if (currentTier.isPro) {
+                                Spacer(modifier = Modifier.width(8.dp))
+                                Text(
+                                    text = stringResource(R.string.subscription_current_plan),
+                                    fontSize = fontSettings.scaled(11),
+                                    fontWeight = FontWeight.Bold,
+                                    color = Color.White.copy(alpha = 0.9f),
+                                    modifier = Modifier
+                                        .clip(RoundedCornerShape(4.dp))
+                                        .background(Color.White.copy(alpha = 0.2f))
+                                        .padding(horizontal = 6.dp, vertical = 2.dp)
+                                )
+                            }
+                        }
+
+                        Spacer(modifier = Modifier.height(6.dp))
+
+                        Text(
+                            text = stringResource(R.string.subscription_desc),
+                            fontSize = fontSettings.scaled(13),
+                            color = Color.White.copy(alpha = 0.8f)
+                        )
+
+                        Spacer(modifier = Modifier.height(12.dp))
+
+                        val proFeatures = listOf(
+                            stringResource(R.string.subscription_feature_youtube),
+                            stringResource(R.string.subscription_feature_web),
+                            stringResource(R.string.subscription_feature_ocr),
+                            stringResource(R.string.subscription_feature_no_ads)
+                        )
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.SpaceBetween
+                        ) {
+                            Column {
+                                proFeatures.take(2).forEach { feature ->
+                                    Row(verticalAlignment = Alignment.CenterVertically) {
+                                        Icon(
+                                            Icons.Default.Check,
+                                            contentDescription = null,
+                                            tint = Color.White.copy(alpha = 0.9f),
+                                            modifier = Modifier.size(14.dp)
+                                        )
+                                        Spacer(modifier = Modifier.width(4.dp))
+                                        Text(feature, fontSize = fontSettings.scaled(12), color = Color.White.copy(alpha = 0.9f))
+                                    }
+                                    Spacer(modifier = Modifier.height(2.dp))
+                                }
+                            }
+                            Column {
+                                proFeatures.drop(2).forEach { feature ->
+                                    Row(verticalAlignment = Alignment.CenterVertically) {
+                                        Icon(
+                                            Icons.Default.Check,
+                                            contentDescription = null,
+                                            tint = Color.White.copy(alpha = 0.9f),
+                                            modifier = Modifier.size(14.dp)
+                                        )
+                                        Spacer(modifier = Modifier.width(4.dp))
+                                        Text(feature, fontSize = fontSettings.scaled(12), color = Color.White.copy(alpha = 0.9f))
+                                    }
+                                    Spacer(modifier = Modifier.height(2.dp))
+                                }
+                            }
+                        }
+
+                        if (!currentTier.isPro) {
+                            Spacer(modifier = Modifier.height(12.dp))
+
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .clip(RoundedCornerShape(10.dp))
+                                    .background(Color.White.copy(alpha = 0.2f))
+                                    .padding(horizontal = 16.dp, vertical = 10.dp),
+                                horizontalArrangement = Arrangement.Center,
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Text(
+                                    text = stringResource(R.string.ai_limit_upgrade),
+                                    fontSize = fontSettings.scaled(14),
+                                    fontWeight = FontWeight.Bold,
+                                    color = Color.White
+                                )
+                                Spacer(modifier = Modifier.width(4.dp))
+                                Icon(
+                                    Icons.AutoMirrored.Filled.ArrowForward,
+                                    contentDescription = null,
+                                    tint = Color.White,
+                                    modifier = Modifier.size(16.dp)
+                                )
+                            }
+                        }
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(12.dp))
 
                 HorizontalDivider(
                     thickness = 0.3.dp,

--- a/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/subscription/SubscriptionScreen.kt
+++ b/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/subscription/SubscriptionScreen.kt
@@ -1,0 +1,407 @@
+package me.pecos.memozy.presentation.screen.subscription
+
+import android.content.Intent
+import android.net.Uri
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import me.pecos.memozy.data.billing.BillingManager
+import me.pecos.memozy.data.billing.PurchaseState
+import me.pecos.memozy.feature.core.resource.R
+import me.pecos.memozy.presentation.components.AppPopup
+import me.pecos.memozy.presentation.components.PopupActionArea
+import me.pecos.memozy.presentation.components.PopupNavigation
+import me.pecos.memozy.presentation.components.PopupSize
+import me.pecos.memozy.presentation.theme.LocalActivity
+import me.pecos.memozy.presentation.theme.LocalAppColors
+import me.pecos.memozy.presentation.theme.LocalFontSettings
+import me.pecos.memozy.presentation.theme.LocalSubscriptionTier
+
+@Composable
+fun SubscriptionScreen(
+    onBack: () -> Unit = {},
+    billingManager: BillingManager
+) {
+    val subscriptionProducts by billingManager.subscriptionProducts.collectAsState()
+    val purchaseState by billingManager.purchaseState.collectAsState()
+    val currentTier = LocalSubscriptionTier.current
+    val colors = LocalAppColors.current
+    val fontSettings = LocalFontSettings.current
+    val activity = LocalActivity.current
+    val context = LocalContext.current
+    val isSystemDark = colors.screenBackground == Color(0xFF1C1C1E)
+
+    if (purchaseState is PurchaseState.Success) {
+        AppPopup(
+            onDismissRequest = { billingManager.resetPurchaseState() },
+            title = stringResource(R.string.subscription_title),
+            navigation = PopupNavigation.EMPHASIZED,
+            size = PopupSize.MEDIUM,
+            actionArea = PopupActionArea.NONE
+        ) {
+            Text(
+                text = "Pro \uAD6C\uB3C5\uC774 \uD65C\uC131\uD654\uB418\uC5C8\uC5B4\uC694!",
+                color = colors.textBody
+            )
+        }
+    }
+
+    if (purchaseState is PurchaseState.Error) {
+        AppPopup(
+            onDismissRequest = { billingManager.resetPurchaseState() },
+            title = stringResource(R.string.donation_error_title),
+            navigation = PopupNavigation.EMPHASIZED,
+            size = PopupSize.MEDIUM,
+            actionArea = PopupActionArea.NONE
+        ) {
+            Text(
+                text = stringResource(R.string.donation_error_message),
+                color = colors.textBody
+            )
+        }
+    }
+
+    Scaffold(
+        containerColor = colors.screenBackground
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .verticalScroll(rememberScrollState())
+        ) {
+            // ── 히어로 영역 ──
+            val heroGradient = if (isSystemDark) {
+                Brush.verticalGradient(listOf(Color(0xFF1A3A5C), Color(0xFF2A1A4E), colors.screenBackground))
+            } else {
+                Brush.verticalGradient(listOf(Color(0xFF4A90D9), Color(0xFF7B5EA7), colors.screenBackground))
+            }
+
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(heroGradient)
+                    .padding(horizontal = 24.dp)
+                    .padding(top = 24.dp, bottom = 32.dp)
+            ) {
+                Column {
+                    // 뒤로가기
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.close),
+                            tint = Color.White
+                        )
+                    }
+
+                    Spacer(modifier = Modifier.height(16.dp))
+
+                    Text(
+                        text = "Memozy Pro",
+                        fontSize = fontSettings.scaled(28),
+                        fontWeight = FontWeight.Bold,
+                        color = Color.White
+                    )
+
+                    Spacer(modifier = Modifier.height(8.dp))
+
+                    Text(
+                        text = stringResource(R.string.subscription_desc),
+                        fontSize = fontSettings.scaled(15),
+                        color = Color.White.copy(alpha = 0.85f)
+                    )
+
+                    if (currentTier.isPro) {
+                        Spacer(modifier = Modifier.height(12.dp))
+                        Text(
+                            text = stringResource(R.string.subscription_current_plan),
+                            fontSize = fontSettings.scaled(13),
+                            fontWeight = FontWeight.Bold,
+                            color = Color.White,
+                            modifier = Modifier
+                                .clip(RoundedCornerShape(6.dp))
+                                .background(Color.White.copy(alpha = 0.2f))
+                                .padding(horizontal = 10.dp, vertical = 4.dp)
+                        )
+                    }
+                }
+            }
+
+            // ── Free vs Pro 비교 테이블 ──
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 20.dp)
+                    .clip(RoundedCornerShape(16.dp))
+                    .background(colors.cardBackground)
+                    .border(1.dp, colors.cardBorder, RoundedCornerShape(16.dp))
+                    .padding(20.dp)
+            ) {
+                // 헤더
+                Row(modifier = Modifier.fillMaxWidth()) {
+                    Spacer(modifier = Modifier.weight(1.4f))
+                    Text(
+                        text = "Free",
+                        fontSize = fontSettings.scaled(13),
+                        fontWeight = FontWeight.Bold,
+                        color = colors.textSecondary,
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier.weight(1f)
+                    )
+                    Text(
+                        text = "Pro",
+                        fontSize = fontSettings.scaled(13),
+                        fontWeight = FontWeight.Bold,
+                        color = colors.chipText,
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier.weight(1f)
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(8.dp))
+                HorizontalDivider(color = colors.cardBorder, thickness = 0.5.dp)
+                Spacer(modifier = Modifier.height(8.dp))
+
+                // 비교 항목
+                val comparisons = listOf(
+                    Triple(stringResource(R.string.subscription_feature_youtube), true, true),
+                    Triple(stringResource(R.string.subscription_feature_web), false, true),
+                    Triple(stringResource(R.string.subscription_feature_ocr), false, true),
+                    Triple(stringResource(R.string.subscription_feature_more), false, true),
+                    Triple(stringResource(R.string.subscription_feature_no_ads), false, true),
+                )
+
+                comparisons.forEach { (label, free, pro) ->
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 6.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Text(
+                            text = label,
+                            fontSize = fontSettings.scaled(13),
+                            color = colors.textBody,
+                            modifier = Modifier.weight(1.4f)
+                        )
+                        Box(modifier = Modifier.weight(1f), contentAlignment = Alignment.Center) {
+                            if (free) {
+                                Icon(Icons.Default.Check, null, tint = colors.textSecondary, modifier = Modifier.size(16.dp))
+                            } else {
+                                Icon(Icons.Default.Close, null, tint = colors.cardBorder, modifier = Modifier.size(16.dp))
+                            }
+                        }
+                        Box(modifier = Modifier.weight(1f), contentAlignment = Alignment.Center) {
+                            if (pro) {
+                                Icon(Icons.Default.Check, null, tint = colors.chipText, modifier = Modifier.size(16.dp))
+                            } else {
+                                Icon(Icons.Default.Close, null, tint = colors.cardBorder, modifier = Modifier.size(16.dp))
+                            }
+                        }
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            // ── 구독 상품 카드 ──
+            val monthly = subscriptionProducts.find { it.productId == BillingManager.SUB_PRO_MONTHLY }
+            val yearly = subscriptionProducts.find { it.productId == BillingManager.SUB_PRO_YEARLY }
+
+            if (yearly != null) {
+                SubscriptionCard(
+                    label = stringResource(R.string.subscription_yearly),
+                    price = yearly.formattedPrice,
+                    badge = stringResource(R.string.subscription_yearly_discount),
+                    isCurrentPlan = currentTier.isPro,
+                    isRecommended = true,
+                    onClick = {
+                        if (activity != null && !currentTier.isPro) {
+                            billingManager.launchSubscriptionFlow(activity, BillingManager.SUB_PRO_YEARLY)
+                        }
+                    }
+                )
+                Spacer(modifier = Modifier.height(12.dp))
+            }
+
+            if (monthly != null) {
+                SubscriptionCard(
+                    label = stringResource(R.string.subscription_monthly),
+                    price = monthly.formattedPrice,
+                    isCurrentPlan = currentTier.isPro,
+                    onClick = {
+                        if (activity != null && !currentTier.isPro) {
+                            billingManager.launchSubscriptionFlow(activity, BillingManager.SUB_PRO_MONTHLY)
+                        }
+                    }
+                )
+                Spacer(modifier = Modifier.height(12.dp))
+            }
+
+            // 상품이 아직 로드 안 됐을 때
+            if (subscriptionProducts.isEmpty()) {
+                Text(
+                    text = stringResource(R.string.donation_loading),
+                    fontSize = fontSettings.scaled(14),
+                    color = colors.textSecondary,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(24.dp)
+                )
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // ── 하단 링크 ──
+            if (currentTier.isPro) {
+                Text(
+                    text = stringResource(R.string.subscription_manage),
+                    fontSize = fontSettings.scaled(14),
+                    color = colors.chipText,
+                    fontWeight = FontWeight.Medium,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable {
+                            context.startActivity(
+                                Intent(Intent.ACTION_VIEW, Uri.parse("https://play.google.com/store/account/subscriptions"))
+                            )
+                        }
+                        .padding(12.dp)
+                )
+            }
+
+            Text(
+                text = stringResource(R.string.subscription_restore),
+                fontSize = fontSettings.scaled(14),
+                color = colors.textSecondary,
+                textAlign = TextAlign.Center,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { billingManager.queryExistingSubscriptions() }
+                    .padding(12.dp)
+            )
+
+            Spacer(modifier = Modifier.height(24.dp))
+        }
+    }
+}
+
+@Composable
+private fun SubscriptionCard(
+    label: String,
+    price: String,
+    badge: String? = null,
+    isCurrentPlan: Boolean,
+    isRecommended: Boolean = false,
+    onClick: () -> Unit
+) {
+    val colors = LocalAppColors.current
+    val fontSettings = LocalFontSettings.current
+    val isSystemDark = colors.screenBackground == Color(0xFF1C1C1E)
+
+    val cardGradient = if (isRecommended && !isCurrentPlan) {
+        if (isSystemDark) {
+            Brush.linearGradient(listOf(Color(0xFF1A3A5C), Color(0xFF2A1A4E)))
+        } else {
+            Brush.linearGradient(listOf(Color(0xFF4A90D9), Color(0xFF7B5EA7)))
+        }
+    } else null
+
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 20.dp)
+            .clip(RoundedCornerShape(16.dp))
+            .then(
+                if (cardGradient != null) Modifier.background(cardGradient)
+                else Modifier
+                    .background(colors.cardBackground)
+                    .border(1.dp, colors.cardBorder, RoundedCornerShape(16.dp))
+            )
+            .clickable(enabled = !isCurrentPlan) { onClick() }
+            .padding(20.dp)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Column {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text(
+                        text = label,
+                        fontSize = fontSettings.scaled(16),
+                        fontWeight = FontWeight.Bold,
+                        color = if (cardGradient != null) Color.White else colors.textTitle
+                    )
+                    if (badge != null) {
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text(
+                            text = badge,
+                            fontSize = fontSettings.scaled(11),
+                            fontWeight = FontWeight.Bold,
+                            color = if (cardGradient != null) Color.White else colors.chipText,
+                            modifier = Modifier
+                                .clip(RoundedCornerShape(4.dp))
+                                .background(
+                                    if (cardGradient != null) Color.White.copy(alpha = 0.2f)
+                                    else colors.chipText.copy(alpha = 0.1f)
+                                )
+                                .padding(horizontal = 6.dp, vertical = 2.dp)
+                        )
+                    }
+                }
+            }
+
+            Text(
+                text = price,
+                fontSize = fontSettings.scaled(18),
+                fontWeight = FontWeight.Bold,
+                color = when {
+                    isCurrentPlan -> colors.textSecondary
+                    cardGradient != null -> Color.White
+                    else -> colors.chipText
+                },
+                textAlign = TextAlign.End
+            )
+        }
+    }
+}

--- a/feature/memo-plain/impl/src/main/java/me/pecos/memozy/feature/memoplain/impl/MemoPlainNavigationImpl.kt
+++ b/feature/memo-plain/impl/src/main/java/me/pecos/memozy/feature/memoplain/impl/MemoPlainNavigationImpl.kt
@@ -55,7 +55,9 @@ import me.pecos.memozy.feature.memoplain.api.MemoPlainRoute
 import me.pecos.memozy.presentation.screen.home.model.MemoFormatUi
 import me.pecos.memozy.presentation.screen.home.model.MemoUiState
 import me.pecos.memozy.presentation.screen.memo.MemoScreen
+import me.pecos.memozy.presentation.screen.memo.components.AiLimitBottomSheet
 import me.pecos.memozy.presentation.theme.LocalAppColors
+import me.pecos.memozy.presentation.theme.LocalSubscriptionTier
 import javax.inject.Inject
 
 class MemoPlainNavigationImpl @Inject constructor(
@@ -72,7 +74,6 @@ class MemoPlainNavigationImpl @Inject constructor(
         private const val FEATURE_WEB_SUMMARY = "web_summary"
         private const val FEATURE_TRANSCRIPTION = "transcription"
         private const val FEATURE_IMAGE_OCR = "image_ocr"
-        private const val DAILY_FREE_LIMIT = 100
 
         private fun startOfToday(): Long {
             return Calendar.getInstance().apply {
@@ -284,12 +285,26 @@ class MemoPlainNavigationImpl @Inject constructor(
                 }
             }
 
+            // AI 사용량 체크 (티어별 일일 한도)
+            val subscriptionTier = LocalSubscriptionTier.current
+            var dailyUsageCount by remember { mutableStateOf(0) }
+            LaunchedEffect(Unit) {
+                dailyUsageCount = aiUsageDao.getTotalCountSince(startOfToday())
+            }
+            val dailyLimit = subscriptionTier.dailyAiLimit
+            val canUseAi = dailyUsageCount < dailyLimit
+            var showLimitBottomSheet by remember { mutableStateOf(false) }
+
             // 이미지 OCR 처리
             var imageOcrState by remember { mutableStateOf<SummaryState>(SummaryState.Idle) }
             val imageContext = LocalContext.current
 
             LaunchedEffect(sharedFileUri, isSharedImage) {
                 if (isSharedImage && sharedFileUri != null && imageOcrState is SummaryState.Idle) {
+                    if (!canUseAi) {
+                        imageOcrState = SummaryState.Error("오늘 AI 사용 한도를 모두 사용했어요.")
+                        return@LaunchedEffect
+                    }
                     imageOcrState = SummaryState.Loading
                     try {
                         val bytes = imageContext.contentResolver.openInputStream(sharedFileUri)?.use { it.readBytes() }
@@ -377,13 +392,6 @@ class MemoPlainNavigationImpl @Inject constructor(
                 }
 
             val context = LocalContext.current
-
-            // AI 사용량 체크 (일일 5회 제한)
-            var dailyUsageCount by remember { mutableStateOf(0) }
-            LaunchedEffect(Unit) {
-                dailyUsageCount = aiUsageDao.getCountSince(FEATURE_YOUTUBE_SUMMARY, startOfToday())
-            }
-            val canSummarize = dailyUsageCount < DAILY_FREE_LIMIT
 
             // 요약 상태 통합 (ACTION_SEND + 메모 내 링크 감지)
             var inlineSummaryState by remember { mutableStateOf<SummaryState>(SummaryState.Idle) }
@@ -570,7 +578,13 @@ class MemoPlainNavigationImpl @Inject constructor(
                 summaryResult = (inlineSummaryState as? SummaryState.Success)?.text,
                 summaryError = (inlineSummaryState as? SummaryState.Error)?.message,
                 youtubeTitle = youtubeTitle,
-                onStartRecording = { startRecording() },
+                onStartRecording = {
+                    if (!canUseAi) {
+                        showLimitBottomSheet = true
+                    } else {
+                        startRecording()
+                    }
+                },
                 onStopRecording = { stopRecordingAndTranscribe() },
                 isRecording = isRecording,
                 isTranscribing = isTranscribing,
@@ -585,6 +599,10 @@ class MemoPlainNavigationImpl @Inject constructor(
                     isTranscribing = false
                 },
                 onWebSummarize = { url, mode ->
+                    if (!canUseAi) {
+                        showLimitBottomSheet = true
+                        return@MemoScreen
+                    }
                     currentSummarizeJob = scope.launch {
                         isWebSummarizing = true
                         webSummaryError = null
@@ -630,8 +648,8 @@ class MemoPlainNavigationImpl @Inject constructor(
                 },
                 onYoutubeSummarize = { url, mode ->
                     currentSummarizeJob = scope.launch {
-                        if (!canSummarize) {
-                            inlineSummaryState = SummaryState.Error("오늘 무료 요약 횟수를 모두 사용했어요.")
+                        if (!canUseAi) {
+                            showLimitBottomSheet = true
                             return@launch
                         }
                         val videoId = extractVideoId(url)
@@ -717,6 +735,13 @@ class MemoPlainNavigationImpl @Inject constructor(
                     }
                 } else null
             )
+
+            if (showLimitBottomSheet) {
+                AiLimitBottomSheet(
+                    subscriptionTier = subscriptionTier,
+                    onDismiss = { showLimitBottomSheet = false }
+                )
+            }
         }
     }
 

--- a/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/components/AiLimitBottomSheet.kt
+++ b/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/components/AiLimitBottomSheet.kt
@@ -1,0 +1,115 @@
+package me.pecos.memozy.presentation.screen.memo.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import me.pecos.memozy.feature.core.resource.R
+import me.pecos.memozy.presentation.theme.LocalAppColors
+import me.pecos.memozy.presentation.theme.LocalFontSettings
+import me.pecos.memozy.presentation.theme.SubscriptionTier
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AiLimitBottomSheet(
+    subscriptionTier: SubscriptionTier,
+    onDismiss: () -> Unit
+) {
+    val colors = LocalAppColors.current
+    val fontSettings = LocalFontSettings.current
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = rememberModalBottomSheetState(),
+        containerColor = colors.cardBackground
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 24.dp, vertical = 8.dp)
+                .padding(bottom = 24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(
+                text = stringResource(R.string.ai_limit_title),
+                fontSize = fontSettings.scaled(18),
+                fontWeight = FontWeight.Bold,
+                color = colors.textTitle,
+                textAlign = TextAlign.Center
+            )
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            val message = if (subscriptionTier.isPro) {
+                stringResource(R.string.ai_limit_pro_message, subscriptionTier.dailyAiLimit)
+            } else {
+                stringResource(R.string.ai_limit_free_message, subscriptionTier.dailyAiLimit)
+            }
+
+            Text(
+                text = message,
+                fontSize = fontSettings.scaled(14),
+                color = colors.textBody,
+                textAlign = TextAlign.Center
+            )
+
+            Spacer(modifier = Modifier.height(20.dp))
+
+            if (!subscriptionTier.isPro) {
+                Button(
+                    onClick = onDismiss,
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = RoundedCornerShape(12.dp),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = colors.chipText
+                    )
+                ) {
+                    Text(
+                        text = stringResource(R.string.ai_limit_upgrade),
+                        fontWeight = FontWeight.Bold,
+                        modifier = Modifier.padding(vertical = 4.dp)
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(4.dp))
+
+                Text(
+                    text = stringResource(R.string.ai_limit_upgrade_desc),
+                    fontSize = fontSettings.scaled(12),
+                    color = colors.textBody.copy(alpha = 0.6f),
+                    textAlign = TextAlign.Center
+                )
+
+                Spacer(modifier = Modifier.height(12.dp))
+            }
+
+            OutlinedButton(
+                onClick = onDismiss,
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(12.dp)
+            ) {
+                Text(
+                    text = stringResource(R.string.ai_limit_close),
+                    color = colors.textBody,
+                    modifier = Modifier.padding(vertical = 4.dp)
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- BillingManager에 Google Play 구독(월/연) 로직 추가
- SubscriptionTier(FREE/PRO) 기반 일일 AI 한도 시스템 (Free: 2회, Pro: 15회)
- 모든 AI 기능(유튜브 요약, 웹 요약, STT, OCR)에 통합 한도 체크 적용
- 한도 초과 시 Pro 업그레이드 유도 바텀시트
- 설정 화면: 계정 섹션 바로 아래에 그라데이션 Pro 카드 배치
- 구독 화면: 히어로 영역 + Free vs Pro 비교 테이블 + 연간 추천 카드
- 키보드 이중 IME 패딩 버그 수정 (adjustNothing)
- 3개 국어 문자열 리소스 (ko/en/ja)

## Test plan
- [ ] 설정 화면에서 Pro 카드가 계정 섹션 바로 아래에 표시되는지 확인
- [ ] Pro 카드 탭 → 구독 화면 진입 확인
- [ ] Free vs Pro 비교 테이블 정상 렌더링 확인
- [ ] AI 요약 2회 사용 후 한도 초과 바텀시트 표시 확인
- [ ] 모든 AI 기능(유튜브/웹/STT/OCR)에서 한도 체크 동작 확인
- [ ] 메모 편집 시 키보드 위 서식 툴바가 정상 위치에 표시되는지 확인
- [ ] 다크모드에서 그라데이션 색상 정상 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)