### PR TITLE
Fix: Gemini thinking 비활성화로 토큰 소모 절감

### DIFF
--- a/datasource/remote/ai/api/src/main/java/me/pecos/memozy/data/datasource/remote/ai/model/AIRequest.kt
+++ b/datasource/remote/ai/api/src/main/java/me/pecos/memozy/data/datasource/remote/ai/model/AIRequest.kt
@@ -5,17 +5,23 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class GeminiRequest(
     val contents: List<GeminiContent>,
-    val generationConfig: GenerationConfig? = null,
+    val generationConfig: GenerationConfig = GenerationConfig.THINKING_DISABLED,
 )
 
 @Serializable
 data class GenerationConfig(
     val thinkingConfig: ThinkingConfig? = null,
-)
+) {
+    companion object {
+        val THINKING_DISABLED = GenerationConfig(
+            thinkingConfig = ThinkingConfig(thinkingBudget = 0)
+        )
+    }
+}
 
 @Serializable
 data class ThinkingConfig(
-    val thinkingBudget: Int = 0,  // 0 = thinking 끔
+    val thinkingBudget: Int,
 )
 
 @Serializable

--- a/datasource/remote/ai/api/src/main/java/me/pecos/memozy/data/datasource/remote/ai/model/AIRequest.kt
+++ b/datasource/remote/ai/api/src/main/java/me/pecos/memozy/data/datasource/remote/ai/model/AIRequest.kt
@@ -5,6 +5,17 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class GeminiRequest(
     val contents: List<GeminiContent>,
+    val generationConfig: GenerationConfig? = null,
+)
+
+@Serializable
+data class GenerationConfig(
+    val thinkingConfig: ThinkingConfig? = null,
+)
+
+@Serializable
+data class ThinkingConfig(
+    val thinkingBudget: Int = 0,  // 0 = thinking 끔
 )
 
 @Serializable

--- a/datasource/remote/ai/impl/src/main/java/me/pecos/memozy/data/datasource/remote/ai/AIApiServiceImpl.kt
+++ b/datasource/remote/ai/impl/src/main/java/me/pecos/memozy/data/datasource/remote/ai/AIApiServiceImpl.kt
@@ -12,14 +12,12 @@ import io.ktor.utils.io.readUTF8Line
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.serialization.json.Json
-import me.pecos.memozy.data.datasource.remote.ai.model.GenerationConfig
 import me.pecos.memozy.data.datasource.remote.ai.model.GeminiContent
 import me.pecos.memozy.data.datasource.remote.ai.model.GeminiFileData
 import me.pecos.memozy.data.datasource.remote.ai.model.GeminiInlineData
 import me.pecos.memozy.data.datasource.remote.ai.model.GeminiPart
 import me.pecos.memozy.data.datasource.remote.ai.model.GeminiRequest
 import me.pecos.memozy.data.datasource.remote.ai.model.GeminiResponse
-import me.pecos.memozy.data.datasource.remote.ai.model.ThinkingConfig
 
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -36,9 +34,6 @@ class AIApiServiceImpl @Inject constructor(
                 GeminiContent(
                     parts = listOf(GeminiPart(text = prompt))
                 )
-            ),
-            generationConfig = GenerationConfig(
-                thinkingConfig = ThinkingConfig(thinkingBudget = 0)
             )
         )
 
@@ -59,9 +54,6 @@ class AIApiServiceImpl @Inject constructor(
                         GeminiPart(text = prompt),
                     )
                 )
-            ),
-            generationConfig = GenerationConfig(
-                thinkingConfig = ThinkingConfig(thinkingBudget = 0)
             )
         )
 
@@ -74,9 +66,6 @@ class AIApiServiceImpl @Inject constructor(
                 GeminiContent(
                     parts = listOf(GeminiPart(text = prompt))
                 )
-            ),
-            generationConfig = GenerationConfig(
-                thinkingConfig = ThinkingConfig(thinkingBudget = 0)
             )
         )
 
