### PR TITLE
Add: 유튜브 요약 양식 선택 + 언어학습 + UI 개선

### DIFF
--- a/feature/core/resource/src/main/res/values-en/strings.xml
+++ b/feature/core/resource/src/main/res/values-en/strings.xml
@@ -52,6 +52,7 @@
     <string name="search_placeholder">Search by title or content</string>
     <string name="sort_newest">Newest</string>
     <string name="sort_oldest">Oldest</string>
+    <string name="edit_mode">Edit</string>
     <string name="memo_count">%d memos</string>
     <string name="memo_updated_at">Edited:</string>
     <string name="memo_copy">Copy</string>
@@ -165,6 +166,8 @@
     <string name="summary_mode_simple">Quick Summary</string>
     <string name="summary_mode_detailed">Detailed Summary</string>
     <string name="youtube_url_copied">YouTube URL copied</string>
+    <string name="youtube_open_to_copy">Copy URL from YouTube →</string>
+    <string name="summary_style_select">Summarize</string>
     <string name="web_url_copied">Web URL copied</string>
 
     <!-- Trash Extra -->

--- a/feature/core/resource/src/main/res/values-ja/strings.xml
+++ b/feature/core/resource/src/main/res/values-ja/strings.xml
@@ -52,6 +52,7 @@
     <string name="search_placeholder">タイトルまたは内容で検索</string>
     <string name="sort_newest">新しい順</string>
     <string name="sort_oldest">古い順</string>
+    <string name="edit_mode">編集</string>
     <string name="memo_count">計 %d件</string>
     <string name="memo_updated_at">編集:</string>
     <string name="memo_copy">コピー</string>
@@ -165,6 +166,8 @@
     <string name="summary_mode_simple">簡単要約</string>
     <string name="summary_mode_detailed">詳細要約</string>
     <string name="youtube_url_copied">YouTube URLがコピーされました</string>
+    <string name="youtube_open_to_copy">YouTubeからURLをコピー →</string>
+    <string name="summary_style_select">要約する</string>
     <string name="web_url_copied">Web URLがコピーされました</string>
 
     <!-- Trash Extra -->

--- a/feature/core/resource/src/main/res/values/strings.xml
+++ b/feature/core/resource/src/main/res/values/strings.xml
@@ -51,6 +51,7 @@
     <string name="search_placeholder">제목 또는 내용으로 검색</string>
     <string name="sort_newest">최신순</string>
     <string name="sort_oldest">오래된순</string>
+    <string name="edit_mode">편집</string>
     <string name="memo_count">총 %d개</string>
     <string name="memo_updated_at">수정:</string>
     <string name="memo_copy">복사</string>
@@ -163,6 +164,8 @@
     <string name="summary_mode_simple">간단 요약</string>
     <string name="summary_mode_detailed">상세 요약</string>
     <string name="youtube_url_copied">유튜브 URL이 복사되었습니다</string>
+    <string name="youtube_open_to_copy">YouTube에서 URL 복사하기 →</string>
+    <string name="summary_style_select">요약 하기</string>
     <string name="web_url_copied">웹 URL이 복사되었습니다</string>
 
     <!-- Trash Extra -->

--- a/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/home/HomeScreen.kt
+++ b/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/home/HomeScreen.kt
@@ -235,6 +235,21 @@ fun HomeScreen(
                                 color = colors.textSecondary
                             )
                         }
+                        Spacer(modifier = Modifier.width(6.dp))
+                        Row(
+                            modifier = Modifier
+                                .border(1.5.dp, colors.cardBorder, RoundedCornerShape(12.dp))
+                                .clickable { isSelectionMode = true }
+                                .padding(horizontal = 12.dp, vertical = 6.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Text(
+                                text = stringResource(R.string.edit_mode),
+                                fontSize = fontSettings.scaled(13),
+                                fontWeight = FontWeight.Medium,
+                                color = colors.textSecondary
+                            )
+                        }
                     }
                 }
 

