### PR TITLE
Add: #177 유튜브 자막 ANDROID InnerTube API 전환 — Supadata 제거

### DIFF
--- a/workers/src/index.ts
+++ b/workers/src/index.ts
@@ -156,15 +156,16 @@ async function handleGeminiStream(req: Request, env: Env): Promise<Response> {
 
 // --- YouTube InnerTube (ANDROID client) ---
 
-const INNERTUBE_API_URL = "https://www.youtube.com/youtubei/v1/player?key=AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8";
+const YOUTUBE_CLIENT_VERSION = "20.10.38";
+const INNERTUBE_API_URL = "https://www.youtube.com/youtubei/v1/player?key=AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8"; // YouTube 공개 키
 const INNERTUBE_CONTEXT = {
   client: {
     clientName: "ANDROID",
-    clientVersion: "20.10.38",
+    clientVersion: YOUTUBE_CLIENT_VERSION,
     androidSdkVersion: 30,
   },
 };
-const ANDROID_USER_AGENT = "com.google.android.youtube/20.10.38 (Linux; U; Android 11) gzip";
+const ANDROID_USER_AGENT = `com.google.android.youtube/${YOUTUBE_CLIENT_VERSION} (Linux; U; Android 11) gzip`;
 
 interface CaptionTrack {
   baseUrl: string;
@@ -234,7 +235,9 @@ async function handleYoutubeCaptions(req: Request, _env: Env): Promise<Response>
   if (!track) track = tracks[0];
 
   // 3. 자막 XML fetch (baseUrl에서 fmt=srv3 제거)
-  const captionUrl = track.baseUrl.replace("&fmt=srv3", "");
+  const captionUrlObj = new URL(track.baseUrl);
+  captionUrlObj.searchParams.delete("fmt");
+  const captionUrl = captionUrlObj.toString();
   const captionRes = await fetch(captionUrl);
 
   if (!captionRes.ok) {

--- a/workers/src/index.ts
+++ b/workers/src/index.ts
@@ -6,9 +6,6 @@ export interface Env {
   SUPABASE_URL: string;
   SUPABASE_SERVICE_KEY: string;
   SUPABASE_JWT_SECRET: string;
-  PROXY_URL?: string;
-  PROXY_AUTH?: string;
-  PROXY_ENABLED?: string;
 }
 
 const AI_GATEWAY_URL = "https://gateway.ai.cloudflare.com/v1/fd6859f0e7b0f6307cfa850af2324d90/memozy/google-ai-studio";
@@ -103,121 +100,6 @@ async function callGeminiStream(
   });
 }
 
-// --- Proxy fetch helper ---
-
-const BROWSER_HEADERS: Record<string, string> = {
-  "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
-  "Accept-Language": "ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7",
-  "Accept": "*/*",
-  "Referer": "https://www.youtube.com/",
-  "Origin": "https://www.youtube.com",
-};
-
-async function proxyFetch(url: string, env: Env, init?: RequestInit): Promise<Response> {
-  const headers = { ...BROWSER_HEADERS, ...init?.headers };
-
-  // 프록시가 활성화되어 있고 Cloudflare Worker에서 프록시 사용 가능한 경우
-  // 현재 CF Worker는 직접 프록시를 지원하지 않으므로, 프록시 URL이 HTTP proxy endpoint인 경우에 대비
-  // 실제 프록시 연동은 프록시 업체 연동 시 확정
-  return fetch(url, { ...init, headers });
-}
-
-// --- InnerTube YouTube transcript ---
-
-interface CaptionTrack {
-  baseUrl: string;
-  languageCode: string;
-  kind?: string;
-  name?: { simpleText?: string };
-}
-
-async function fetchYoutubeTranscript(
-  videoId: string,
-  lang: string,
-  env: Env
-): Promise<{ lang: string; content: string } | { error: string }> {
-  // 1. InnerTube Player API 호출
-  const playerUrl = "https://www.youtube.com/youtubei/v1/player";
-  const playerBody = {
-    context: {
-      client: {
-        clientName: "WEB",
-        clientVersion: "2.20241028.01.00",
-        hl: lang,
-      },
-    },
-    videoId,
-  };
-
-  const playerRes = await proxyFetch(playerUrl, env, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(playerBody),
-  });
-
-  if (!playerRes.ok) {
-    return { error: `InnerTube API error: ${playerRes.status}` };
-  }
-
-  const playerData = await playerRes.json<{
-    captions?: {
-      playerCaptionsTracklistRenderer?: {
-        captionTracks?: CaptionTrack[];
-      };
-    };
-  }>();
-
-  const tracks = playerData?.captions?.playerCaptionsTracklistRenderer?.captionTracks;
-  if (!tracks || tracks.length === 0) {
-    return { error: "no_captions" };
-  }
-
-  // 2. 원하는 언어 자막 찾기 (수동 우선, 자동생성 fallback)
-  const findTrack = (targetLang: string): CaptionTrack | undefined => {
-    // 수동 자막 우선
-    const manual = tracks.find(t => t.languageCode === targetLang && t.kind !== "asr");
-    if (manual) return manual;
-    // 자동생성 자막
-    return tracks.find(t => t.languageCode === targetLang);
-  };
-
-  let track = findTrack(lang);
-  if (!track && lang !== "en") track = findTrack("en");
-  if (!track) track = tracks[0]; // 아무 자막이라도
-
-  const actualLang = track.languageCode;
-
-  // 3. 자막 XML fetch
-  const captionRes = await proxyFetch(track.baseUrl, env);
-  if (!captionRes.ok) {
-    return { error: `Caption fetch error: ${captionRes.status}` };
-  }
-
-  const xml = await captionRes.text();
-
-  // 4. XML 파싱 → 텍스트 추출
-  const textParts: string[] = [];
-  const regex = /<text[^>]*>([\s\S]*?)<\/text>/g;
-  let match: RegExpExecArray | null;
-  while ((match = regex.exec(xml)) !== null) {
-    let text = match[1]
-      .replace(/&amp;/g, "&")
-      .replace(/&lt;/g, "<")
-      .replace(/&gt;/g, ">")
-      .replace(/&quot;/g, '"')
-      .replace(/&#39;/g, "'")
-      .replace(/\n/g, " ")
-      .trim();
-    if (text) textParts.push(text);
-  }
-
-  if (textParts.length === 0) {
-    return { error: "no_captions" };
-  }
-
-  return { lang: actualLang, content: textParts.join(" ") };
-}
-
 // --- Route handlers ---
 
 async function handleGeminiGenerate(req: Request, env: Env): Promise<Response> {
@@ -272,7 +154,25 @@ async function handleGeminiStream(req: Request, env: Env): Promise<Response> {
   });
 }
 
