### PR TITLE
Update: 요약 삭제 버튼 + AI 어시스트 UX 전면 개선

### DIFF
--- a/feature/core/resource/src/main/res/values-en/strings.xml
+++ b/feature/core/resource/src/main/res/values-en/strings.xml
@@ -170,6 +170,9 @@
     <string name="summary_style_select">Summarize</string>
     <string name="web_url_copied">Web URL copied</string>
     <string name="summary_copy">Copy summary</string>
+    <string name="summary_delete_title">Delete Summary</string>
+    <string name="summary_delete_message">Are you sure you want to delete the summary?\nThis cannot be undone.</string>
+    <string name="summary_delete_action">Delete</string>
     <string name="memo_copy_done">Copied</string>
 
     <!-- Trash Extra -->

--- a/feature/core/resource/src/main/res/values-ja/strings.xml
+++ b/feature/core/resource/src/main/res/values-ja/strings.xml
@@ -170,6 +170,9 @@
     <string name="summary_style_select">要約する</string>
     <string name="web_url_copied">Web URLがコピーされました</string>
     <string name="summary_copy">要約をコピー</string>
+    <string name="summary_delete_title">要約を削除</string>
+    <string name="summary_delete_message">要約を削除しますか？\n削除すると元に戻せません。</string>
+    <string name="summary_delete_action">削除</string>
     <string name="memo_copy_done">コピーしました</string>
 
     <!-- Trash Extra -->

--- a/feature/core/resource/src/main/res/values/strings.xml
+++ b/feature/core/resource/src/main/res/values/strings.xml
@@ -168,6 +168,9 @@
     <string name="summary_style_select">요약 하기</string>
     <string name="web_url_copied">웹 URL이 복사되었습니다</string>
     <string name="summary_copy">요약 복사</string>
+    <string name="summary_delete_title">요약 삭제</string>
+    <string name="summary_delete_message">요약 내용을 삭제하시겠습니까?\n삭제 시 복구할 수 없습니다.</string>
+    <string name="summary_delete_action">삭제</string>
     <string name="memo_copy_done">복사되었습니다</string>
 
     <!-- Trash Extra -->

--- a/feature/memo-plain/impl/src/main/java/me/pecos/memozy/feature/memoplain/impl/MemoPlainNavigationImpl.kt
+++ b/feature/memo-plain/impl/src/main/java/me/pecos/memozy/feature/memoplain/impl/MemoPlainNavigationImpl.kt
@@ -431,7 +431,8 @@ class MemoPlainNavigationImpl @Inject constructor(
             }
 
             // AI 어시스트 상태
-            var showAiAssist by remember { mutableStateOf(false) }
+            var showAiAssistSheet by remember { mutableStateOf(false) }
+            var aiAssistMessages by remember { mutableStateOf(listOf<me.pecos.memozy.presentation.screen.memo.components.AiAssistMessage>()) }
             var aiAssistStreamingText by remember { mutableStateOf<String?>(null) }
             var isAiAssistLoading by remember { mutableStateOf(false) }
             var aiAssistJob by remember { mutableStateOf<kotlinx.coroutines.Job?>(null) }
@@ -819,23 +820,16 @@ class MemoPlainNavigationImpl @Inject constructor(
                     }
                 } else null,
                 // AI 어시스트
-                showAiAssistInput = showAiAssist,
                 aiAssistStreamingText = aiAssistStreamingText,
                 isAiAssistLoading = isAiAssistLoading,
                 onAiAssistClick = {
                     if (!canUseAi) {
                         showLimitBottomSheet = true
                     } else {
-                        showAiAssist = !showAiAssist
+                        showAiAssistSheet = true
                     }
                 },
