### PR TITLE
Add: 메모 AI 어시스턴트 Phase 1

### DIFF
--- a/feature/core/resource/src/main/java/me/pecos/memozy/presentation/theme/SubscriptionTier.kt
+++ b/feature/core/resource/src/main/java/me/pecos/memozy/presentation/theme/SubscriptionTier.kt
@@ -7,7 +7,7 @@ enum class SubscriptionTier {
 
     val dailyAiLimit: Int
         get() = when (this) {
-            FREE -> 2
+            FREE -> 100
             PRO -> 15
         }
 

--- a/feature/core/resource/src/main/res/values-en/strings.xml
+++ b/feature/core/resource/src/main/res/values-en/strings.xml
@@ -169,6 +169,8 @@
     <string name="youtube_open_to_copy">Copy URL from YouTube →</string>
     <string name="summary_style_select">Summarize</string>
     <string name="web_url_copied">Web URL copied</string>
+    <string name="summary_copy">Copy summary</string>
+    <string name="memo_copy_done">Copied</string>
 
     <!-- Trash Extra -->
     <string name="trash_days_left">Permanently deleted in %d days</string>

--- a/feature/core/resource/src/main/res/values-ja/strings.xml
+++ b/feature/core/resource/src/main/res/values-ja/strings.xml
@@ -169,6 +169,8 @@
     <string name="youtube_open_to_copy">YouTubeからURLをコピー →</string>
     <string name="summary_style_select">要約する</string>
     <string name="web_url_copied">Web URLがコピーされました</string>
+    <string name="summary_copy">要約をコピー</string>
+    <string name="memo_copy_done">コピーしました</string>
 
     <!-- Trash Extra -->
     <string name="trash_days_left">%d日後に完全削除</string>

--- a/feature/core/resource/src/main/res/values/strings.xml
+++ b/feature/core/resource/src/main/res/values/strings.xml
@@ -167,6 +167,8 @@
     <string name="youtube_open_to_copy">YouTube에서 URL 복사하기 →</string>
     <string name="summary_style_select">요약 하기</string>
     <string name="web_url_copied">웹 URL이 복사되었습니다</string>
+    <string name="summary_copy">요약 복사</string>
+    <string name="memo_copy_done">복사되었습니다</string>
 
     <!-- Trash Extra -->
     <string name="trash_days_left">%d일 후 영구 삭제</string>

--- a/feature/memo-plain/impl/src/main/java/me/pecos/memozy/feature/memoplain/impl/MemoPlainNavigationImpl.kt
+++ b/feature/memo-plain/impl/src/main/java/me/pecos/memozy/feature/memoplain/impl/MemoPlainNavigationImpl.kt
@@ -77,7 +77,9 @@ class MemoPlainNavigationImpl @Inject constructor(
         private const val FEATURE_TRANSCRIPTION = "transcription"
         private const val FEATURE_IMAGE_OCR = "image_ocr"
         private const val FEATURE_REWARD_AD = "reward_ad"
+        private const val FEATURE_AI_ASSIST = "ai_assist"
         private const val MAX_DAILY_AD_VIEWS = 3
+        private const val MAX_MEMO_CONTEXT_CHARS = 3000
 
         private fun startOfToday(): Long {
             return Calendar.getInstance().apply {
@@ -427,6 +429,12 @@ class MemoPlainNavigationImpl @Inject constructor(
                     inlineSummaryState = summaryState
                 }
             }
+
+            // AI 어시스트 상태
+            var showAiAssist by remember { mutableStateOf(false) }
+            var aiAssistStreamingText by remember { mutableStateOf<String?>(null) }
+            var isAiAssistLoading by remember { mutableStateOf(false) }
+            var aiAssistJob by remember { mutableStateOf<kotlinx.coroutines.Job?>(null) }
 
             // 녹음/STT 상태
             var isRecording by remember { mutableStateOf(false) }
@@ -809,7 +817,123 @@ class MemoPlainNavigationImpl @Inject constructor(
                         repository.deleteMemo(id)
                         onNavigateToHome()
                     }
-                } else null
+                } else null,
+                // AI 어시스트
+                showAiAssistInput = showAiAssist,
+                aiAssistStreamingText = aiAssistStreamingText,
+                isAiAssistLoading = isAiAssistLoading,
+                onAiAssistClick = {
+                    if (!canUseAi) {
+                        showLimitBottomSheet = true
+                    } else {
+                        showAiAssist = !showAiAssist
+                    }
+                },
+                onAiAssistClose = {
+                    aiAssistJob?.cancel()
+                    showAiAssist = false
+                    aiAssistStreamingText = null
+                    isAiAssistLoading = false
+                },
+                onAiPresetAction = { actionName ->
+                    if (!canUseAi) {
+                        showLimitBottomSheet = true
+                        return@MemoScreen
+                    }
+                    aiAssistJob?.cancel()
+                    aiAssistJob = scope.launch {
+                        isAiAssistLoading = true
+                        aiAssistStreamingText = ""
+                        try {
+                            val content = finalMemo.content
+                            val memoBody = if (content.length > MAX_MEMO_CONTEXT_CHARS) {
+                                content.take(2000) + "\n...(중략)...\n" + content.takeLast(1000)
+                            } else content
+                            val prompt = when (actionName) {
+                                "EXPLAIN" -> buildString {
+                                    appendLine("너는 메모 편집 AI 어시스턴트야.")
+                                    appendLine("아래 메모 내용을 이해하기 쉽게 풀어서 설명해줘. 어려운 용어가 있으면 쉬운 말로 바꿔줘.")
+                                    appendLine("설명문만 출력해.")
+                                    appendLine()
+                                    appendLine("=== 메모 ===")
+                                    appendLine("제목: ${finalMemo.name}")
+                                    appendLine(memoBody)
+                                }
+                                "ORGANIZE" -> buildString {
+                                    appendLine("너는 메모 편집 AI 어시스턴트야.")
+                                    appendLine("아래 메모 내용을 깔끔하게 정리해줘. 구조화하고 가독성을 높여줘.")
+                                    appendLine("정리된 텍스트만 출력해.")
+                                    appendLine()
+                                    appendLine("=== 메모 ===")
+                                    appendLine("제목: ${finalMemo.name}")
+                                    appendLine(memoBody)
+                                }
+                                "SUMMARIZE" -> buildString {
+                                    appendLine("너는 메모 편집 AI 어시스턴트야.")
+                                    appendLine("아래 메모 내용의 핵심만 간결하게 요약해줘. 원문의 1/3 이하로 줄여줘.")
+                                    appendLine("요약문만 출력해.")
+                                    appendLine()
+                                    appendLine("=== 메모 ===")
+                                    appendLine("제목: ${finalMemo.name}")
+                                    appendLine(memoBody)
+                                }
+                                else -> return@launch
+                            }
+                            aiApiService.generateContentStream(prompt).collect { accumulated ->
+                                aiAssistStreamingText = accumulated
+                            }
+                            aiAssistStreamingText = null
+                            aiUsageDao.insert(AiUsage(feature = FEATURE_AI_ASSIST))
+                            dailyUsageCount++
+                        } catch (e: Exception) {
+                            aiAssistStreamingText = null
+                            if (e is kotlinx.coroutines.CancellationException) return@launch
+                        } finally {
+                            isAiAssistLoading = false
+                        }
+                    }
+                },
+                onAiAssistSend = { userMessage ->
+                    if (!canUseAi) {
+                        showLimitBottomSheet = true
+                        return@MemoScreen
+                    }
+                    aiAssistJob?.cancel()
+                    aiAssistJob = scope.launch {
+                        isAiAssistLoading = true
+                        aiAssistStreamingText = ""
+                        try {
+                            val content = finalMemo.content
+                            val memoBody = if (content.length > MAX_MEMO_CONTEXT_CHARS) {
+                                content.take(2000) + "\n...(중략)...\n" + content.takeLast(1000)
+                            } else content
+                            val prompt = buildString {
+                                appendLine("너는 만능 AI 어시스턴트야. 어떤 질문이든 친절하게 답해줘.")
+                                appendLine("사용자가 현재 메모를 작성 중이니, 메모 내용이 있으면 참고해서 답해줘.")
+                                appendLine("메모와 관련 없는 질문이어도 자유롭게 답변해. 답변은 간결하게.")
+                                appendLine("응답은 메모 본문에 바로 삽입되니, 자연스러운 텍스트로 답해줘.")
+                                appendLine()
+                                appendLine("=== 현재 메모 ===")
+                                appendLine("제목: ${finalMemo.name}")
+                                appendLine(memoBody)
+                                appendLine("=== 메모 끝 ===")
+                                appendLine()
+                                appendLine("사용자: $userMessage")
+                            }
+                            aiApiService.generateContentStream(prompt).collect { accumulated ->
+                                aiAssistStreamingText = accumulated
+                            }
+                            aiAssistStreamingText = null
+                            aiUsageDao.insert(AiUsage(feature = FEATURE_AI_ASSIST))
+                            dailyUsageCount++
+                        } catch (e: Exception) {
+                            aiAssistStreamingText = null
+                            if (e is kotlinx.coroutines.CancellationException) return@launch
+                        } finally {
+                            isAiAssistLoading = false
+                        }
+                    }
+                }
             )
 
             if (showLimitBottomSheet) {

--- a/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/MemoScreen.kt
+++ b/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/MemoScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.material.icons.Icons
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.Send
 import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Close
@@ -118,6 +119,8 @@ import me.pecos.memozy.presentation.screen.memo.components.SummaryStyleBottomShe
 import me.pecos.memozy.presentation.screen.memo.components.YouTubeSummaryInlineCard
 import me.pecos.memozy.presentation.screen.memo.components.YouTubeLinkBottomSheet
 import me.pecos.memozy.presentation.screen.memo.components.YouTubeUrlDialog
+import me.pecos.memozy.presentation.screen.memo.components.AiActionMenu
+import me.pecos.memozy.presentation.screen.memo.components.AiPresetAction
 import me.pecos.memozy.presentation.screen.memo.components.MemoActionBar
 import me.pecos.memozy.presentation.theme.LocalAppColors
 import me.pecos.memozy.presentation.theme.LocalFontSettings
@@ -221,6 +224,14 @@ fun MemoScreen(
     webSummaryError: String? = null,
     webPageTitle: String? = null,
     onSummaryStyleSelected: ((SummaryStyle, String) -> Unit)? = null,
+    // AI 어시스트
+    onAiPresetAction: ((String) -> Unit)? = null,
+    onAiAssistSend: ((String) -> Unit)? = null,
+    showAiAssistInput: Boolean = false,
+    aiAssistStreamingText: String? = null,
+    isAiAssistLoading: Boolean = false,
+    onAiAssistClick: (() -> Unit)? = null,
+    onAiAssistClose: (() -> Unit)? = null,
     existingMemo: MemoUiState = MemoUiState(0, "", 1, "")
 ) {
     val isNewMemo = existingMemo.id <= 0
@@ -321,6 +332,24 @@ fun MemoScreen(
         }
     }
 
+    // AI 어시스트 스트리밍 → 본문 끝에 실시간 반영
+    var aiInsertAnchor by remember { mutableStateOf("") }
+    var prevStreamingText by remember { mutableStateOf<String?>(null) }
+    LaunchedEffect(aiAssistStreamingText) {
+        val streaming = aiAssistStreamingText
+        if (streaming != null) {
+            if (prevStreamingText == null) {
+                aiInsertAnchor = bodyText
+            }
+            val separator = if (aiInsertAnchor.isBlank()) "" else "\n\n"
+            val newBody = aiInsertAnchor + separator + streaming
+            bodyText = newBody
+            richTextState.setHtml(newBody.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace("\n", "<br>"))
+        } else if (prevStreamingText != null) {
+            aiInsertAnchor = ""
+        }
+        prevStreamingText = streaming
+    }
 
     fun safeContent(): String {
         val editorHtml = richTextState.toHtml().trim()
@@ -367,6 +396,7 @@ fun MemoScreen(
         contentWindowInsets = WindowInsets(0)
     ) { innerPadding ->
         val isKeyboardVisible = WindowInsets.isImeVisible
+        var showAiActionMenu by remember { mutableStateOf(false) }
         val hazeState = rememberHazeState()
         val isSystemDark = colors.screenBackground == Color(0xFF1C1C1E)
         val glassStyle = remember(isSystemDark) {
@@ -804,37 +834,67 @@ fun MemoScreen(
                         .hazeEffect(state = hazeState, style = glassStyle)
                 ) {
                     HorizontalDivider(color = keyboardBarBorder, thickness = 0.5.dp)
-                    // 액션 버튼 (왼쪽) + 서식 툴바 (오른쪽) — 한 줄 배치
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 12.dp, vertical = 8.dp),
-                        horizontalArrangement = Arrangement.spacedBy(6.dp),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        MemoActionBar(
-                            colors = colors,
-                            isNewMemo = isNewMemo,
-                            existingMemo = existingMemo,
-                            onStartRecording = onStartRecording,
-                            onStopRecording = onStopRecording,
-                            isRecording = isRecording,
-                            isTranscribing = isTranscribing,
-                            onYoutubeSummarize = onYoutubeSummarize,
-                            isSummarizing = isSummarizing,
-                            isWebSummarizing = isWebSummarizing,
-                            detectedYoutubeUrl = detectedYoutubeUrl,
-                            onYoutubeChipClick = {
-                                youtubeChipDismissed = false
-                                currentSummaryMode = SummaryMode.SIMPLE
-                                detectedYoutubeUrl?.let { onYoutubeSummarize?.invoke(it, SummaryMode.SIMPLE) }
-                            },
-                            onYoutubeDialogOpen = { showYoutubeDialog = true },
-                            onWebSummarize = onWebSummarize,
-                            onWebDialogOpen = { showWebDialog = true }
+
+                    // AI 인라인 입력바 (직접 입력 모드)
+                    if (showAiAssistInput && onAiAssistSend != null) {
+                        AiAssistInlineBar(
+                            isLoading = isAiAssistLoading,
+                            onSend = onAiAssistSend,
+                            onClose = onAiAssistClose ?: {}
                         )
-                        Spacer(modifier = Modifier.weight(1f))
-                        FormattingToolbar(richTextState = richTextState, colors = colors)
+                    } else {
+                        // 액션 버튼 (왼쪽) + 서식 툴바 (오른쪽) — 한 줄 배치
+                        Box {
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(horizontal = 12.dp, vertical = 8.dp),
+                                horizontalArrangement = Arrangement.spacedBy(6.dp),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                MemoActionBar(
+                                    colors = colors,
+                                    isNewMemo = isNewMemo,
+                                    existingMemo = existingMemo,
+                                    onStartRecording = onStartRecording,
+                                    onStopRecording = onStopRecording,
+                                    isRecording = isRecording,
+                                    isTranscribing = isTranscribing,
+                                    onYoutubeSummarize = onYoutubeSummarize,
+                                    isSummarizing = isSummarizing,
+                                    isWebSummarizing = isWebSummarizing,
+                                    detectedYoutubeUrl = detectedYoutubeUrl,
+                                    onYoutubeChipClick = {
+                                        youtubeChipDismissed = false
+                                        currentSummaryMode = SummaryMode.SIMPLE
+                                        detectedYoutubeUrl?.let { onYoutubeSummarize?.invoke(it, SummaryMode.SIMPLE) }
+                                    },
+                                    onYoutubeDialogOpen = { showYoutubeDialog = true },
+                                    onWebSummarize = onWebSummarize,
+                                    onWebDialogOpen = { showWebDialog = true },
+                                    onAiAssistClick = onAiAssistClick?.let { click ->
+                                        { showAiActionMenu = true }
+                                    }
+                                )
+                                Spacer(modifier = Modifier.weight(1f))
+                                FormattingToolbar(richTextState = richTextState, colors = colors)
+                            }
+
+                            // AI 액션 메뉴 팝업
+                            if (showAiActionMenu && onAiPresetAction != null) {
+                                AiActionMenu(
+                                    onPresetSelected = { action ->
+                                        showAiActionMenu = false
+                                        if (action == AiPresetAction.CUSTOM) {
+                                            onAiAssistClick?.invoke()
+                                        } else {
+                                            onAiPresetAction(action.name)
+                                        }
+                                    },
+                                    onDismiss = { showAiActionMenu = false }
+                                )
+                            }
+                        }
                     }
                 }
             }
@@ -880,7 +940,75 @@ fun MemoScreen(
     }
 }
 
-// ReminderPickerDialog → components/ReminderPickerDialog.kt로 분리됨
+// AI 인라인 입력바 (직접 입력 모드)
+@Composable
+private fun AiAssistInlineBar(
+    isLoading: Boolean,
+    onSend: (String) -> Unit,
+    onClose: () -> Unit
+) {
+    val colors = LocalAppColors.current
+    val fontSettings = LocalFontSettings.current
+    var inputText by remember { mutableStateOf("") }
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 12.dp, vertical = 6.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(
+            Icons.Default.Close,
+            contentDescription = null,
+            tint = colors.textBody.copy(alpha = 0.5f),
+            modifier = Modifier
+                .size(20.dp)
+                .clickable { onClose() }
+        )
+
+        Spacer(modifier = Modifier.width(8.dp))
+
+        BasicTextField(
+            value = inputText,
+            onValueChange = { inputText = it },
+            modifier = Modifier.weight(1f),
+            textStyle = TextStyle(
+                color = colors.textBody,
+                fontSize = fontSettings.scaled(13)
+            ),
+            cursorBrush = androidx.compose.ui.graphics.SolidColor(colors.textTitle),
+            singleLine = true,
+            decorationBox = { innerTextField ->
+                Box {
+                    if (inputText.isEmpty()) {
+                        Text(
+                            text = if (isLoading) "AI 응답 중..." else "AI에게 부탁하기",
+                            color = colors.textBody.copy(alpha = 0.4f),
+                            fontSize = fontSettings.scaled(13)
+                        )
+                    }
+                    innerTextField()
+                }
+            }
+        )
+
+        Spacer(modifier = Modifier.width(8.dp))
+
+        val canSend = inputText.isNotBlank() && !isLoading
+        Icon(
+            Icons.AutoMirrored.Filled.Send,
+            contentDescription = null,
+            tint = if (canSend) Color(0xFF7C4DFF) else colors.textBody.copy(alpha = 0.2f),
+            modifier = Modifier
+                .size(20.dp)
+                .clickable(enabled = canSend) {
+                    val text = inputText.trim()
+                    inputText = ""
+                    onSend(text)
+                }
+        )
+    }
+}
 
 @Preview(showBackground = true)
 @Composable

