### PR TITLE
Fix: YouTubeCaptionService InnerTube 응답 포맷 호환성 수정

### DIFF
--- a/datasource/remote/ai/impl/src/main/java/me/pecos/memozy/data/datasource/remote/ai/YouTubeCaptionServiceImpl.kt
+++ b/datasource/remote/ai/impl/src/main/java/me/pecos/memozy/data/datasource/remote/ai/YouTubeCaptionServiceImpl.kt
@@ -7,7 +7,6 @@ import io.ktor.client.statement.bodyAsText
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import javax.inject.Inject
@@ -29,8 +28,8 @@ class YouTubeCaptionServiceImpl @Inject constructor(
                 // 제목과 자막을 병렬로 가져오기
                 val titleDeferred = async { fetchTitle(videoId) }
                 val captionsDeferred = async {
-                    fetchCaptionsFromSupadata(videoId, "ko")
-                        ?: fetchCaptionsFromSupadata(videoId, "en")
+                    fetchCaptionsFromWorker(videoId, "ko")
+                        ?: fetchCaptionsFromWorker(videoId, "en")
                 }
 
                 YouTubeVideoInfo(
@@ -57,7 +56,7 @@ class YouTubeCaptionServiceImpl @Inject constructor(
         }
     }
 
-    private suspend fun fetchCaptionsFromSupadata(videoId: String, lang: String = "ko"): String? {
+    private suspend fun fetchCaptionsFromWorker(videoId: String, lang: String = "ko"): String? {
         return try {
             val responseText = httpClient.get("youtube-captions") {
                 parameter("url", "https://www.youtube.com/watch?v=$videoId")
@@ -65,19 +64,8 @@ class YouTubeCaptionServiceImpl @Inject constructor(
             }.bodyAsText()
 
             val root = json.parseToJsonElement(responseText).jsonObject
-            val content = root["content"]?.jsonArray ?: return null
-
-            val sb = StringBuilder()
-            for (item in content) {
-                val obj = item.jsonObject
-                val text = obj["text"]?.jsonPrimitive?.content?.trim() ?: continue
-                val offsetMs = obj["offset"]?.jsonPrimitive?.content?.toLongOrNull() ?: 0L
-                val sec = offsetMs / 1000
-                val minutes = (sec / 60).toInt()
-                val seconds = (sec % 60).toInt()
-                sb.appendLine("[${String.format("%02d:%02d", minutes, seconds)}] $text")
-            }
-            sb.toString().takeIf { it.isNotBlank() }
+            if (root.containsKey("error")) return null
+            root["content"]?.jsonPrimitive?.content?.takeIf { it.isNotBlank() }
         } catch (e: Exception) {
             null
         }


### PR DESCRIPTION
## Summary
- Worker가 InnerTube로 전환되면서 응답 포맷이 변경됨 (content: jsonArray → string)
- 앱의 YouTubeCaptionServiceImpl을 새 포맷에 맞게 수정
- #187 배포 후 앱 자막 추출이 깨지는 문제 해결

## Test plan
- [ ] 유튜브 요약이 정상 동작하는지 확인
- [ ] 한국어/영어 자막 모두 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)