-async function handleYoutubeCaptions(req: Request, env: Env): Promise<Response> {
+// --- YouTube InnerTube (ANDROID client) ---
+
+const INNERTUBE_API_URL = "https://www.youtube.com/youtubei/v1/player?key=AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8";
+const INNERTUBE_CONTEXT = {
+  client: {
+    clientName: "ANDROID",
+    clientVersion: "20.10.38",
+    androidSdkVersion: 30,
+  },
+};
+const ANDROID_USER_AGENT = "com.google.android.youtube/20.10.38 (Linux; U; Android 11) gzip";
+
+interface CaptionTrack {
+  baseUrl: string;
+  languageCode: string;
+  kind?: string;
+}
+
+async function handleYoutubeCaptions(req: Request, _env: Env): Promise<Response> {
   const reqUrl = new URL(req.url);
   const videoUrl = reqUrl.searchParams.get("url");
   const lang = reqUrl.searchParams.get("lang") ?? "ko";
@@ -281,24 +181,91 @@ async function handleYoutubeCaptions(req: Request, env: Env): Promise<Response> 
     return Response.json({ error: "Missing 'url' parameter" }, { status: 400 });
   }
 
-  // URL에서 videoId 추출
   const videoIdMatch = videoUrl.match(/(?:v=|youtu\.be\/|shorts\/)([\w-]+)/);
   const videoId = videoIdMatch?.[1];
   if (!videoId) {
     return Response.json({ error: "Invalid YouTube URL" }, { status: 400 });
   }
 
-  const result = await fetchYoutubeTranscript(videoId, lang, env);
+  // 1. InnerTube Player API (ANDROID client)
+  const playerRes = await fetch(INNERTUBE_API_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "User-Agent": ANDROID_USER_AGENT,
+    },
+    body: JSON.stringify({
+      context: INNERTUBE_CONTEXT,
+      videoId,
+    }),
+  });
 
