### PR TITLE
Add: #165 AdMob 리워드 광고 연동

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,4 +1,5 @@
 import me.pecos.memozy.convention.extension.setNamespace
+import java.util.Properties
 
 plugins {
     id("memozy.android.application")
@@ -15,6 +16,17 @@ android {
         applicationId = "me.pecos.memozy"
         versionCode = 3
         versionName = "1.2603.0"
+
+        val admobAppId = rootProject.file("local.properties").let { file ->
+            if (file.exists()) {
+                val props = Properties()
+                props.load(file.inputStream())
+                props.getProperty("admob.app.id", "ca-app-pub-3940256099942544~3347511713")
+            } else {
+                "ca-app-pub-3940256099942544~3347511713"
+            }
+        }
+        manifestPlaceholders["admobAppId"] = admobAppId
     }
     buildTypes {
         release {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -62,6 +62,9 @@ dependencies {
     implementation(libs.glance.appwidget)
     implementation(libs.glance.material3)
 
+    // ads
+    implementation(libs.play.services.ads)
+
     // firebase
     implementation(platform(libs.firebase.bom))
     implementation(libs.firebase.analytics)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,7 +21,7 @@
 
         <meta-data
             android:name="com.google.android.gms.ads.APPLICATION_ID"
-            android:value="ca-app-pub-3940256099942544~3347511713" />
+            android:value="${admobAppId}" />
 
         <receiver
             android:name=".widget.MemoWidgetReceiver"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,9 +5,7 @@
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
-    <uses-permission
-        android:name="com.google.android.gms.permission.AD_ID"
-        tools:node="remove" />
+    <uses-permission android:name="com.google.android.gms.permission.AD_ID" />
 
     <application
         android:name=".MemozyApplication"
@@ -20,6 +18,10 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.Memozy"
         android:localeConfig="@xml/locales_config">
+
+        <meta-data
+            android:name="com.google.android.gms.ads.APPLICATION_ID"
+            android:value="ca-app-pub-3940256099942544~3347511713" />
 
         <receiver
             android:name=".widget.MemoWidgetReceiver"

--- a/app/src/main/java/me/pecos/memozy/MemozyApplication.kt
+++ b/app/src/main/java/me/pecos/memozy/MemozyApplication.kt
@@ -30,6 +30,8 @@ class MemozyApplication : Application(), Configuration.Provider {
 
     override fun onCreate() {
         super.onCreate()
-        MobileAds.initialize(this)
+        CoroutineScope(Dispatchers.IO).launch {
+            MobileAds.initialize(this@MemozyApplication)
+        }
     }
 }

--- a/app/src/main/java/me/pecos/memozy/MemozyApplication.kt
+++ b/app/src/main/java/me/pecos/memozy/MemozyApplication.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
+import com.google.android.gms.ads.MobileAds
 import javax.inject.Inject
 
 @HiltAndroidApp
@@ -29,5 +30,6 @@ class MemozyApplication : Application(), Configuration.Provider {
 
     override fun onCreate() {
         super.onCreate()
+        MobileAds.initialize(this)
     }
 }

--- a/feature/core/resource/src/main/java/me/pecos/memozy/presentation/theme/LocalRewardAd.kt
+++ b/feature/core/resource/src/main/java/me/pecos/memozy/presentation/theme/LocalRewardAd.kt
@@ -1,0 +1,16 @@
+package me.pecos.memozy.presentation.theme
+
+import androidx.compose.runtime.compositionLocalOf
+
+/**
+ * 리워드 광고 상태를 앱 전역에서 참조하기 위한 인터페이스.
+ * feature/home/impl의 RewardAdManager가 이를 구현합니다.
+ */
+interface RewardAdProvider {
+    val isAdReady: Boolean
+    val isAdLoading: Boolean
+    fun loadAd()
+    fun showAd(onRewarded: () -> Unit)
+}
+
+val LocalRewardAdProvider = compositionLocalOf<RewardAdProvider?> { null }

--- a/feature/core/resource/src/main/res/values-en/strings.xml
+++ b/feature/core/resource/src/main/res/values-en/strings.xml
@@ -234,6 +234,10 @@
     <string name="ai_limit_pro_message">Pro users can use AI features up to %d times per day.\nYou can use it again tomorrow.</string>
     <string name="ai_limit_upgrade">Upgrade to Pro</string>
     <string name="ai_limit_upgrade_desc">More AI summaries + all premium features</string>
+    <string name="ai_limit_watch_ad">Watch ad for +1 use</string>
+    <string name="ai_limit_ad_remaining">%d more views available today</string>
+    <string name="ai_limit_ad_exhausted">No more ad views available today</string>
+    <string name="ai_limit_ad_loading">Loading ad…</string>
     <string name="ai_limit_close">Close</string>
 
     <!-- Subscription -->

--- a/feature/core/resource/src/main/res/values-ja/strings.xml
+++ b/feature/core/resource/src/main/res/values-ja/strings.xml
@@ -234,6 +234,10 @@
     <string name="ai_limit_pro_message">Proユーザーは1日%d回までAI機能を使用できます。\n明日また使用できます。</string>
     <string name="ai_limit_upgrade">Proにアップグレード</string>
     <string name="ai_limit_upgrade_desc">より多くのAI要約 + すべてのプレミアム機能</string>
+    <string name="ai_limit_watch_ad">広告を見て1回追加</string>
+    <string name="ai_limit_ad_remaining">今日あと%d回視聴可能</string>
+    <string name="ai_limit_ad_exhausted">今日の広告視聴回数を使い切りました</string>
+    <string name="ai_limit_ad_loading">広告を準備中…</string>
     <string name="ai_limit_close">閉じる</string>
 
     <!-- Subscription -->

--- a/feature/core/resource/src/main/res/values/strings.xml
+++ b/feature/core/resource/src/main/res/values/strings.xml
@@ -232,6 +232,10 @@
     <string name="ai_limit_pro_message">Pro 사용자는 하루 %d회까지 AI 기능을 사용할 수 있어요.\n내일 다시 사용할 수 있어요.</string>
     <string name="ai_limit_upgrade">Pro로 업그레이드</string>
     <string name="ai_limit_upgrade_desc">더 많은 AI 요약 + 모든 프리미엄 기능</string>
+    <string name="ai_limit_watch_ad">광고 보고 1회 추가</string>
+    <string name="ai_limit_ad_remaining">오늘 %d회 더 시청 가능</string>
+    <string name="ai_limit_ad_exhausted">오늘 광고 시청 횟수를 모두 사용했어요</string>
+    <string name="ai_limit_ad_loading">광고 준비 중…</string>
     <string name="ai_limit_close">닫기</string>
 
     <!-- Subscription -->

--- a/feature/home/impl/build.gradle.kts
+++ b/feature/home/impl/build.gradle.kts
@@ -42,6 +42,7 @@ dependencies {
     implementation(libs.android.joda)
     implementation(libs.montage.android)
     implementation(libs.billing.ktx)
+    implementation(libs.play.services.ads)
     implementation(libs.kotlinx.coroutines.android)
     implementation(libs.androidx.compose.material.icons.extended)
     implementation(libs.hilt.navigation.compose)

--- a/feature/home/impl/src/main/java/me/pecos/memozy/MainActivity.kt
+++ b/feature/home/impl/src/main/java/me/pecos/memozy/MainActivity.kt
@@ -58,6 +58,7 @@ import dev.chrisbanes.haze.hazeEffect
 import dev.chrisbanes.haze.hazeSource
 import dev.chrisbanes.haze.rememberHazeState
 import me.pecos.memozy.data.billing.BillingManager
+import me.pecos.memozy.presentation.theme.LocalRewardAdProvider
 import me.pecos.memozy.presentation.theme.LocalSubscriptionTier
 import me.pecos.memozy.feature.home.api.HomeRoute
 import me.pecos.memozy.feature.memoplain.api.MemoPlainNavigation
@@ -91,6 +92,7 @@ class MainActivity : AppCompatActivity() {
     @Inject lateinit var memoPlainNavigation: MemoPlainNavigation
 
     private val billingManager by lazy { BillingManager(this) }
+    private val rewardAdManager by lazy { me.pecos.memozy.data.ads.RewardAdManager(this, this) }
 
     // 공유 Intent 상태 — singleTask에서 onNewIntent 처리
     private val _currentIntent = androidx.compose.runtime.mutableStateOf<Intent?>(null)
@@ -135,6 +137,7 @@ class MainActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         billingManager.connect()
+        rewardAdManager.loadAd()
 
         setContent {
             val settingsViewModel: SettingsViewModel = viewModel()
@@ -162,7 +165,8 @@ class MainActivity : AppCompatActivity() {
 
             CompositionLocalProvider(
                 LocalActivity provides this@MainActivity,
-                LocalSubscriptionTier provides currentTier
+                LocalSubscriptionTier provides currentTier,
+                LocalRewardAdProvider provides rewardAdManager
             ) {
             OverrideNightMode(isDarkTheme = isDarkTheme) {
                 CompositionLocalProvider(

--- a/feature/home/impl/src/main/java/me/pecos/memozy/data/ads/RewardAdManager.kt
+++ b/feature/home/impl/src/main/java/me/pecos/memozy/data/ads/RewardAdManager.kt
@@ -1,0 +1,94 @@
+package me.pecos.memozy.data.ads
+
+import android.app.Activity
+import android.content.Context
+import com.google.android.gms.ads.AdError
+import com.google.android.gms.ads.AdRequest
+import com.google.android.gms.ads.FullScreenContentCallback
+import com.google.android.gms.ads.LoadAdError
+import com.google.android.gms.ads.rewarded.RewardedAd
+import com.google.android.gms.ads.rewarded.RewardedAdLoadCallback
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import me.pecos.memozy.presentation.theme.RewardAdProvider
+
+sealed class RewardAdState {
+    data object NotLoaded : RewardAdState()
+    data object Loading : RewardAdState()
+    data object Ready : RewardAdState()
+    data object Showing : RewardAdState()
+    data object Rewarded : RewardAdState()
+    data class Error(val message: String) : RewardAdState()
+}
+
+class RewardAdManager(
+    private val context: Context,
+    private val activity: Activity
+) : RewardAdProvider {
+
+    companion object {
+        // 테스트 광고 단위 ID — 출시 시 실제 ID로 교체
+        private const val AD_UNIT_ID = "ca-app-pub-3940256099942544/5224354917"
+        const val MAX_DAILY_AD_VIEWS = 3
+    }
+
+    private var rewardedAd: RewardedAd? = null
+
+    private val _state = MutableStateFlow<RewardAdState>(RewardAdState.NotLoaded)
+    val state: StateFlow<RewardAdState> = _state
+
+    override val isAdReady: Boolean get() = _state.value is RewardAdState.Ready
+    override val isAdLoading: Boolean get() = _state.value is RewardAdState.Loading
+
+    override fun loadAd() {
+        if (_state.value is RewardAdState.Loading || _state.value is RewardAdState.Ready) return
+
+        _state.value = RewardAdState.Loading
+
+        val adRequest = AdRequest.Builder().build()
+        RewardedAd.load(context, AD_UNIT_ID, adRequest, object : RewardedAdLoadCallback() {
+            override fun onAdLoaded(ad: RewardedAd) {
+                rewardedAd = ad
+                _state.value = RewardAdState.Ready
+            }
+
+            override fun onAdFailedToLoad(error: LoadAdError) {
+                rewardedAd = null
+                _state.value = RewardAdState.Error(error.message)
+            }
+        })
+    }
+
+    override fun showAd(onRewarded: () -> Unit) {
+        val ad = rewardedAd ?: run {
+            _state.value = RewardAdState.Error("광고가 준비되지 않았어요.")
+            return
+        }
+
+        _state.value = RewardAdState.Showing
+
+        ad.fullScreenContentCallback = object : FullScreenContentCallback() {
+            override fun onAdDismissedFullScreenContent() {
+                rewardedAd = null
+                loadAd()
+            }
+
+            override fun onAdFailedToShowFullScreenContent(error: AdError) {
+                rewardedAd = null
+                _state.value = RewardAdState.Error(error.message)
+                loadAd()
+            }
+        }
+
+        ad.show(activity) {
+            _state.value = RewardAdState.Rewarded
+            onRewarded()
+        }
+    }
+
+    fun resetState() {
+        if (_state.value is RewardAdState.Rewarded || _state.value is RewardAdState.Error) {
+            _state.value = if (rewardedAd != null) RewardAdState.Ready else RewardAdState.NotLoaded
+        }
+    }
+}

--- a/feature/memo-plain/impl/src/main/java/me/pecos/memozy/feature/memoplain/impl/MemoPlainNavigationImpl.kt
+++ b/feature/memo-plain/impl/src/main/java/me/pecos/memozy/feature/memoplain/impl/MemoPlainNavigationImpl.kt
@@ -57,6 +57,7 @@ import me.pecos.memozy.presentation.screen.home.model.MemoUiState
 import me.pecos.memozy.presentation.screen.memo.MemoScreen
 import me.pecos.memozy.presentation.screen.memo.components.AiLimitBottomSheet
 import me.pecos.memozy.presentation.theme.LocalAppColors
+import me.pecos.memozy.presentation.theme.LocalRewardAdProvider
 import me.pecos.memozy.presentation.theme.LocalSubscriptionTier
 import javax.inject.Inject
 
@@ -74,6 +75,8 @@ class MemoPlainNavigationImpl @Inject constructor(
         private const val FEATURE_WEB_SUMMARY = "web_summary"
         private const val FEATURE_TRANSCRIPTION = "transcription"
         private const val FEATURE_IMAGE_OCR = "image_ocr"
+        private const val FEATURE_REWARD_AD = "reward_ad"
+        private const val MAX_DAILY_AD_VIEWS = 3
 
         private fun startOfToday(): Long {
             return Calendar.getInstance().apply {
@@ -287,12 +290,18 @@ class MemoPlainNavigationImpl @Inject constructor(
 
             // AI 사용량 체크 (티어별 일일 한도)
             val subscriptionTier = LocalSubscriptionTier.current
+            val rewardAdProvider = LocalRewardAdProvider.current
             var dailyUsageCount by remember { mutableStateOf(0) }
+            var dailyAdViewCount by remember { mutableStateOf(0) }
+            var adBonusCount by remember { mutableStateOf(0) }
             LaunchedEffect(Unit) {
                 dailyUsageCount = aiUsageDao.getTotalCountSince(startOfToday())
+                dailyAdViewCount = aiUsageDao.getCountSince(FEATURE_REWARD_AD, startOfToday())
             }
-            val dailyLimit = subscriptionTier.dailyAiLimit
+            val dailyLimit = subscriptionTier.dailyAiLimit + adBonusCount
             val canUseAi = dailyUsageCount < dailyLimit
+            val canWatchAd = !subscriptionTier.isPro && dailyAdViewCount < MAX_DAILY_AD_VIEWS
+            val remainingAdViews = MAX_DAILY_AD_VIEWS - dailyAdViewCount
             var showLimitBottomSheet by remember { mutableStateOf(false) }
 
             // 이미지 OCR 처리
@@ -739,6 +748,20 @@ class MemoPlainNavigationImpl @Inject constructor(
             if (showLimitBottomSheet) {
                 AiLimitBottomSheet(
                     subscriptionTier = subscriptionTier,
+                    canWatchAd = canWatchAd,
+                    remainingAdViews = remainingAdViews,
+                    isAdLoading = rewardAdProvider?.isAdLoading == true,
+                    onWatchAd = {
+                        rewardAdProvider?.showAd {
+                            scope.launch {
+                                aiUsageDao.insert(AiUsage(feature = FEATURE_REWARD_AD))
+                                dailyAdViewCount++
+                                adBonusCount++
+                                showLimitBottomSheet = false
+                            }
+                        }
+                    },
+                    onUpgrade = { showLimitBottomSheet = false },
                     onDismiss = { showLimitBottomSheet = false }
                 )
             }

--- a/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/components/AiLimitBottomSheet.kt
+++ b/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/components/AiLimitBottomSheet.kt
@@ -5,9 +5,11 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedButton
@@ -29,6 +31,11 @@ import me.pecos.memozy.presentation.theme.SubscriptionTier
 @Composable
 fun AiLimitBottomSheet(
     subscriptionTier: SubscriptionTier,
+    canWatchAd: Boolean,
+    remainingAdViews: Int,
+    isAdLoading: Boolean,
+    onWatchAd: () -> Unit,
+    onUpgrade: () -> Unit,
     onDismiss: () -> Unit
 ) {
     val colors = LocalAppColors.current
@@ -72,17 +79,62 @@ fun AiLimitBottomSheet(
             Spacer(modifier = Modifier.height(20.dp))
 
             if (!subscriptionTier.isPro) {
-                Button(
-                    onClick = onDismiss,
-                    modifier = Modifier.fillMaxWidth(),
-                    shape = RoundedCornerShape(12.dp),
-                    colors = ButtonDefaults.buttonColors(
-                        containerColor = colors.chipText
+                // 광고 시청 버튼 (Free 유저만)
+                if (canWatchAd) {
+                    Button(
+                        onClick = onWatchAd,
+                        enabled = !isAdLoading,
+                        modifier = Modifier.fillMaxWidth(),
+                        shape = RoundedCornerShape(12.dp),
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = colors.chipText
+                        )
+                    ) {
+                        if (isAdLoading) {
+                            CircularProgressIndicator(
+                                modifier = Modifier.size(16.dp),
+                                strokeWidth = 2.dp,
+                                color = colors.cardBackground
+                            )
+                        } else {
+                            Text(
+                                text = stringResource(R.string.ai_limit_watch_ad),
+                                fontWeight = FontWeight.Bold,
+                                modifier = Modifier.padding(vertical = 4.dp)
+                            )
+                        }
+                    }
+
+                    Spacer(modifier = Modifier.height(4.dp))
+
+                    Text(
+                        text = stringResource(R.string.ai_limit_ad_remaining, remainingAdViews),
+                        fontSize = fontSettings.scaled(12),
+                        color = colors.textBody.copy(alpha = 0.6f),
+                        textAlign = TextAlign.Center
                     )
+
+                    Spacer(modifier = Modifier.height(12.dp))
+                } else {
+                    Text(
+                        text = stringResource(R.string.ai_limit_ad_exhausted),
+                        fontSize = fontSettings.scaled(13),
+                        color = colors.textSecondary,
+                        textAlign = TextAlign.Center
+                    )
+                    Spacer(modifier = Modifier.height(12.dp))
+                }
+
+                // Pro 업그레이드 버튼
+                OutlinedButton(
+                    onClick = onUpgrade,
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = RoundedCornerShape(12.dp)
                 ) {
                     Text(
                         text = stringResource(R.string.ai_limit_upgrade),
-                        fontWeight = FontWeight.Bold,
+                        color = colors.chipText,
+                        fontWeight = FontWeight.SemiBold,
                         modifier = Modifier.padding(vertical = 4.dp)
                     )
                 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ kotlin = "2.3.20"
 composeBom = "2025.05.00"
 ksp = "2.3.6"
 billingKtx = "7.1.1"
+playServicesAds = "24.4.0"
 androidJoda = "2.12.7"
 haze = "1.7.2"
 montageAndroid = "3.3.0"
@@ -40,6 +41,7 @@ gradlePlugin-kotlinSerialization = { module = "org.jetbrains.kotlin:kotlin-seria
 android-joda = { module = "net.danlew:android.joda", version.ref = "androidJoda" }
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 billing-ktx = { module = "com.android.billingclient:billing-ktx", version.ref = "billingKtx" }
+play-services-ads = { module = "com.google.android.gms:play-services-ads", version.ref = "playServicesAds" }
 firebase-crashlytics = { module = "com.google.firebase:firebase-crashlytics" }
 haze = { module = "dev.chrisbanes.haze:haze", version.ref = "haze" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }


### PR DESCRIPTION
## Summary
- Google AdMob SDK 연동 (play-services-ads 24.4.0)
- RewardAdManager: 리워드 광고 로드/표시/콜백 관리
- Free 유저 AI 한도 초과 시 "광고 보고 1회 추가" 버튼 (하루 최대 3회)
- 광고 시청 완료 → AI 사용 한도 +1 보너스
- Pro 유저는 광고 관련 UI 미노출
- 테스트 광고 ID 사용 중 (출시 전 실제 ID 교체 필요)

## Test plan
- [ ] 앱 시작 시 AdMob 초기화 확인 (로그)
- [ ] AI 한도(2회) 소진 후 바텀시트에 "광고 보고 1회 추가" 버튼 표시 확인
- [ ] 광고 시청 완료 → 바텀시트 닫히고 AI 기능 1회 추가 사용 가능 확인
- [ ] 광고 3회 시청 후 "오늘 광고 시청 횟수를 모두 사용했어요" 표시 확인
- [ ] Pro 유저는 광고 버튼 미노출 확인
- [ ] 다크모드에서 바텀시트 UI 정상 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)