--- a/feature/memo-plain/impl/src/main/java/me/pecos/memozy/feature/memoplain/impl/MemoPlainNavigationImpl.kt
+++ b/feature/memo-plain/impl/src/main/java/me/pecos/memozy/feature/memoplain/impl/MemoPlainNavigationImpl.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import me.pecos.memozy.presentation.screen.memo.SummaryMode
+import me.pecos.memozy.presentation.screen.memo.SummaryStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.foundation.layout.Column
@@ -104,10 +105,10 @@ class MemoPlainNavigationImpl @Inject constructor(
             else -> "한국어로"
         }
 
-        private fun buildYoutubePrompt(mode: SummaryMode, lang: String): String {
+        private fun buildYoutubePrompt(style: SummaryStyle, lang: String): String {
             val l = langInstruction(lang)
-            return when (mode) {
-                SummaryMode.SIMPLE -> """
+            return when (style) {
+                SummaryStyle.SIMPLE -> """
                     |이 유튜브 영상을 ${l} 간결하게 요약해줘. 인사말이나 부가 설명 없이 아래 형식만 정확히 출력해:
                     |
                     |📋 한줄 요약
@@ -125,7 +126,7 @@ class MemoPlainNavigationImpl @Inject constructor(
                     |
                     |(가장 중요한 내용 3~5개를 각 1줄로 정리. 첫 항목은 📖 핵심 내용 바로 다음 줄에, 이후 항목들 사이에는 빈 줄 1개를 넣어줘)
                 """.trimMargin()
-                SummaryMode.DETAILED -> """
+                SummaryStyle.DETAILED -> """
                     |이 유튜브 영상을 ${l} 상세하게 요약해줘. 인사말이나 부가 설명 없이 아래 형식만 정확히 출력해:
                     |
                     |📋 한줄 요약
@@ -148,7 +149,62 @@ class MemoPlainNavigationImpl @Inject constructor(
                     |💡 핵심 인사이트
                     |- 영상에서 얻을 수 있는 주요 인사이트를 정리
                 """.trimMargin()
+                SummaryStyle.NOTE -> """
+                    |다음 유튜브 영상 내용을 ${l} 학습 노트 형태로 정리해줘. 인사말이나 부가 설명 없이 바로 시작해:
+                    |
+                    |주제별로 묶어서 개조식(- 기호)으로 간결하게 작성해.
+                    |굵게(**) 표시는 꼭 필요한 핵심 용어에만 최소한으로 사용해.
+                    |한 항목당 1줄, 복습할 때 빠르게 훑을 수 있는 형태로.
+                """.trimMargin()
+                SummaryStyle.LANGUAGE -> {
+                    val userLang = when (lang) {
+                        "en" -> "English"
+                        "ja" -> "日本語"
+                        else -> "한국어"
+                    }
+                    """
+                    |다음 유튜브 영상 자막을 언어 학습용으로 정리해줘.
+                    |사용자의 모국어는 ${userLang}이고, 영상에 나오는 외국어를 학습하려는 목적이야.
+                    |절대 #, ##, **, *** 같은 마크다운 서식을 사용하지 마. 이모지와 일반 텍스트만 써.
+                    |인사말이나 부가 설명 없이 바로 아래 형식대로만 출력해:
+                    |
+                    |📋 핵심 표현 (10~15개)
+                    |
+                    |영상에서 나온 외국어 표현을 원문 그대로 적고, 바로 다음 줄에 ${userLang} 뜻을 적어.
+                    |표현과 표현 사이에는 빈 줄을 넣어.
+                    |
+                    |외국어 원문
+                    |${userLang} 뜻
+                    |
+                    |외국어 원문
+                    |${userLang} 뜻
+                    |
+                    |📖 주요 문장 (5~10개)
+                    |
+                    |영상에서 나온 핵심 문장을 원문 그대로 적고, 다음 줄에 ${userLang} 해석을 적어.
+                    |각 문장 앞에 * 를 붙여. 문장과 문장 사이에는 빈 줄을 넣어.
+                    |
+                    |* 외국어 원문 문장
+                    |${userLang} 해석
+                    |
+                    |* 외국어 원문 문장
+                    |${userLang} 해석
+                    |
+                    |💡 학습 포인트
+                    |
+                    |문법, 뉘앙스, 발음, 사용법 등 학습에 도움되는 내용을 ${userLang}로 2~4줄 정리.
+                """.trimMargin()
+                }
             }
+        }
+
+        /** 기존 SummaryMode 호환 — 레거시 호출용 */
+        private fun buildYoutubePrompt(mode: SummaryMode, lang: String): String {
+            val style = when (mode) {
+                SummaryMode.SIMPLE -> SummaryStyle.SIMPLE
+                SummaryMode.DETAILED -> SummaryStyle.DETAILED
+            }
+            return buildYoutubePrompt(style, lang)
         }
 
         private fun buildWebPrompt(mode: SummaryMode, lang: String): String {
@@ -242,45 +298,13 @@ class MemoPlainNavigationImpl @Inject constructor(
 
             val scope = rememberCoroutineScope()
 
-            // YouTube URL이면 자동 요약 시작 (캐시 우선 조회)
+            // YouTube URL 공유 시 타이틀만 미리 조회 (자동 요약 안 함 — 인라인 카드로 표시)
             LaunchedEffect(youtubeUrl) {
-                if (youtubeUrl != null && summaryState is SummaryState.Idle) {
+                if (youtubeUrl != null) {
                     val videoId = extractVideoId(youtubeUrl)
-                    // 캐시 조회
-                    val cached = videoId?.let { youtubeSummaryDao.getByKey(it, SummaryMode.SIMPLE.name, languageCode) }
-                    if (cached != null) {
-                        summaryState = SummaryState.Success(cached.summary)
-                        return@LaunchedEffect
-                    }
-                    summaryState = SummaryState.Loading
-                    try {
-                        val summary = summarizeVideo(
-                            videoId!!, youtubeUrl,
-                            mode = SummaryMode.SIMPLE,
-                            lang = languageCode,
-                            onTitleFound = { title -> youtubeTitle = title }
-                        )
-                        // 캐시 저장
-                        youtubeSummaryDao.insert(YoutubeSummary(
-                            videoId = videoId,
-                            mode = SummaryMode.SIMPLE.name,
-                            language = languageCode,
-                            url = youtubeUrl,
-                            summary = summary
-                        ))
-                        summaryState = SummaryState.Success(summary)
-                    } catch (e: Exception) {
-                        val errorMsg = when {
-                            e.message?.contains("Rate limit") == true ->
-                                "요청이 너무 많아요. 잠시 후 다시 시도해주세요."
-                            e.message?.contains("503") == true || e.message?.contains("UNAVAILABLE") == true ||
-                            e.message?.contains("high demand") == true ->
-                                "AI 서버가 일시적으로 바빠요. 잠시 후 다시 시도해주세요."
-                            e.message?.contains("timeout") == true || e.message?.contains("Timeout") == true ->
-                                "응답 시간이 초과됐어요. 더 짧은 영상을 시도해주세요."
-                            else -> "DEBUG: ${e::class.simpleName}: ${e.message}"
-                        }
-                        summaryState = SummaryState.Error(errorMsg)
+                    if (videoId != null) {
+                        val title = captionService.fetchTitle(videoId)
+                        if (title != null) youtubeTitle = title
                     }
                 }
             }
@@ -327,15 +351,11 @@ class MemoPlainNavigationImpl @Inject constructor(
             }
 
             // 일반 공유 텍스트 프리필
-            val sharedMemo = remember(summaryState, imageOcrState) {
+            val sharedMemo = remember(youtubeTitle, imageOcrState) {
                 when {
-                    youtubeUrl != null -> when (val state = summaryState) {
-                        is SummaryState.Success -> {
-                            val lines = state.text.split("\n", limit = 2)
-                            val title = lines.firstOrNull()?.replace(Regex("^#+\\s*"), "")?.take(50) ?: "유튜브 요약"
-                            MemoUiState(0, title, 1, "원본: $youtubeUrl", summaryContent = state.text)
-                        }
-                        else -> null
+                    youtubeUrl != null -> {
+                        // 본문 비우고, youtubeUrl 필드로 인라인 카드 표시
+                        MemoUiState(0, youtubeTitle ?: "", 1, "", youtubeUrl = youtubeUrl)
                     }
                     isSharedImage -> when (val state = imageOcrState) {
                         is SummaryState.Success -> {
@@ -557,6 +577,9 @@ class MemoPlainNavigationImpl @Inject constructor(
             var webSummaryError by remember { mutableStateOf<String?>(null) }
             var webPageTitle by remember { mutableStateOf<String?>(null) }
 
+            // 양식 선택 상태
+            var activeSummaryStyle by remember { mutableStateOf(SummaryStyle.SIMPLE) }
+
             // 현재 진행 중인 요약 Job (취소용)
             var currentSummarizeJob by remember { mutableStateOf<kotlinx.coroutines.Job?>(null) }
 
@@ -644,6 +667,53 @@ class MemoPlainNavigationImpl @Inject constructor(
                 webSummaryResult = webSummaryResult,
                 webSummaryError = webSummaryError,
                 webPageTitle = webPageTitle,
+                onSummaryStyleSelected = { style, url ->
+                    activeSummaryStyle = style
+                    // 바텀시트에서 양식 선택 시 즉시 요약 실행
+                    currentSummarizeJob?.cancel()
+                    currentSummarizeJob = scope.launch {
+                        if (!canUseAi) {
+                            showLimitBottomSheet = true
+                            return@launch
+                        }
+                        val videoId = extractVideoId(url)
+                        val cached = videoId?.let { youtubeSummaryDao.getByKey(it, style.name, languageCode) }
+                        if (cached != null) {
+                            inlineSummaryState = SummaryState.Success(cached.summary)
+                            return@launch
+                        }
+                        inlineSummaryState = SummaryState.Loading
+                        try {
+                            val summary = if (videoId != null) {
+                                summarizeVideo(
+                                    videoId, url,
+                                    style = style,
+                                    lang = languageCode,
+                                    onTitleFound = { title -> youtubeTitle = title }
+                                )
+                            } else {
+                                aiApiService.generateContentWithVideo(
+                                    prompt = buildYoutubePrompt(style, languageCode),
+                                    videoUrl = url,
+                                )
+                            }
+                            if (videoId != null) {
+                                youtubeSummaryDao.insert(YoutubeSummary(
+                                    videoId = videoId,
+                                    mode = style.name,
+                                    language = languageCode,
+                                    url = url,
+                                    summary = summary
+                                ))
+                            }
+                            inlineSummaryState = SummaryState.Success(summary)
+                            aiUsageDao.insert(AiUsage(feature = FEATURE_YOUTUBE_SUMMARY))
+                            dailyUsageCount++
+                        } catch (e: Exception) {
+                            inlineSummaryState = SummaryState.Error(e.message ?: "요약 실패")
+                        }
+                    }
+                },
                 onYoutubeDetected = { videoId ->
                     scope.launch {
                         val title = captionService.fetchTitle(videoId)
@@ -659,19 +729,19 @@ class MemoPlainNavigationImpl @Inject constructor(
                             return@launch
                         }
                         val videoId = extractVideoId(url)
-                        // 캐시 조회 (mode + language 기반)
-                        val cached = videoId?.let { youtubeSummaryDao.getByKey(it, mode.name, languageCode) }
+                        // 캐시 조회 (style + language 기반)
+                        val cached = videoId?.let { youtubeSummaryDao.getByKey(it, activeSummaryStyle.name, languageCode) }
                         if (cached != null) {
                             inlineSummaryState = SummaryState.Success(cached.summary)
                             return@launch
                         }
                         inlineSummaryState = SummaryState.Loading
-                        val ytPrompt = buildYoutubePrompt(mode, languageCode)
+                        val ytPrompt = buildYoutubePrompt(activeSummaryStyle, languageCode)
                         try {
                             val summary = if (videoId != null) {
                                 summarizeVideo(
                                     videoId, url,
-                                    mode = mode,
+                                    style = activeSummaryStyle,
                                     lang = languageCode,
                                     onTitleFound = { title -> youtubeTitle = title }
                                 )
@@ -685,7 +755,7 @@ class MemoPlainNavigationImpl @Inject constructor(
                             if (videoId != null) {
                                 youtubeSummaryDao.insert(YoutubeSummary(
                                     videoId = videoId,
-                                    mode = mode.name,
+                                    mode = activeSummaryStyle.name,
                                     language = languageCode,
                                     url = url,
                                     summary = summary
@@ -808,11 +878,11 @@ class MemoPlainNavigationImpl @Inject constructor(
     private suspend fun summarizeVideo(
         videoId: String,
         videoUrl: String,
-        mode: SummaryMode = SummaryMode.SIMPLE,
+        style: SummaryStyle = SummaryStyle.SIMPLE,
         lang: String = "ko",
         onTitleFound: ((String) -> Unit)? = null
     ): String {
-        val prompt = buildYoutubePrompt(mode, lang)
+        val prompt = buildYoutubePrompt(style, lang)
         // 1. 자막 + 제목 추출 시도
         val videoInfo = captionService.extractVideoInfo(videoId)
         if (videoInfo != null) {

--- a/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/MemoScreen.kt
+++ b/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/MemoScreen.kt
@@ -114,6 +114,7 @@ import me.pecos.memozy.presentation.screen.memo.components.FormattingToolbar
 import me.pecos.memozy.presentation.screen.memo.components.WebLinkBottomSheet
 import me.pecos.memozy.presentation.screen.memo.components.WebSummaryInlineCard
 import me.pecos.memozy.presentation.screen.memo.components.WebUrlDialog
+import me.pecos.memozy.presentation.screen.memo.components.SummaryStyleBottomSheet
 import me.pecos.memozy.presentation.screen.memo.components.YouTubeSummaryInlineCard
 import me.pecos.memozy.presentation.screen.memo.components.YouTubeLinkBottomSheet
 import me.pecos.memozy.presentation.screen.memo.components.YouTubeUrlDialog
@@ -219,6 +220,7 @@ fun MemoScreen(
     webSummaryResult: String? = null,
     webSummaryError: String? = null,
     webPageTitle: String? = null,
+    onSummaryStyleSelected: ((SummaryStyle, String) -> Unit)? = null,
     existingMemo: MemoUiState = MemoUiState(0, "", 1, "")
 ) {
     val isNewMemo = existingMemo.id <= 0
@@ -276,6 +278,8 @@ fun MemoScreen(
 
     // 요약 결과 표시 상태
     var showSummary by remember { mutableStateOf(false) }
+    var showSummaryStyleSheet by remember { mutableStateOf(false) }
+    var selectedSummaryStyle by remember { mutableStateOf(SummaryStyle.SIMPLE) }
 
     // 요약 콘텐츠 접기/펼치기 상태 (summaryContent 별도 컬럼에서 로드)
     val initialSummary = remember(existingMemo.id) { existingMemo.summaryContent }
@@ -588,7 +592,21 @@ fun MemoScreen(
                         },
                         colors = colors,
                         context = context,
-                        clipboardManager = clipboardManager
+                        clipboardManager = clipboardManager,
+                        onStyleSelect = { showSummaryStyleSheet = true }
+                    )
+                }
+
+                // 양식 선택 바텀시트
+                if (showSummaryStyleSheet) {
+                    SummaryStyleBottomSheet(
+                        onSelect = { style ->
+                            val url = detectedYoutubeUrl ?: savedYoutubeUrl ?: return@SummaryStyleBottomSheet
+                            selectedSummaryStyle = style
+                            currentSummaryMode = style.summaryMode
+                            onSummaryStyleSelected?.invoke(style, url)
+                        },
+                        onDismiss = { showSummaryStyleSheet = false }
                     )
                 }
 
@@ -851,6 +869,7 @@ fun MemoScreen(
         YouTubeUrlDialog(
             colors = colors,
             clipboardManager = clipboardManager,
+            context = context,
             onDismiss = { showYoutubeDialog = false },
             onUrlAdded = { url ->
                 bodyText = if (bodyText.isBlank()) url else "$bodyText\n$url"

--- a/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/SummaryStyle.kt
+++ b/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/SummaryStyle.kt
@@ -1,0 +1,35 @@
+package me.pecos.memozy.presentation.screen.memo
+
+enum class SummaryStyle(
+    val displayName: String,
+    val emoji: String,
+    val description: String,
+) {
+    SIMPLE(
+        displayName = "간단 요약",
+        emoji = "📋",
+        description = "키워드 + 핵심 포인트 3~5개",
+    ),
+    DETAILED(
+        displayName = "상세 요약",
+        emoji = "📖",
+        description = "타임라인별 상세 정리",
+    ),
+    NOTE(
+        displayName = "노트 정리",
+        emoji = "📝",
+        description = "학습/복습용 개조식",
+    ),
+    LANGUAGE(
+        displayName = "언어 학습",
+        emoji = "🌐",
+        description = "원문 표현 유지 + 모국어 해설",
+    );
+
+    val summaryMode: SummaryMode get() = when (this) {
+        SIMPLE -> SummaryMode.SIMPLE
+        DETAILED -> SummaryMode.DETAILED
+        NOTE -> SummaryMode.DETAILED
+        LANGUAGE -> SummaryMode.DETAILED
+    }
+}

--- a/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/components/MemoDialogs.kt
+++ b/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/components/MemoDialogs.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Link
+import androidx.compose.material.icons.filled.SmartDisplay
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ModalBottomSheet
@@ -54,6 +55,7 @@ private val YOUTUBE_URL_REGEX = Regex(
 fun YouTubeUrlDialog(
     colors: AppColors,
     clipboardManager: ClipboardManager,
+    context: Context,
     onDismiss: () -> Unit,
     onUrlAdded: (String) -> Unit
 ) {
@@ -103,6 +105,32 @@ fun YouTubeUrlDialog(
                     maxLines = 1, overflow = TextOverflow.Ellipsis
                 )
             }
+        }
+        Spacer(modifier = Modifier.height(8.dp))
+        Row(
+            modifier = Modifier
+                .clip(RoundedCornerShape(8.dp))
+                .clickable {
+                    val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://www.youtube.com")).apply {
+                        setPackage("com.google.android.youtube")
+                    }
+                    try { context.startActivity(intent) } catch (_: Exception) {
+                        context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse("https://www.youtube.com")))
+                    }
+                }
+                .padding(horizontal = 10.dp, vertical = 6.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                Icons.Default.SmartDisplay, contentDescription = null,
+                tint = Color(0xFFFF0000), modifier = Modifier.size(14.dp)
+            )
+            Spacer(modifier = Modifier.width(6.dp))
+            Text(
+                text = stringResource(R.string.youtube_open_to_copy),
+                fontSize = fontSettings.scaled(12),
+                color = Color(0xFFFF0000), fontWeight = FontWeight.Medium
+            )
         }
     }
 }

--- a/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/components/SummaryStyleBottomSheet.kt
+++ b/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/components/SummaryStyleBottomSheet.kt
@@ -1,0 +1,86 @@
+package me.pecos.memozy.presentation.screen.memo.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import me.pecos.memozy.presentation.screen.memo.SummaryStyle
+import me.pecos.memozy.presentation.theme.LocalAppColors
+import me.pecos.memozy.presentation.theme.LocalFontSettings
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SummaryStyleBottomSheet(
+    onSelect: (SummaryStyle) -> Unit,
+    onDismiss: () -> Unit
+) {
+    val colors = LocalAppColors.current
+    val fontSettings = LocalFontSettings.current
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = rememberModalBottomSheetState(),
+        containerColor = colors.cardBackground
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 24.dp)
+                .padding(bottom = 32.dp)
+        ) {
+            Text(
+                text = "요약 양식 선택",
+                fontSize = fontSettings.scaled(18),
+                fontWeight = FontWeight.Bold,
+                color = colors.textTitle
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            SummaryStyle.entries.forEach { style ->
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable {
+                            onSelect(style)
+                            onDismiss()
+                        }
+                        .padding(vertical = 12.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = style.emoji,
+                        fontSize = fontSettings.scaled(20)
+                    )
+                    Spacer(modifier = Modifier.width(12.dp))
+                    Column {
+                        Text(
+                            text = style.displayName,
+                            fontSize = fontSettings.scaled(15),
+                            fontWeight = FontWeight.SemiBold,
+                            color = colors.textTitle
+                        )
+                        Text(
+                            text = style.description,
+                            fontSize = fontSettings.scaled(12),
+                            color = colors.textSecondary
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/components/YouTubeSummaryInlineCard.kt
+++ b/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/components/YouTubeSummaryInlineCard.kt
@@ -58,7 +58,8 @@ fun YouTubeSummaryInlineCard(
     onResummarize: (SummaryMode) -> Unit,
     colors: AppColors,
     context: Context,
-    clipboardManager: ClipboardManager
+    clipboardManager: ClipboardManager,
+    onStyleSelect: (() -> Unit)? = null
 ) {
     val fontSettings = LocalFontSettings.current
 
@@ -121,10 +122,9 @@ fun YouTubeSummaryInlineCard(
                     }
                 }
 
-                // 액션 버튼
+                // 액션 버튼 — 원본 보기 + 복사 + 요약 양식
                 Spacer(modifier = Modifier.height(10.dp))
                 Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(6.dp)) {
-                    // 원본 보기
                     Row(
                         modifier = Modifier.weight(1f).clip(RoundedCornerShape(6.dp)).background(colors.chipBackground)
                             .clickable {
@@ -140,7 +140,6 @@ fun YouTubeSummaryInlineCard(
                         Text("🔗", fontSize = fontSettings.scaled(10)); Spacer(modifier = Modifier.width(3.dp))
                         Text(stringResource(R.string.summary_card_open), fontSize = fontSettings.scaled(10), color = colors.chipText, fontWeight = FontWeight.Medium)
                     }
-                    // 복사
                     Row(
                         modifier = Modifier.weight(1f).clip(RoundedCornerShape(6.dp)).background(colors.chipBackground)
                             .clickable {
@@ -155,22 +154,16 @@ fun YouTubeSummaryInlineCard(
                         Spacer(modifier = Modifier.width(3.dp))
                         Text(stringResource(R.string.memo_copy), fontSize = fontSettings.scaled(10), color = colors.chipText, fontWeight = FontWeight.Medium)
                     }
-                    // 요약 버튼 (아직 요약 안 됨)
-                    if (onSummarize != null && summaryText == null) {
+                    if (onSummarize != null && summaryText == null && onStyleSelect != null) {
                         Row(
                             modifier = Modifier.weight(1f).clip(RoundedCornerShape(6.dp)).background(Color(0xFF2196F3).copy(alpha = 0.1f))
-                                .clickable { onSummarize(youtubeUrl, SummaryMode.SIMPLE) }
+                                .clickable { onStyleSelect() }
                                 .padding(vertical = 5.dp),
                             verticalAlignment = Alignment.CenterVertically,
                             horizontalArrangement = Arrangement.Center
-                        ) { Text(stringResource(R.string.summary_mode_simple), fontSize = fontSettings.scaled(10), color = Color(0xFF2196F3), fontWeight = FontWeight.Medium) }
-                        Row(
-                            modifier = Modifier.weight(1f).clip(RoundedCornerShape(6.dp)).background(Color(0xFFFF9800).copy(alpha = 0.1f))
-                                .clickable { onSummarize(youtubeUrl, SummaryMode.DETAILED) }
-                                .padding(vertical = 5.dp),
-                            verticalAlignment = Alignment.CenterVertically,
-                            horizontalArrangement = Arrangement.Center
-                        ) { Text(stringResource(R.string.summary_mode_detailed), fontSize = fontSettings.scaled(10), color = Color(0xFFFF9800), fontWeight = FontWeight.Medium) }
+                        ) {
+                            Text(stringResource(R.string.summary_style_select), fontSize = fontSettings.scaled(10), color = Color(0xFF2196F3), fontWeight = FontWeight.Medium)
+                        }
                     }
                 }
 

--- a/supabase/functions/gemini-generate/index.ts
+++ b/supabase/functions/gemini-generate/index.ts
@@ -3,7 +3,7 @@ import { verifyAppAuth } from "../_shared/auth.ts";
 
 const GEMINI_API_KEY = Deno.env.get("GEMINI_API_KEY")!;
 const GEMINI_MODEL = Deno.env.get("GEMINI_MODEL") ?? "gemini-2.5-flash";
-const FALLBACK_MODELS = ["gemini-2.5-flash-lite", "gemini-1.5-flash"];
+const FALLBACK_MODELS = ["gemini-2.5-flash-lite", "gemini-2.0-flash"];
 const GEMINI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta";
 
 async function callGemini(model: string, body: unknown): Promise<Response> {
@@ -30,7 +30,7 @@ Deno.serve(async (req) => {
     let geminiRes = await callGemini(GEMINI_MODEL, body);
 
     // 503 또는 429면 fallback 모델 순차 시도
-    if (geminiRes.status === 503 || geminiRes.status === 429) {
+    if (geminiRes.status === 503 || geminiRes.status === 429 || geminiRes.status === 404) {
       for (const fallback of FALLBACK_MODELS) {
         geminiRes = await callGemini(fallback, body);
         if (geminiRes.status !== 503 && geminiRes.status !== 429 && geminiRes.status !== 404) {

--- a/supabase/functions/gemini-stream/index.ts
+++ b/supabase/functions/gemini-stream/index.ts
@@ -3,7 +3,7 @@ import { verifyAppAuth } from "../_shared/auth.ts";
 
 const GEMINI_API_KEY = Deno.env.get("GEMINI_API_KEY")!;
 const GEMINI_MODEL = Deno.env.get("GEMINI_MODEL") ?? "gemini-2.5-flash";
-const FALLBACK_MODELS = ["gemini-2.5-flash-lite", "gemini-1.5-flash"];
+const FALLBACK_MODELS = ["gemini-2.5-flash-lite", "gemini-2.0-flash"];
 const GEMINI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta";
 
 async function callGeminiStream(model: string, body: unknown): Promise<Response> {
@@ -30,7 +30,7 @@ Deno.serve(async (req) => {
     let geminiRes = await callGeminiStream(GEMINI_MODEL, body);
 
     // 503 또는 429면 fallback 모델 순차 시도
-    if (geminiRes.status === 503 || geminiRes.status === 429) {
+    if (geminiRes.status === 503 || geminiRes.status === 429 || geminiRes.status === 404) {
       for (const fallback of FALLBACK_MODELS) {
         geminiRes = await callGeminiStream(fallback, body);
         if (geminiRes.status !== 503 && geminiRes.status !== 429 && geminiRes.status !== 404) {

--- a/workers/src/index.ts
+++ b/workers/src/index.ts
@@ -207,6 +207,7 @@ async function handleYoutubeCaptions(req: Request, _env: Env): Promise<Response>
 
   const playerData = await playerRes.json<{
     playabilityStatus?: { status?: string };
+    videoDetails?: { lengthSeconds?: string; title?: string };
     captions?: {
       playerCaptionsTracklistRenderer?: {
         captionTracks?: CaptionTrack[];
@@ -266,9 +267,14 @@ async function handleYoutubeCaptions(req: Request, _env: Env): Promise<Response>
     return Response.json({ error: "no_captions" }, { status: 404 });
   }
 
+  const durationSeconds = parseInt(playerData.videoDetails?.lengthSeconds ?? "0") || 0;
+  const videoTitle = playerData.videoDetails?.title ?? null;
+
   return Response.json({
     lang: track.languageCode,
     content: textParts.join(" "),
+    durationSeconds,
+    title: videoTitle,
   });
 }
 


### PR DESCRIPTION
## Summary
- 유튜브 요약 양식 4종 (간단 요약 / 상세 요약 / 노트 정리 / 언어 학습) 바텀시트 선택 기능
- YouTube 공유 시 자동요약 제거 → 인라인 카드(요약 전) UI로 통일
- YouTubeUrlDialog에 "YouTube에서 URL 복사하기 →" 링크 추가
- 인라인 카드 버튼 레이아웃 1줄 구성 (원본보기 | 복사 | 요약 하기)
- 홈 화면 상단 편집 버튼 추가 (최신순 옆)
- Gemini fallback 모델 gemini-1.5-flash → gemini-2.0-flash 교체 + 404 fallback 트리거 추가
- Worker 응답에 durationSeconds / title 필드 추가

## Test plan
- [ ] 양식 4종 각각 다른 프롬프트로 요약되는지 확인
- [ ] 캐시가 양식별로 독립 동작하는지 확인
- [ ] YouTube 공유로 진입 시 인라인 카드(요약 전) UI 표시 확인
- [ ] 홈 화면 편집 버튼 → 선택 모드 진입 확인
- [ ] YouTubeUrlDialog에서 YouTube 앱 열기 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)