-  if ("error" in result) {
-    const status = result.error === "no_captions" ? 404 : 502;
-    return Response.json({ error: result.error }, { status });
+  if (!playerRes.ok) {
+    return Response.json({ error: `InnerTube error: ${playerRes.status}` }, { status: 502 });
   }
 
-  // Supadata 호환 응답 포맷 유지 (Android 앱 변경 최소화)
+  const playerData = await playerRes.json<{
+    playabilityStatus?: { status?: string };
+    captions?: {
+      playerCaptionsTracklistRenderer?: {
+        captionTracks?: CaptionTrack[];
+      };
+    };
+  }>();
+
+  if (playerData.playabilityStatus?.status !== "OK") {
+    return Response.json({ error: "video_unavailable" }, { status: 404 });
+  }
+
+  const tracks = playerData.captions?.playerCaptionsTracklistRenderer?.captionTracks;
+  if (!tracks || tracks.length === 0) {
+    return Response.json({ error: "no_captions" }, { status: 404 });
+  }
+
+  // 2. 자막 트랙 선택 (수동 우선, ASR fallback)
+  const findTrack = (targetLang: string): CaptionTrack | undefined => {
+    const manual = tracks.find(t => t.languageCode === targetLang && t.kind !== "asr");
+    if (manual) return manual;
+    return tracks.find(t => t.languageCode === targetLang);
+  };
+
+  let track = findTrack(lang);
+  if (!track && lang !== "en") track = findTrack("en");
+  if (!track) track = tracks[0];
+
+  // 3. 자막 XML fetch (baseUrl에서 fmt=srv3 제거)
+  const captionUrl = track.baseUrl.replace("&fmt=srv3", "");
+  const captionRes = await fetch(captionUrl);
+
+  if (!captionRes.ok) {
+    return Response.json({ error: `Caption fetch error: ${captionRes.status}` }, { status: 502 });
+  }
+
+  const xml = await captionRes.text();
+
+  // 4. XML → 텍스트 추출
+  const textParts: string[] = [];
+  const regex = /<text[^>]*>([\s\S]*?)<\/text>/g;
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(xml)) !== null) {
+    const text = match[1]
+      .replace(/&amp;/g, "&")
+      .replace(/&lt;/g, "<")
+      .replace(/&gt;/g, ">")
+      .replace(/&quot;/g, '"')
+      .replace(/&#39;/g, "'")
+      .replace(/\n/g, " ")
+      .trim();
+    if (text) textParts.push(text);
+  }
+
+  if (textParts.length === 0) {
+    return Response.json({ error: "no_captions" }, { status: 404 });
+  }
+
   return Response.json({
-    lang: result.lang,
-    content: result.content,
+    lang: track.languageCode,
+    content: textParts.join(" "),
   });
 }
 

--- a/workers/src/index.ts
+++ b/workers/src/index.ts
@@ -6,6 +6,9 @@ export interface Env {
   SUPABASE_URL: string;
   SUPABASE_SERVICE_KEY: string;
   SUPABASE_JWT_SECRET: string;
+  PROXY_URL?: string;
+  PROXY_AUTH?: string;
+  PROXY_ENABLED?: string;
 }
 
 const AI_GATEWAY_URL = "https://gateway.ai.cloudflare.com/v1/fd6859f0e7b0f6307cfa850af2324d90/memozy/google-ai-studio";
@@ -100,6 +103,121 @@ async function callGeminiStream(
   });
 }
 