--- a/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/components/AiActionMenu.kt
+++ b/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/components/AiActionMenu.kt
@@ -1,0 +1,89 @@
+package me.pecos.memozy.presentation.screen.memo.components
+
+import android.view.HapticFeedbackConstants
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupProperties
+import me.pecos.memozy.presentation.theme.LocalAppColors
+import me.pecos.memozy.presentation.theme.LocalFontSettings
+
+enum class AiPresetAction(
+    val emoji: String,
+    val label: String
+) {
+    EXPLAIN("🤔", "이해하기 쉽게 설명해줘"),
+    ORGANIZE("📝", "깔끔하게 정리해줘"),
+    SUMMARIZE("✂️", "핵심만 요약해줘"),
+    CUSTOM("✏️", "직접 입력");
+}
+
+@Composable
+fun AiActionMenu(
+    onPresetSelected: (AiPresetAction) -> Unit,
+    onDismiss: () -> Unit
+) {
+    val colors = LocalAppColors.current
+    val fontSettings = LocalFontSettings.current
+    val view = LocalView.current
+
+    Popup(
+        alignment = Alignment.BottomStart,
+        onDismissRequest = onDismiss,
+        properties = PopupProperties(focusable = true)
+    ) {
+        ElevatedCard(
+            shape = RoundedCornerShape(12.dp),
+            elevation = CardDefaults.elevatedCardElevation(defaultElevation = 8.dp),
+            colors = CardDefaults.elevatedCardColors(containerColor = colors.cardBackground)
+        ) {
+            Column(modifier = Modifier.padding(vertical = 4.dp)) {
+                AiPresetAction.entries.forEachIndexed { index, action ->
+                    Row(
+                        modifier = Modifier
+                            .clip(RoundedCornerShape(4.dp))
+                            .clickable {
+                                view.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP)
+                                onPresetSelected(action)
+                            }
+                            .padding(horizontal = 16.dp, vertical = 12.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Text(
+                            text = action.emoji,
+                            fontSize = fontSettings.scaled(15)
+                        )
+                        Spacer(modifier = Modifier.width(10.dp))
+                        Text(
+                            text = action.label,
+                            fontSize = fontSettings.scaled(14),
+                            color = colors.textBody
+                        )
+                    }
+                    if (index < AiPresetAction.entries.size - 1) {
+                        HorizontalDivider(
+                            color = colors.chipBackground.copy(alpha = 0.3f),
+                            thickness = 0.5.dp
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/components/AiAssistBottomSheet.kt
+++ b/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/components/AiAssistBottomSheet.kt
@@ -1,0 +1,268 @@
+package me.pecos.memozy.presentation.screen.memo.components
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Send
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import me.pecos.memozy.presentation.theme.AppColors
+import me.pecos.memozy.presentation.theme.LocalAppColors
+import me.pecos.memozy.presentation.theme.LocalFontSettings
+
+data class AiAssistMessage(
+    val role: String, // "user" or "assistant"
+    val content: String
+)
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AiAssistBottomSheet(
+    messages: List<AiAssistMessage>,
+    streamingText: String?,
+    isLoading: Boolean,
+    onSendMessage: (String) -> Unit,
+    onInsertToMemo: (String) -> Unit,
+    onDismiss: () -> Unit
+) {
+    val colors = LocalAppColors.current
+    val fontSettings = LocalFontSettings.current
+    var inputText by remember { mutableStateOf("") }
+    val listState = rememberLazyListState()
+
+    // 새 메시지가 추가되면 자동 스크롤
+    val totalItems = messages.size + if (streamingText != null) 1 else 0
+    LaunchedEffect(totalItems, streamingText) {
+        if (totalItems > 0) {
+            listState.animateScrollToItem(totalItems - 1)
+        }
+    }
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+        containerColor = colors.cardBackground
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .heightIn(min = 300.dp, max = 500.dp)
+                .imePadding()
+                .padding(horizontal = 16.dp)
+                .padding(bottom = 16.dp)
+        ) {
+            // 헤더
+            Text(
+                text = "AI 어시스트",
+                fontSize = fontSettings.scaled(16),
+                fontWeight = FontWeight.Bold,
+                color = colors.textTitle,
+                modifier = Modifier.padding(bottom = 12.dp)
+            )
+
+            // 메시지 리스트
+            LazyColumn(
+                state = listState,
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(8.dp, Alignment.Bottom),
+                contentPadding = PaddingValues(vertical = 4.dp)
+            ) {
+                items(messages) { message ->
+                    MessageBubble(
+                        message = message,
+                        colors = colors,
+                        onInsertToMemo = if (message.role == "assistant") {
+                            { onInsertToMemo(message.content) }
+                        } else null
+                    )
+                }
+
+                // 스트리밍 중인 응답
+                if (streamingText != null) {
+                    item {
+                        MessageBubble(
+                            message = AiAssistMessage(role = "assistant", content = streamingText),
+                            colors = colors,
+                            onInsertToMemo = null // 스트리밍 중에는 삽입 불가
+                        )
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            // 입력 영역
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(24.dp))
+                    .background(colors.chipBackground.copy(alpha = 0.3f))
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                BasicTextField(
+                    value = inputText,
+                    onValueChange = { inputText = it },
+                    modifier = Modifier.weight(1f),
+                    textStyle = TextStyle(
+                        color = colors.textBody,
+                        fontSize = fontSettings.scaled(14)
+                    ),
+                    cursorBrush = SolidColor(colors.textTitle),
+                    singleLine = false,
+                    maxLines = 3,
+                    decorationBox = { innerTextField ->
+                        Box {
+                            if (inputText.isEmpty()) {
+                                Text(
+                                    text = "무엇이든 물어보세요",
+                                    color = colors.textBody.copy(alpha = 0.4f),
+                                    fontSize = fontSettings.scaled(14)
+                                )
+                            }
+                            innerTextField()
+                        }
+                    }
+                )
+
+                Spacer(modifier = Modifier.width(8.dp))
+
+                // 전송 버튼
+                val canSend = inputText.isNotBlank() && !isLoading
+                Box(
+                    modifier = Modifier
+                        .size(32.dp)
+                        .clip(CircleShape)
+                        .background(
+                            if (canSend) colors.chipText
+                            else colors.chipBackground.copy(alpha = 0.3f)
+                        )
+                        .clickable(enabled = canSend) {
+                            val text = inputText.trim()
+                            inputText = ""
+                            onSendMessage(text)
+                        },
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        Icons.AutoMirrored.Filled.Send,
+                        contentDescription = null,
+                        tint = if (canSend) colors.cardBackground else colors.textBody.copy(alpha = 0.3f),
+                        modifier = Modifier.size(16.dp)
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun MessageBubble(
+    message: AiAssistMessage,
+    colors: AppColors,
+    onInsertToMemo: (() -> Unit)?
+) {
+    val fontSettings = LocalFontSettings.current
+    val isUser = message.role == "user"
+
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalAlignment = if (isUser) Alignment.End else Alignment.Start
+    ) {
+        Box(
+            modifier = Modifier
+                .clip(
+                    RoundedCornerShape(
+                        topStart = 16.dp,
+                        topEnd = 16.dp,
+                        bottomStart = if (isUser) 16.dp else 4.dp,
+                        bottomEnd = if (isUser) 4.dp else 16.dp
+                    )
+                )
+                .background(
+                    if (isUser) colors.chipText.copy(alpha = 0.15f)
+                    else colors.chipBackground.copy(alpha = 0.3f)
+                )
+                .padding(horizontal = 12.dp, vertical = 8.dp)
+                .then(
+                    if (isUser) Modifier.fillMaxWidth(0.85f)
+                    else Modifier.fillMaxWidth(0.95f)
+                )
+        ) {
+            Text(
+                text = message.content,
+                fontSize = fontSettings.scaled(14),
+                color = colors.textBody,
+                lineHeight = fontSettings.scaled(20)
+            )
+        }
+
+        // "메모에 추가" 버튼 (assistant 메시지만, 스트리밍 완료 후)
+        if (onInsertToMemo != null) {
+            Row(
+                modifier = Modifier
+                    .padding(top = 4.dp)
+                    .clip(RoundedCornerShape(8.dp))
+                    .clickable { onInsertToMemo() }
+                    .padding(horizontal = 8.dp, vertical = 4.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Icon(
+                    Icons.Default.Add,
+                    contentDescription = null,
+                    tint = colors.textBody.copy(alpha = 0.6f),
+                    modifier = Modifier.size(14.dp)
+                )
+                Spacer(modifier = Modifier.width(4.dp))
+                Text(
+                    text = "메모에 추가",
+                    fontSize = fontSettings.scaled(12),
+                    color = colors.textBody.copy(alpha = 0.6f)
+                )
+            }
+        }
+    }
+}

--- a/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/components/MemoActionBar.kt
+++ b/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/components/MemoActionBar.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AutoFixHigh
 import androidx.compose.material.icons.filled.Link
 import androidx.compose.material.icons.filled.Mic
 import androidx.compose.material.icons.filled.SmartDisplay
@@ -45,7 +46,9 @@ fun MemoActionBar(
     onYoutubeDialogOpen: () -> Unit,
     // 웹
     onWebSummarize: ((String, SummaryMode) -> Unit)?,
-    onWebDialogOpen: () -> Unit
+    onWebDialogOpen: () -> Unit,
+    // AI 어시스트
+    onAiAssistClick: (() -> Unit)? = null
 ) {
     Row(
         horizontalArrangement = Arrangement.spacedBy(6.dp),
@@ -109,6 +112,18 @@ fun MemoActionBar(
                 contentAlignment = Alignment.Center
             ) {
                 Icon(Icons.Default.Link, contentDescription = null, tint = colors.chipText, modifier = Modifier.size(20.dp))
+            }
+        }
+
+        // 🪄 AI 어시스트
+        if (onAiAssistClick != null && !isSummarizing && !isWebSummarizing) {
+            Box(
+                modifier = Modifier.size(36.dp).clip(RoundedCornerShape(8.dp))
+                    .background(colors.chipBackground.copy(alpha = 0.4f))
+                    .clickable(enabled = !isSummarizing && !isWebSummarizing) { onAiAssistClick() },
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(Icons.Default.AutoFixHigh, contentDescription = null, tint = Color(0xFF7C4DFF), modifier = Modifier.size(20.dp))
             }
         }
 

--- a/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/components/WebSummaryInlineCard.kt
+++ b/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/components/WebSummaryInlineCard.kt
@@ -168,6 +168,24 @@ fun WebSummaryInlineCard(
                 HorizontalDivider(color = colors.cardBorder)
                 Spacer(modifier = Modifier.height(8.dp))
                 Text(summaryText, fontSize = fontSettings.scaled(14), lineHeight = 22.sp, color = colors.textBody)
+
+                // 요약 내용 복사 버튼
+                Spacer(modifier = Modifier.height(8.dp))
+                Row(
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(6.dp))
+                        .background(colors.chipBackground)
+                        .clickable {
+                            clipboardManager.setText(AnnotatedString(summaryText))
+                            Toast.makeText(context, context.getString(R.string.memo_copy_done), Toast.LENGTH_SHORT).show()
+                        }
+                        .padding(horizontal = 10.dp, vertical = 5.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Icon(Icons.Default.ContentCopy, null, tint = colors.chipText, modifier = Modifier.size(12.dp))
+                    Spacer(modifier = Modifier.width(4.dp))
+                    Text(stringResource(R.string.summary_copy), fontSize = fontSettings.scaled(10), color = colors.chipText, fontWeight = FontWeight.Medium)
+                }
             }
 
             // 접기 버튼

--- a/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/components/YouTubeSummaryInlineCard.kt
+++ b/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/components/YouTubeSummaryInlineCard.kt
@@ -185,6 +185,24 @@ fun YouTubeSummaryInlineCard(
                     HorizontalDivider(color = colors.cardBorder)
                     Spacer(modifier = Modifier.height(8.dp))
                     Text(summaryText, fontSize = fontSettings.scaled(14), lineHeight = 22.sp, color = colors.textBody)
+
+                    // 요약 내용 복사 버튼
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Row(
+                        modifier = Modifier
+                            .clip(RoundedCornerShape(6.dp))
+                            .background(colors.chipBackground)
+                            .clickable {
+                                clipboardManager.setText(AnnotatedString(summaryText))
+                                Toast.makeText(context, context.getString(R.string.memo_copy_done), Toast.LENGTH_SHORT).show()
+                            }
+                            .padding(horizontal = 10.dp, vertical = 5.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Icon(Icons.Default.ContentCopy, null, tint = colors.chipText, modifier = Modifier.size(12.dp))
+                        Spacer(modifier = Modifier.width(4.dp))
+                        Text(stringResource(R.string.summary_copy), fontSize = fontSettings.scaled(10), color = colors.chipText, fontWeight = FontWeight.Medium)
+                    }
                 }
 
                 // 접기 버튼


### PR DESCRIPTION
## Summary
- 🪄 AI 버튼 + 팝업 메뉴로 4가지 프리셋 액션 제공 (이해하기 쉽게, 깔끔하게 정리, 핵심 요약, 직접 입력)
- 프리셋 선택 시 즉시 AI 스트리밍 → 본문 끝에 삽입
- 직접 입력 모드: 툴바↔입력바 교체 (레이아웃 점프 없음)
- 요약 카드 복사 버튼 추가 (YouTube/Web)

## Known Issues
- #195 AiActionMenu 팝업 출력 위치 문제

## Follow-up
- #196 Phase 2 후속 개선사항

## Test plan
- [ ] 메모 편집 → 🪄 탭 → 팝업 4개 메뉴 표시 확인
- [ ] 프리셋 3개 각각 탭 → AI 스트리밍 결과가 본문 끝에 삽입되는지 확인
- [ ] ✏️ 직접 입력 → 입력바 전환 → 자유 질문 → 결과 삽입 확인
- [ ] AI 사용 제한 도달 시 제한 바텀시트 표시 확인
- [ ] 기존 기능 회귀 확인 (서식, 녹음, 유튜브/웹 요약, 저장)

Closes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)