@@ -130,9 +119,6 @@ class AIApiServiceImpl @Inject constructor(
                         GeminiPart(text = prompt),
                     )
                 )
-            ),
-            generationConfig = GenerationConfig(
-                thinkingConfig = ThinkingConfig(thinkingBudget = 0)
             )
         )
 
@@ -155,9 +141,6 @@ class AIApiServiceImpl @Inject constructor(
                         GeminiPart(text = prompt),
                     )
                 )
-            ),
-            generationConfig = GenerationConfig(
-                thinkingConfig = ThinkingConfig(thinkingBudget = 0)
             )
         )
 

--- a/datasource/remote/ai/impl/src/main/java/me/pecos/memozy/data/datasource/remote/ai/AIApiServiceImpl.kt
+++ b/datasource/remote/ai/impl/src/main/java/me/pecos/memozy/data/datasource/remote/ai/AIApiServiceImpl.kt
@@ -12,12 +12,14 @@ import io.ktor.utils.io.readUTF8Line
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.serialization.json.Json
+import me.pecos.memozy.data.datasource.remote.ai.model.GenerationConfig
 import me.pecos.memozy.data.datasource.remote.ai.model.GeminiContent
 import me.pecos.memozy.data.datasource.remote.ai.model.GeminiFileData
 import me.pecos.memozy.data.datasource.remote.ai.model.GeminiInlineData
 import me.pecos.memozy.data.datasource.remote.ai.model.GeminiPart
 import me.pecos.memozy.data.datasource.remote.ai.model.GeminiRequest
 import me.pecos.memozy.data.datasource.remote.ai.model.GeminiResponse
+import me.pecos.memozy.data.datasource.remote.ai.model.ThinkingConfig
 
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -34,6 +36,9 @@ class AIApiServiceImpl @Inject constructor(
                 GeminiContent(
                     parts = listOf(GeminiPart(text = prompt))
                 )
+            ),
+            generationConfig = GenerationConfig(
+                thinkingConfig = ThinkingConfig(thinkingBudget = 0)
             )
         )
 
@@ -54,6 +59,9 @@ class AIApiServiceImpl @Inject constructor(
                         GeminiPart(text = prompt),
                     )
                 )
+            ),
+            generationConfig = GenerationConfig(
+                thinkingConfig = ThinkingConfig(thinkingBudget = 0)
             )
         )
 
@@ -66,6 +74,9 @@ class AIApiServiceImpl @Inject constructor(
                 GeminiContent(
                     parts = listOf(GeminiPart(text = prompt))
                 )
+            ),
+            generationConfig = GenerationConfig(
+                thinkingConfig = ThinkingConfig(thinkingBudget = 0)
             )
         )
 
@@ -119,6 +130,9 @@ class AIApiServiceImpl @Inject constructor(
                         GeminiPart(text = prompt),
                     )
                 )
+            ),
+            generationConfig = GenerationConfig(
+                thinkingConfig = ThinkingConfig(thinkingBudget = 0)
             )
         )
 
@@ -141,6 +155,9 @@ class AIApiServiceImpl @Inject constructor(
                         GeminiPart(text = prompt),
                     )
                 )
+            ),
+            generationConfig = GenerationConfig(
+                thinkingConfig = ThinkingConfig(thinkingBudget = 0)
             )
         )
 


### PR DESCRIPTION
## Summary
- Gemini API 요청에 `generationConfig.thinkingConfig.thinkingBudget = 0` 추가
- 기존에 `generationConfig`가 없어 thinking이 기본값(켜짐)으로 동작하여 불필요한 토큰 소모 발생
- `generateContent`, `generateContentWithVideo`, `generateContentStream`, `transcribeAudio`, `describeImage` 5개 함수 전부 적용

## Test plan
- [ ] 유튜브 요약 실행 후 AI Studio에서 thinking 토큰 0 확인
- [ ] 웹 요약 정상 동작 확인
- [ ] 오디오 받아쓰기 정상 동작 확인
- [ ] 이미지 OCR 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)