+// --- Proxy fetch helper ---
+
+const BROWSER_HEADERS: Record<string, string> = {
+  "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
+  "Accept-Language": "ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7",
+  "Accept": "*/*",
+  "Referer": "https://www.youtube.com/",
+  "Origin": "https://www.youtube.com",
+};
+
+async function proxyFetch(url: string, env: Env, init?: RequestInit): Promise<Response> {
+  const headers = { ...BROWSER_HEADERS, ...init?.headers };
+
+  // 프록시가 활성화되어 있고 Cloudflare Worker에서 프록시 사용 가능한 경우
+  // 현재 CF Worker는 직접 프록시를 지원하지 않으므로, 프록시 URL이 HTTP proxy endpoint인 경우에 대비
+  // 실제 프록시 연동은 프록시 업체 연동 시 확정
+  return fetch(url, { ...init, headers });
+}
+
+// --- InnerTube YouTube transcript ---
+
+interface CaptionTrack {
+  baseUrl: string;
+  languageCode: string;
+  kind?: string;
+  name?: { simpleText?: string };
+}
+
+async function fetchYoutubeTranscript(
+  videoId: string,
+  lang: string,
+  env: Env
+): Promise<{ lang: string; content: string } | { error: string }> {
+  // 1. InnerTube Player API 호출
+  const playerUrl = "https://www.youtube.com/youtubei/v1/player";
+  const playerBody = {
+    context: {
+      client: {
+        clientName: "WEB",
+        clientVersion: "2.20241028.01.00",
+        hl: lang,
+      },
+    },
+    videoId,
+  };
+
+  const playerRes = await proxyFetch(playerUrl, env, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(playerBody),
+  });
+
+  if (!playerRes.ok) {
+    return { error: `InnerTube API error: ${playerRes.status}` };
+  }
+
+  const playerData = await playerRes.json<{
+    captions?: {
+      playerCaptionsTracklistRenderer?: {
+        captionTracks?: CaptionTrack[];
+      };
+    };
+  }>();
+
+  const tracks = playerData?.captions?.playerCaptionsTracklistRenderer?.captionTracks;
+  if (!tracks || tracks.length === 0) {
+    return { error: "no_captions" };
+  }
+
+  // 2. 원하는 언어 자막 찾기 (수동 우선, 자동생성 fallback)
+  const findTrack = (targetLang: string): CaptionTrack | undefined => {
+    // 수동 자막 우선
+    const manual = tracks.find(t => t.languageCode === targetLang && t.kind !== "asr");
+    if (manual) return manual;
+    // 자동생성 자막
+    return tracks.find(t => t.languageCode === targetLang);
+  };
+
+  let track = findTrack(lang);
+  if (!track && lang !== "en") track = findTrack("en");
+  if (!track) track = tracks[0]; // 아무 자막이라도
+
+  const actualLang = track.languageCode;
+
+  // 3. 자막 XML fetch
+  const captionRes = await proxyFetch(track.baseUrl, env);
+  if (!captionRes.ok) {
+    return { error: `Caption fetch error: ${captionRes.status}` };
+  }
+
+  const xml = await captionRes.text();
+
+  // 4. XML 파싱 → 텍스트 추출
+  const textParts: string[] = [];
+  const regex = /<text[^>]*>([\s\S]*?)<\/text>/g;
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(xml)) !== null) {
+    let text = match[1]
+      .replace(/&amp;/g, "&")
+      .replace(/&lt;/g, "<")
+      .replace(/&gt;/g, ">")
+      .replace(/&quot;/g, '"')
+      .replace(/&#39;/g, "'")
+      .replace(/\n/g, " ")
+      .trim();
+    if (text) textParts.push(text);
+  }
+
+  if (textParts.length === 0) {
+    return { error: "no_captions" };
+  }
+
+  return { lang: actualLang, content: textParts.join(" ") };
+}
+
 // --- Route handlers ---
 
 async function handleGeminiGenerate(req: Request, env: Env): Promise<Response> {
@@ -163,18 +281,24 @@ async function handleYoutubeCaptions(req: Request, env: Env): Promise<Response> 
     return Response.json({ error: "Missing 'url' parameter" }, { status: 400 });
   }
 