-                onAiAssistClose = {
-                    aiAssistJob?.cancel()
-                    showAiAssist = false
-                    aiAssistStreamingText = null
-                    isAiAssistLoading = false
-                },
-                onAiPresetAction = { actionName ->
+                onAiPresetAction = { actionName, currentTitle, currentBody ->
                     if (!canUseAi) {
                         showLimitBottomSheet = true
                         return@MemoScreen
@@ -845,36 +839,41 @@ class MemoPlainNavigationImpl @Inject constructor(
                         isAiAssistLoading = true
                         aiAssistStreamingText = ""
                         try {
-                            val content = finalMemo.content
-                            val memoBody = if (content.length > MAX_MEMO_CONTEXT_CHARS) {
-                                content.take(2000) + "\n...(중략)...\n" + content.takeLast(1000)
-                            } else content
+                            val plainBody = currentBody.replace(Regex("<[^>]*>"), "").trim()
+                            val memoBody = if (plainBody.length > MAX_MEMO_CONTEXT_CHARS) {
+                                plainBody.take(2000) + "\n...(중략)...\n" + plainBody.takeLast(1000)
+                            } else plainBody
+                            if (memoBody.isBlank()) {
+                                aiAssistStreamingText = null
+                                return@launch
+                            }
+                            val noMarkdownRule = "마크다운 문법(**, ##, - 등)을 절대 사용하지 마. 순수 텍스트로만 답해."
                             val prompt = when (actionName) {
                                 "EXPLAIN" -> buildString {
                                     appendLine("너는 메모 편집 AI 어시스턴트야.")
                                     appendLine("아래 메모 내용을 이해하기 쉽게 풀어서 설명해줘. 어려운 용어가 있으면 쉬운 말로 바꿔줘.")
-                                    appendLine("설명문만 출력해.")
+                                    appendLine("설명문만 출력해. $noMarkdownRule")
                                     appendLine()
                                     appendLine("=== 메모 ===")
-                                    appendLine("제목: ${finalMemo.name}")
+                                    appendLine("제목: $currentTitle")
                                     appendLine(memoBody)
                                 }
                                 "ORGANIZE" -> buildString {
                                     appendLine("너는 메모 편집 AI 어시스턴트야.")
                                     appendLine("아래 메모 내용을 깔끔하게 정리해줘. 구조화하고 가독성을 높여줘.")
-                                    appendLine("정리된 텍스트만 출력해.")
+                                    appendLine("정리된 텍스트만 출력해. $noMarkdownRule")
                                     appendLine()
                                     appendLine("=== 메모 ===")
-                                    appendLine("제목: ${finalMemo.name}")
+                                    appendLine("제목: $currentTitle")
                                     appendLine(memoBody)
                                 }
                                 "SUMMARIZE" -> buildString {
                                     appendLine("너는 메모 편집 AI 어시스턴트야.")
                                     appendLine("아래 메모 내용의 핵심만 간결하게 요약해줘. 원문의 1/3 이하로 줄여줘.")
-                                    appendLine("요약문만 출력해.")
+                                    appendLine("요약문만 출력해. $noMarkdownRule")
                                     appendLine()
                                     appendLine("=== 메모 ===")
-                                    appendLine("제목: ${finalMemo.name}")
+                                    appendLine("제목: $currentTitle")
                                     appendLine(memoBody)
                                 }
                                 else -> return@launch
@@ -893,48 +892,75 @@ class MemoPlainNavigationImpl @Inject constructor(
                         }
                     }
                 },
-                onAiAssistSend = { userMessage ->
-                    if (!canUseAi) {
-                        showLimitBottomSheet = true
-                        return@MemoScreen
-                    }
-                    aiAssistJob?.cancel()
-                    aiAssistJob = scope.launch {
-                        isAiAssistLoading = true
-                        aiAssistStreamingText = ""
-                        try {
-                            val content = finalMemo.content
-                            val memoBody = if (content.length > MAX_MEMO_CONTEXT_CHARS) {
-                                content.take(2000) + "\n...(중략)...\n" + content.takeLast(1000)
-                            } else content
-                            val prompt = buildString {
-                                appendLine("너는 만능 AI 어시스턴트야. 어떤 질문이든 친절하게 답해줘.")
-                                appendLine("사용자가 현재 메모를 작성 중이니, 메모 내용이 있으면 참고해서 답해줘.")
-                                appendLine("메모와 관련 없는 질문이어도 자유롭게 답변해. 답변은 간결하게.")
-                                appendLine("응답은 메모 본문에 바로 삽입되니, 자연스러운 텍스트로 답해줘.")
-                                appendLine()
-                                appendLine("=== 현재 메모 ===")
-                                appendLine("제목: ${finalMemo.name}")
-                                appendLine(memoBody)
-                                appendLine("=== 메모 끝 ===")
-                                appendLine()
-                                appendLine("사용자: $userMessage")
-                            }
-                            aiApiService.generateContentStream(prompt).collect { accumulated ->
-                                aiAssistStreamingText = accumulated
-                            }
-                            aiAssistStreamingText = null
-                            aiUsageDao.insert(AiUsage(feature = FEATURE_AI_ASSIST))
-                            dailyUsageCount++
-                        } catch (e: Exception) {
-                            aiAssistStreamingText = null
-                            if (e is kotlinx.coroutines.CancellationException) return@launch
-                        } finally {
-                            isAiAssistLoading = false
-                        }
-                    }
-                }
             )
+
+            // AI 직접 입력 바텀시트
+            if (showAiAssistSheet) {
+                me.pecos.memozy.presentation.screen.memo.components.AiAssistBottomSheet(
+                    messages = aiAssistMessages,
+                    streamingText = aiAssistStreamingText,
+                    isLoading = isAiAssistLoading,
+                    onSendMessage = { userMessage ->
+                        aiAssistMessages = aiAssistMessages + me.pecos.memozy.presentation.screen.memo.components.AiAssistMessage("user", userMessage)
+                        aiAssistJob?.cancel()
+                        aiAssistJob = scope.launch {
+                            isAiAssistLoading = true
+                            aiAssistStreamingText = ""
+                            try {
+                                val memoContent = finalMemo.content.replace(Regex("<[^>]*>"), "").trim()
+                                val memoBody = if (memoContent.length > MAX_MEMO_CONTEXT_CHARS) {
+                                    memoContent.take(2000) + "\n...(중략)...\n" + memoContent.takeLast(1000)
+                                } else memoContent
+                                val noMarkdownRule = "마크다운 문법(**, ##, - 등)을 절대 사용하지 마. 순수 텍스트로만 답해."
+                                val prompt = buildString {
+                                    appendLine("너는 만능 AI 어시스턴트야. 어떤 질문이든 친절하게 답해줘.")
+                                    appendLine("사용자가 현재 메모를 작성 중이니, 메모 내용이 있으면 참고해서 답해줘.")
+                                    appendLine("메모와 관련 없는 질문이어도 자유롭게 답변해. 답변은 간결하게. $noMarkdownRule")
+                                    appendLine()
+                                    if (memoBody.isNotBlank()) {
+                                        appendLine("=== 현재 메모 ===")
+                                        appendLine("제목: ${finalMemo.name}")
+                                        appendLine(memoBody)
+                                        appendLine("=== 메모 끝 ===")
+                                        appendLine()
+                                    }
+                                    appendLine("사용자: $userMessage")
+                                }
+                                aiApiService.generateContentStream(prompt).collect { accumulated ->
+                                    aiAssistStreamingText = accumulated
+                                }
+                                val finalText = aiAssistStreamingText ?: ""
+                                aiAssistStreamingText = null
+                                if (finalText.isNotBlank()) {
+                                    aiAssistMessages = aiAssistMessages + me.pecos.memozy.presentation.screen.memo.components.AiAssistMessage("assistant", finalText)
+                                }
+                                aiUsageDao.insert(AiUsage(feature = FEATURE_AI_ASSIST))
+                                dailyUsageCount++
+                            } catch (e: Exception) {
+                                aiAssistStreamingText = null
+                                if (e is kotlinx.coroutines.CancellationException) return@launch
+                            } finally {
+                                isAiAssistLoading = false
+                            }
+                        }
+                    },
+                    onInsertToMemo = { text ->
+                        // 본문에 삽입 — MemoScreen의 aiAssistStreamingText를 통해 전달
+                        aiAssistStreamingText = text
+                        // 짧은 딜레이 후 null로 → LaunchedEffect가 본문에 삽입 완료
+                        scope.launch {
+                            kotlinx.coroutines.delay(100)
+                            aiAssistStreamingText = null
+                        }
+                    },
+                    onDismiss = {
+                        aiAssistJob?.cancel()
+                        showAiAssistSheet = false
+                        aiAssistStreamingText = null
+                        isAiAssistLoading = false
+                    }
+                )
+            }
 
             if (showLimitBottomSheet) {
                 AiLimitBottomSheet(

--- a/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/MemoScreen.kt
+++ b/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/MemoScreen.kt
@@ -224,14 +224,11 @@ fun MemoScreen(
     webSummaryError: String? = null,
     webPageTitle: String? = null,
     onSummaryStyleSelected: ((SummaryStyle, String) -> Unit)? = null,
-    // AI 어시스트
-    onAiPresetAction: ((String) -> Unit)? = null,
-    onAiAssistSend: ((String) -> Unit)? = null,
-    showAiAssistInput: Boolean = false,
+    // AI 어시스트 — (actionName, currentTitle, currentBody)
+    onAiPresetAction: ((String, String, String) -> Unit)? = null,
     aiAssistStreamingText: String? = null,
     isAiAssistLoading: Boolean = false,
     onAiAssistClick: (() -> Unit)? = null,
-    onAiAssistClose: (() -> Unit)? = null,
     existingMemo: MemoUiState = MemoUiState(0, "", 1, "")
 ) {
     val isNewMemo = existingMemo.id <= 0
@@ -298,6 +295,9 @@ fun MemoScreen(
     var isSummaryExpanded by remember { mutableStateOf(if (initialSummary == null) true else existingMemo.isSummaryExpanded) }
     var webSummaryText by remember { mutableStateOf<String?>(null) }
     var isWebSummaryExpanded by remember { mutableStateOf(initialSummary == null) }
+
+    // 요약 삭제 확인 다이얼로그
+    var showSummaryDeleteDialog by remember { mutableStateOf<String?>(null) } // "youtube" or "web"
 
     // 요약 완료 시 별도 상태로 분리 (본문에 삽입하지 않음)
     var summaryApplied by remember { mutableStateOf(false) }
@@ -390,13 +390,14 @@ fun MemoScreen(
     val colors = LocalAppColors.current  // ← CompositionLocal에서 현재 테마 색상 가져옴
     val fontSettings = LocalFontSettings.current
 
+    var showAiActionMenu by remember { mutableStateOf(false) }
+
     // containerColor 명시 → MaterialTheme.colorScheme.surface 무시
     Scaffold(
         containerColor = colors.screenBackground,
         contentWindowInsets = WindowInsets(0)
     ) { innerPadding ->
         val isKeyboardVisible = WindowInsets.isImeVisible
-        var showAiActionMenu by remember { mutableStateOf(false) }
         val hazeState = rememberHazeState()
         val isSystemDark = colors.screenBackground == Color(0xFF1C1C1E)
         val glassStyle = remember(isSystemDark) {
@@ -587,8 +588,10 @@ fun MemoScreen(
                 }
 
                 // richTextState → bodyText 단순 동기화 (URL 감지/빈 체크용)
+                // AI 스트리밍 중에는 동기화 스킵 (bodyText 오염 방지)
                 LaunchedEffect(richTextState.annotatedString) {
                     if (!contentInitialized) return@LaunchedEffect
+                    if (aiAssistStreamingText != null) return@LaunchedEffect
                     val plainText = richTextState.annotatedString.text
                     if (plainText != bodyText) {
                         bodyText = plainText
@@ -620,6 +623,7 @@ fun MemoScreen(
                             currentSummaryMode = altMode
                             detectedYoutubeUrl?.let { onYoutubeSummarize?.invoke(it, altMode) }
                         },
+                        onDeleteSummary = { showSummaryDeleteDialog = "youtube" },
                         colors = colors,
                         context = context,
                         clipboardManager = clipboardManager,
@@ -659,6 +663,7 @@ fun MemoScreen(
                             currentSummaryMode = altMode
                             savedWebUrl?.let { onWebSummarize?.invoke(it, altMode) }
                         },
+                        onDeleteSummary = { showSummaryDeleteDialog = "web" },
                         colors = colors,
                         context = context,
                         clipboardManager = clipboardManager
@@ -835,16 +840,8 @@ fun MemoScreen(
                 ) {
                     HorizontalDivider(color = keyboardBarBorder, thickness = 0.5.dp)
 
-                    // AI 인라인 입력바 (직접 입력 모드)
-                    if (showAiAssistInput && onAiAssistSend != null) {
-                        AiAssistInlineBar(
-                            isLoading = isAiAssistLoading,
-                            onSend = onAiAssistSend,
-                            onClose = onAiAssistClose ?: {}
-                        )
-                    } else {
-                        // 액션 버튼 (왼쪽) + 서식 툴바 (오른쪽) — 한 줄 배치
-                        Box {
+                    // 액션 버튼 (왼쪽) + 서식 툴바 (오른쪽) — 한 줄 배치
+                    Box {
                             Row(
                                 modifier = Modifier
                                     .fillMaxWidth()
@@ -879,26 +876,25 @@ fun MemoScreen(
                                 Spacer(modifier = Modifier.weight(1f))
                                 FormattingToolbar(richTextState = richTextState, colors = colors)
                             }
-
-                            // AI 액션 메뉴 팝업
-                            if (showAiActionMenu && onAiPresetAction != null) {
-                                AiActionMenu(
-                                    onPresetSelected = { action ->
-                                        showAiActionMenu = false
-                                        if (action == AiPresetAction.CUSTOM) {
-                                            onAiAssistClick?.invoke()
-                                        } else {
-                                            onAiPresetAction(action.name)
-                                        }
-                                    },
-                                    onDismiss = { showAiActionMenu = false }
-                                )
-                            }
                         }
                     }
                 }
             }
         } // outer Column
+
+    // AI 액션 메뉴 팝업 — AnimatedVisibility 바깥에 배치 (���보드 내려가도 유지)
+    if (showAiActionMenu && onAiPresetAction != null) {
+        AiActionMenu(
+            onPresetSelected = { action ->
+                showAiActionMenu = false
+                if (action == AiPresetAction.CUSTOM) {
+                    onAiAssistClick?.invoke()
+                } else {
+                    onAiPresetAction(action.name, nameText, bodyText)
+                }
+            },
+            onDismiss = { showAiActionMenu = false }
+        )
     }
 
     // 웹 URL 입력 다이얼로그
@@ -938,74 +934,35 @@ fun MemoScreen(
             }
         )
     }
-}
 
-// AI 인라인 입력바 (직접 입력 모드)
-@Composable
-private fun AiAssistInlineBar(
-    isLoading: Boolean,
-    onSend: (String) -> Unit,
-    onClose: () -> Unit
-) {
-    val colors = LocalAppColors.current
-    val fontSettings = LocalFontSettings.current
-    var inputText by remember { mutableStateOf("") }
-
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 12.dp, vertical = 6.dp),
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        Icon(
-            Icons.Default.Close,
-            contentDescription = null,
-            tint = colors.textBody.copy(alpha = 0.5f),
-            modifier = Modifier
-                .size(20.dp)
-                .clickable { onClose() }
-        )
-
-        Spacer(modifier = Modifier.width(8.dp))
-
-        BasicTextField(
-            value = inputText,
-            onValueChange = { inputText = it },
-            modifier = Modifier.weight(1f),
-            textStyle = TextStyle(
-                color = colors.textBody,
-                fontSize = fontSettings.scaled(13)
-            ),
-            cursorBrush = androidx.compose.ui.graphics.SolidColor(colors.textTitle),
-            singleLine = true,
-            decorationBox = { innerTextField ->
-                Box {
-                    if (inputText.isEmpty()) {
-                        Text(
-                            text = if (isLoading) "AI 응답 중..." else "AI에게 부탁하기",
-                            color = colors.textBody.copy(alpha = 0.4f),
-                            fontSize = fontSettings.scaled(13)
-                        )
+    // 요약 삭제 확인 다이얼로그
+    if (showSummaryDeleteDialog != null) {
+        AlertDialog(
+            onDismissRequest = { showSummaryDeleteDialog = null },
+            title = { Text(stringResource(R.string.summary_delete_title)) },
+            text = { Text(stringResource(R.string.summary_delete_message)) },
+            confirmButton = {
+                TextButton(onClick = {
+                    when (showSummaryDeleteDialog) {
+                        "youtube" -> {
+                            summaryText = null
+                            summaryApplied = false
+                        }
+                        "web" -> {
+                            webSummaryText = null
+                            webSummaryApplied = false
+                        }
                     }
-                    innerTextField()
+                    showSummaryDeleteDialog = null
+                }) {
+                    Text(stringResource(R.string.summary_delete_action), color = Color.Red)
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showSummaryDeleteDialog = null }) {
+                    Text(stringResource(R.string.cancel))
                 }
             }
-        )
-
-        Spacer(modifier = Modifier.width(8.dp))
-
-        val canSend = inputText.isNotBlank() && !isLoading
-        Icon(
-            Icons.AutoMirrored.Filled.Send,
-            contentDescription = null,
-            tint = if (canSend) Color(0xFF7C4DFF) else colors.textBody.copy(alpha = 0.2f),
-            modifier = Modifier
-                .size(20.dp)
-                .clickable(enabled = canSend) {
-                    val text = inputText.trim()
-                    inputText = ""
-                    onSend(text)
-                }
         )
     }
 }

--- a/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/components/AiActionMenu.kt
+++ b/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/components/AiActionMenu.kt
@@ -5,22 +5,20 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.ElevatedCard
-import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.Popup
-import androidx.compose.ui.window.PopupProperties
 import me.pecos.memozy.presentation.theme.LocalAppColors
 import me.pecos.memozy.presentation.theme.LocalFontSettings
 
@@ -28,12 +26,13 @@ enum class AiPresetAction(
     val emoji: String,
     val label: String
 ) {
-    EXPLAIN("🤔", "이해하기 쉽게 설명해줘"),
-    ORGANIZE("📝", "깔끔하게 정리해줘"),
-    SUMMARIZE("✂️", "핵심만 요약해줘"),
-    CUSTOM("✏️", "직접 입력");
+    EXPLAIN("\uD83E\uDD14", "이해하기 쉽게 설명해줘"),
+    ORGANIZE("\uD83D\uDCDD", "깔끔하게 정리해줘"),
+    SUMMARIZE("✂\uFE0F", "핵심만 요약해줘"),
+    CUSTOM("✏\uFE0F", "직접 입력");
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AiActionMenu(
     onPresetSelected: (AiPresetAction) -> Unit,
@@ -43,45 +42,53 @@ fun AiActionMenu(
     val fontSettings = LocalFontSettings.current
     val view = LocalView.current
 
-    Popup(
-        alignment = Alignment.BottomStart,
+    ModalBottomSheet(
         onDismissRequest = onDismiss,
-        properties = PopupProperties(focusable = true)
+        sheetState = rememberModalBottomSheetState(),
+        containerColor = colors.cardBackground
     ) {
-        ElevatedCard(
-            shape = RoundedCornerShape(12.dp),
-            elevation = CardDefaults.elevatedCardElevation(defaultElevation = 8.dp),
-            colors = CardDefaults.elevatedCardColors(containerColor = colors.cardBackground)
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = 24.dp)
         ) {
-            Column(modifier = Modifier.padding(vertical = 4.dp)) {
-                AiPresetAction.entries.forEachIndexed { index, action ->
-                    Row(
-                        modifier = Modifier
-                            .clip(RoundedCornerShape(4.dp))
-                            .clickable {
-                                view.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP)
-                                onPresetSelected(action)
-                            }
-                            .padding(horizontal = 16.dp, vertical = 12.dp),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Text(
-                            text = action.emoji,
-                            fontSize = fontSettings.scaled(15)
-                        )
-                        Spacer(modifier = Modifier.width(10.dp))
-                        Text(
-                            text = action.label,
-                            fontSize = fontSettings.scaled(14),
-                            color = colors.textBody
-                        )
-                    }
-                    if (index < AiPresetAction.entries.size - 1) {
-                        HorizontalDivider(
-                            color = colors.chipBackground.copy(alpha = 0.3f),
-                            thickness = 0.5.dp
-                        )
-                    }
+            Text(
+                text = "AI 어시스트",
+                fontSize = fontSettings.scaled(16),
+                fontWeight = FontWeight.Bold,
+                color = colors.textTitle,
+                modifier = Modifier.padding(horizontal = 20.dp, vertical = 4.dp)
+            )
+            Spacer(modifier = Modifier.padding(top = 8.dp))
+
+            AiPresetAction.entries.forEachIndexed { index, action ->
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable {
+                            view.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP)
+                            onPresetSelected(action)
+                        }
+                        .padding(horizontal = 20.dp, vertical = 14.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = action.emoji,
+                        fontSize = fontSettings.scaled(18)
+                    )
+                    Spacer(modifier = Modifier.width(12.dp))
+                    Text(
+                        text = action.label,
+                        fontSize = fontSettings.scaled(15),
+                        color = colors.textBody
+                    )
+                }
+                if (index < AiPresetAction.entries.size - 1) {
+                    HorizontalDivider(
+                        color = colors.chipBackground.copy(alpha = 0.3f),
+                        thickness = 0.5.dp,
+                        modifier = Modifier.padding(horizontal = 20.dp)
+                    )
                 }
             }
         }

--- a/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/components/MemoDialogs.kt
+++ b/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/components/MemoDialogs.kt
@@ -1,5 +1,6 @@
 package me.pecos.memozy.presentation.screen.memo.components
 
+import android.content.ClipboardManager as AndroidClipboardManager
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
@@ -15,6 +16,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ContentPaste
 import androidx.compose.material.icons.filled.Link
 import androidx.compose.material.icons.filled.SmartDisplay
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -33,6 +35,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.ClipboardManager
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontWeight
@@ -51,6 +54,15 @@ private val YOUTUBE_URL_REGEX = Regex(
     """(?:https?://)?(?:www\.)?(?:youtube\.com/watch\?v=|youtu\.be/|youtube\.com/shorts/)[\w\-]+(?:[&?][\w\-=]*)*"""
 )
 
+private val WEB_URL_REGEX = Regex(
+    """https?://\S+"""
+)
+
+private fun getSystemClipboardText(context: Context): String {
+    val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as? AndroidClipboardManager
+    return clipboard?.primaryClip?.getItemAt(0)?.text?.toString() ?: ""
+}
+
 @Composable
 fun YouTubeUrlDialog(
     colors: AppColors,
@@ -61,7 +73,7 @@ fun YouTubeUrlDialog(
 ) {
     val fontSettings = LocalFontSettings.current
     var urlInput by remember { mutableStateOf("") }
-    val clipText = clipboardManager.getText()?.text ?: ""
+    val clipText = remember { getSystemClipboardText(context) }
     val isValid = YOUTUBE_URL_REGEX.containsMatchIn(urlInput)
 
     AppPopup(
@@ -88,19 +100,21 @@ fun YouTubeUrlDialog(
             Spacer(modifier = Modifier.height(8.dp))
             Row(
                 modifier = Modifier
+                    .fillMaxWidth()
                     .clip(RoundedCornerShape(8.dp))
-                    .background(colors.chipBackground.copy(alpha = 0.6f))
-                    .clickable { urlInput = clipText }
-                    .padding(horizontal = 10.dp, vertical = 6.dp),
+                    .background(Color(0xFF2196F3).copy(alpha = 0.08f))
+                    .clickable { urlInput = YOUTUBE_URL_REGEX.find(clipText)?.value ?: clipText }
+                    .padding(horizontal = 10.dp, vertical = 8.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 Icon(
-                    Icons.Default.Link, contentDescription = null,
-                    tint = Color(0xFF2196F3), modifier = Modifier.size(14.dp)
+                    Icons.Default.ContentPaste, contentDescription = null,
+                    tint = Color(0xFF2196F3), modifier = Modifier.size(16.dp)
                 )
-                Spacer(modifier = Modifier.width(6.dp))
+                Spacer(modifier = Modifier.width(8.dp))
                 Text(
-                    text = clipText, fontSize = fontSettings.scaled(12),
+                    text = YOUTUBE_URL_REGEX.find(clipText)?.value ?: clipText,
+                    fontSize = fontSettings.scaled(12),
                     color = Color(0xFF2196F3), fontWeight = FontWeight.Medium,
                     maxLines = 1, overflow = TextOverflow.Ellipsis
                 )
@@ -141,9 +155,10 @@ fun WebUrlDialog(
     onDismiss: () -> Unit,
     onUrlConfirmed: (String) -> Unit
 ) {
+    val context = LocalContext.current
     val fontSettings = LocalFontSettings.current
     var webUrlInput by remember { mutableStateOf("") }
-    val clipText = clipboardManager.getText()?.text ?: ""
+    val clipText = remember { getSystemClipboardText(context) }
     val colors = me.pecos.memozy.presentation.theme.LocalAppColors.current
     val isValid = webUrlInput.startsWith("http")
 
@@ -167,23 +182,26 @@ fun WebUrlDialog(
             placeholder = { Text("https://...", fontSize = fontSettings.scaled(14)) },
             singleLine = true, modifier = Modifier.fillMaxWidth()
         )
-        if (clipText.isNotBlank() && webUrlInput.isBlank() && clipText.trimStart().startsWith("http")) {
+        val webClipUrl = remember(clipText) { WEB_URL_REGEX.find(clipText)?.value }
+        val isWebUrl = webClipUrl != null && !YOUTUBE_URL_REGEX.containsMatchIn(webClipUrl)
+        if (webUrlInput.isBlank() && isWebUrl) {
             Spacer(modifier = Modifier.height(8.dp))
             Row(
                 modifier = Modifier
+                    .fillMaxWidth()
                     .clip(RoundedCornerShape(8.dp))
-                    .background(colors.chipBackground.copy(alpha = 0.6f))
-                    .clickable { webUrlInput = clipText }
-                    .padding(horizontal = 10.dp, vertical = 6.dp),
+                    .background(Color(0xFF2196F3).copy(alpha = 0.08f))
+                    .clickable { webUrlInput = webClipUrl }
+                    .padding(horizontal = 10.dp, vertical = 8.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 Icon(
-                    Icons.Default.Link, contentDescription = null,
-                    tint = Color(0xFF2196F3), modifier = Modifier.size(14.dp)
+                    Icons.Default.ContentPaste, contentDescription = null,
+                    tint = Color(0xFF2196F3), modifier = Modifier.size(16.dp)
                 )
-                Spacer(modifier = Modifier.width(6.dp))
+                Spacer(modifier = Modifier.width(8.dp))
                 Text(
-                    text = clipText, fontSize = fontSettings.scaled(12),
+                    text = webClipUrl, fontSize = fontSettings.scaled(12),
                     color = Color(0xFF2196F3), fontWeight = FontWeight.Medium,
                     maxLines = 1, overflow = TextOverflow.Ellipsis
                 )

--- a/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/components/WebSummaryInlineCard.kt
+++ b/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/components/WebSummaryInlineCard.kt
@@ -7,6 +7,7 @@ import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -53,6 +54,7 @@ fun WebSummaryInlineCard(
     onSummarize: ((String, SummaryMode) -> Unit)?,
     onCancelSummarize: (() -> Unit)?,
     onResummarize: (SummaryMode) -> Unit,
+    onDeleteSummary: (() -> Unit)? = null,
     colors: AppColors,
     context: Context,
     clipboardManager: ClipboardManager
@@ -76,6 +78,7 @@ fun WebSummaryInlineCard(
 
     // 펼친 상태
     if (isExpanded) {
+        Box(modifier = Modifier.fillMaxWidth()) {
         Column(
             modifier = Modifier.fillMaxWidth().clip(RoundedCornerShape(12.dp))
                 .background(colors.cardBackground).padding(16.dp)
@@ -199,6 +202,20 @@ fun WebSummaryInlineCard(
                     Text("▼ ${stringResource(R.string.summary_collapse)}", fontSize = fontSettings.scaled(12), color = colors.textSecondary)
                 }
             }
+        }
+        // X 삭제 버튼 (요약 있을 때만)
+        if (summaryText != null && onDeleteSummary != null) {
+            Icon(
+                Icons.Default.Close,
+                contentDescription = null,
+                tint = colors.textSecondary,
+                modifier = Modifier
+                    .size(28.dp)
+                    .align(Alignment.TopEnd)
+                    .padding(6.dp)
+                    .clickable { onDeleteSummary() }
+            )
+        }
         }
         Spacer(modifier = Modifier.height(12.dp))
     }

--- a/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/components/YouTubeSummaryInlineCard.kt
+++ b/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/components/YouTubeSummaryInlineCard.kt
@@ -7,6 +7,7 @@ import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -56,6 +57,7 @@ fun YouTubeSummaryInlineCard(
     onSummarize: ((String, SummaryMode) -> Unit)?,
     onCancelSummarize: (() -> Unit)?,
     onResummarize: (SummaryMode) -> Unit,
+    onDeleteSummary: (() -> Unit)? = null,
     colors: AppColors,
     context: Context,
     clipboardManager: ClipboardManager,
@@ -80,6 +82,7 @@ fun YouTubeSummaryInlineCard(
 
     // 펼친 상태
     if (isExpanded) {
+        Box(modifier = Modifier.fillMaxWidth()) {
         Column(
             modifier = Modifier.fillMaxWidth().clip(RoundedCornerShape(12.dp)).background(colors.cardBackground)
         ) {
@@ -217,6 +220,20 @@ fun YouTubeSummaryInlineCard(
                     }
                 }
             }
+        }
+        // X 삭제 버튼 (요약 있을 때만)
+        if (summaryText != null && onDeleteSummary != null) {
+            Icon(
+                Icons.Default.Close,
+                contentDescription = null,
+                tint = colors.textSecondary,
+                modifier = Modifier
+                    .size(28.dp)
+                    .align(Alignment.TopEnd)
+                    .padding(6.dp)
+                    .clickable { onDeleteSummary() }
+            )
+        }
         }
         Spacer(modifier = Modifier.height(12.dp))
     }


### PR DESCRIPTION
## Summary
- 요약 카드(유튜브/웹)에 삭제 X 버튼 + 확인 다이얼로그 추가
- URL 입력 다이얼로그 클립보드 붙여넣기 시스템 API로 수정 (Android 13+ 호환)
- AI 액션 메뉴를 Popup → ModalBottomSheet로 전환 (리플 범위 균일화)
- AI 메뉴 뜨자마자 사라지는 버그 수정 (키보드 포커스 충돌)
- AI가 현재 편집 중인 본문을 읽도록 수정 (초기값 → 실시간 본문 전달)
- AI 응답 마크다운 금지 프롬프트 추가
- 스트리밍 중 bodyText 동기화 경쟁 조건 수정
- 직접 입력을 인라인 바 → AiAssistBottomSheet 대화창으로 전환

## Test plan
- [ ] 유튜브 요약 후 X 버튼으로 삭제 → 확인 다이얼로그 동작 확인
- [ ] 웹 요약 후 X 버튼으로 삭제 → 확인 다이얼로그 동작 확인
- [ ] 유튜브 URL 복사 후 다이얼로그 열기 → 클립보드 버튼 표시 확인
- [ ] 웹 URL 복사 후 다이얼로그 열기 → 클립보드 버튼 표시 확인 (유튜브 URL 제외)
- [ ] AI 버튼 → 바텀시트 메뉴 정상 표시 (사라지지 않음)
- [ ] 설명/정리/요약 프리셋 → 현재 본문 기반 응답 + 끊김 없이 완료
- [ ] 직접 입력 → 바텀시트 대화창 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)