-  const supadataUrl = new URL("https://api.supadata.ai/v1/youtube/transcript");
-  supadataUrl.searchParams.set("url", videoUrl);
-  supadataUrl.searchParams.set("lang", lang);
+  // URL에서 videoId 추출
+  const videoIdMatch = videoUrl.match(/(?:v=|youtu\.be\/|shorts\/)([\w-]+)/);
+  const videoId = videoIdMatch?.[1];
+  if (!videoId) {
+    return Response.json({ error: "Invalid YouTube URL" }, { status: 400 });
+  }
 
-  const supadataRes = await fetch(supadataUrl.toString(), {
-    headers: { "x-api-key": env.SUPADATA_API_KEY },
-  });
+  const result = await fetchYoutubeTranscript(videoId, lang, env);
 
-  const data = await supadataRes.text();
-  return new Response(data, {
-    status: supadataRes.status,
-    headers: { "Content-Type": "application/json" },
+  if ("error" in result) {
+    const status = result.error === "no_captions" ? 404 : 502;
+    return Response.json({ error: result.error }, { status });
+  }
+
+  // Supadata 호환 응답 포맷 유지 (Android 앱 변경 최소화)
+  return Response.json({
+    lang: result.lang,
+    content: result.content,
   });
 }
 

--- a/workers/wrangler.toml
+++ b/workers/wrangler.toml
@@ -8,11 +8,8 @@ mode = "smart"
 
 # secrets (set via `wrangler secret put`):
 #   GEMINI_API_KEY
-#   SUPADATA_API_KEY  (legacy — InnerTube 전환 후 제거 예정)
+#   SUPADATA_API_KEY
 #   APP_SECRET_KEY
 #   SUPABASE_URL
 #   SUPABASE_SERVICE_KEY
 #   SUPABASE_JWT_SECRET
-#   PROXY_URL         (optional — 레지덴셜 프록시 URL)
-#   PROXY_AUTH        (optional — 프록시 인증 user:pass)
-#   PROXY_ENABLED     (optional — "true"로 설정 시 프록시 경유)

--- a/workers/wrangler.toml
+++ b/workers/wrangler.toml
@@ -8,8 +8,11 @@ mode = "smart"
 
 # secrets (set via `wrangler secret put`):
 #   GEMINI_API_KEY
-#   SUPADATA_API_KEY
+#   SUPADATA_API_KEY  (legacy — InnerTube 전환 후 제거 예정)
 #   APP_SECRET_KEY
 #   SUPABASE_URL
 #   SUPABASE_SERVICE_KEY
 #   SUPABASE_JWT_SECRET
+#   PROXY_URL         (optional — 레지덴셜 프록시 URL)
+#   PROXY_AUTH        (optional — 프록시 인증 user:pass)
+#   PROXY_ENABLED     (optional — "true"로 설정 시 프록시 경유)


### PR DESCRIPTION
## Summary
- Supadata API 의존 완전 제거 → ANDROID InnerTube Player API로 자막 직접 추출
- 프록시 불필요 (ANDROID client는 서버 IP 차단 없음)
- 자막 언어 fallback: 요청 lang → en → 첫 번째 가용 자막
- 수동 자막 우선, ASR fallback
- 기존 응답 포맷 호환 → Android 앱 코드 변경 불필요

## 비용 효과
- **Before:** Supadata Pro $17/월 (3,000건)
- **After:** $0 (InnerTube API 무료)

## 로컬 테스트 결과
- [x] 영어 자막 (Rick Astley) — 정상
- [x] 한국어 자막 (BTS Dynamite) — 정상
- [x] 존재하지 않는 영상 — video_unavailable 에러
- [x] 잘못된 URL — Invalid YouTube URL 에러

## Test plan
- [ ] `npx wrangler dev` → curl 테스트 재현
- [ ] `npx wrangler deploy` → 프로덕션 배포
- [ ] Android 앱에서 유튜브 요약 정상 동작 확인
- [ ] 자막 없는 영상 에러 UI 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)