### PR TITLE
Update: Memozy AI 리브랜딩 + 직접입력 본문 삽입 + UX 개선

### DIFF
--- a/feature/memo-plain/impl/src/main/java/me/pecos/memozy/feature/memoplain/impl/MemoPlainNavigationImpl.kt
+++ b/feature/memo-plain/impl/src/main/java/me/pecos/memozy/feature/memoplain/impl/MemoPlainNavigationImpl.kt
@@ -81,6 +81,15 @@ class MemoPlainNavigationImpl @Inject constructor(
         private const val MAX_DAILY_AD_VIEWS = 3
         private const val MAX_MEMO_CONTEXT_CHARS = 3000
 
+        private fun stripMarkdown(text: String): String = text
+            .replace(Regex("""^\s*#{1,6}\s+""", RegexOption.MULTILINE), "")  // ### 제목
+            .replace(Regex("""\*\*(.+?)\*\*"""), "$1")                       // **볼드**
+            .replace(Regex("""\*(.+?)\*"""), "$1")                           // *이탤릭*
+            .replace(Regex("""~~(.+?)~~"""), "$1")                           // ~~취소선~~
+            .replace(Regex("""^[-*+]\s+""", RegexOption.MULTILINE), "• ")   // - 리스트 → •
+            .replace(Regex("""^\d+\.\s+""", RegexOption.MULTILINE), "")     // 1. 번호 리스트
+            .replace(Regex("""`(.+?)`"""), "$1")                             // `코드`
+
         private fun startOfToday(): Long {
             return Calendar.getInstance().apply {
                 set(Calendar.HOUR_OF_DAY, 0)
@@ -430,9 +439,7 @@ class MemoPlainNavigationImpl @Inject constructor(
                 }
             }
 
-            // AI 어시스트 상태
-            var showAiAssistSheet by remember { mutableStateOf(false) }
-            var aiAssistMessages by remember { mutableStateOf(listOf<me.pecos.memozy.presentation.screen.memo.components.AiAssistMessage>()) }
+            // Memozy AI 상태
             var aiAssistStreamingText by remember { mutableStateOf<String?>(null) }
             var isAiAssistLoading by remember { mutableStateOf(false) }
             var aiAssistJob by remember { mutableStateOf<kotlinx.coroutines.Job?>(null) }
@@ -819,14 +826,52 @@ class MemoPlainNavigationImpl @Inject constructor(
                         onNavigateToHome()
                     }
                 } else null,
-                // AI 어시스트
+                // Memozy AI
                 aiAssistStreamingText = aiAssistStreamingText,
                 isAiAssistLoading = isAiAssistLoading,
-                onAiAssistClick = {
+                onAiCustomSend = { userMessage, currentTitle, currentBody ->
                     if (!canUseAi) {
                         showLimitBottomSheet = true
-                    } else {
-                        showAiAssistSheet = true
+                        return@MemoScreen
+                    }
+                    aiAssistJob?.cancel()
+                    aiAssistJob = scope.launch {
+                        isAiAssistLoading = true
+                        aiAssistStreamingText = ""
+                        try {
+                            val plainBody = currentBody.replace(Regex("<[^>]*>"), "").trim()
+                            val memoBody = if (plainBody.length > MAX_MEMO_CONTEXT_CHARS) {
+                                plainBody.take(2000) + "\n...(중략)...\n" + plainBody.takeLast(1000)
+                            } else plainBody
+                            val systemRole = "너는 Memozy AI야. 메모지 앱의 AI 어시스턴트로, 사용자의 메모 작성을 돕는 게 너의 역할이야. 너의 이름은 'Memozy AI'이고, 다른 AI 서비스의 이름으로 자신을 소개하면 안 돼. 사용자가 '너 누구야?' 등 정체를 물어볼 때만 'Memozy AI입니다! 메모 작성을 도와드릴게요' 라고 답해. 그 외에는 자기소개 없이 바로 답변해."
+                            val noMarkdownRule = "마크다운 문법(**, ##, - 등)을 절대 사용하지 마. 순수 텍스트로만 답해."
+                            val prompt = buildString {
+                                appendLine(systemRole)
+                                appendLine("어떤 질문이든 친절하게 답해줘.")
+                                appendLine("사용자가 현재 메모를 작성 중이니, 메모 내용이 있으면 참고해서 답해줘.")
+                                appendLine("메모와 관련 없는 질문이어도 자유롭게 답변해. 답변은 간결하게. $noMarkdownRule")
+                                appendLine()
+                                if (memoBody.isNotBlank()) {
+                                    appendLine("=== 현재 메모 ===")
+                                    appendLine("제목: $currentTitle")
+                                    appendLine(memoBody)
+                                    appendLine("=== 메모 끝 ===")
+                                    appendLine()
+                                }
+                                appendLine("사용자: $userMessage")
+                            }
+                            aiApiService.generateContentStream(prompt).collect { accumulated ->
+                                aiAssistStreamingText = stripMarkdown(accumulated)
+                            }
+                            aiAssistStreamingText = null
+                            aiUsageDao.insert(AiUsage(feature = FEATURE_AI_ASSIST))
+                            dailyUsageCount++
+                        } catch (e: Exception) {
+                            aiAssistStreamingText = null
+                            if (e is kotlinx.coroutines.CancellationException) return@launch
+                        } finally {
+                            isAiAssistLoading = false
+                        }
                     }
                 },
                 onAiPresetAction = { actionName, currentTitle, currentBody ->
@@ -847,10 +892,11 @@ class MemoPlainNavigationImpl @Inject constructor(
                                 aiAssistStreamingText = null
                                 return@launch
                             }
+                            val systemRole = "너는 Memozy AI야. 메모지 앱의 AI 어시스턴트로, 사용자의 메모 작성을 돕는 게 너의 역할이야. 너의 이름은 'Memozy AI'이고, 다른 AI 서비스의 이름으로 자신을 소개하면 안 돼. 사용자가 '너 누구야?' 등 정체를 물어볼 때만 'Memozy AI입니다! 메모 작성을 도와드릴게요' 라고 답해. 그 외에는 자기소개 없이 바로 답변해."
                             val noMarkdownRule = "마크다운 문법(**, ##, - 등)을 절대 사용하지 마. 순수 텍스트로만 답해."
                             val prompt = when (actionName) {
                                 "EXPLAIN" -> buildString {
-                                    appendLine("너는 메모 편집 AI 어시스턴트야.")
+                                    appendLine(systemRole)
                                     appendLine("아래 메모 내용을 이해하기 쉽게 풀어서 설명해줘. 어려운 용어가 있으면 쉬운 말로 바꿔줘.")
                                     appendLine("설명문만 출력해. $noMarkdownRule")
                                     appendLine()
@@ -859,7 +905,7 @@ class MemoPlainNavigationImpl @Inject constructor(
                                     appendLine(memoBody)
                                 }
                                 "ORGANIZE" -> buildString {
-                                    appendLine("너는 메모 편집 AI 어시스턴트야.")
+                                    appendLine(systemRole)
                                     appendLine("아래 메모 내용을 깔끔하게 정리해줘. 구조화하고 가독성을 높여줘.")
                                     appendLine("정리된 텍스트만 출력해. $noMarkdownRule")
                                     appendLine()
@@ -868,7 +914,7 @@ class MemoPlainNavigationImpl @Inject constructor(
                                     appendLine(memoBody)
                                 }
                                 "SUMMARIZE" -> buildString {
-                                    appendLine("너는 메모 편집 AI 어시스턴트야.")
+                                    appendLine(systemRole)
                                     appendLine("아래 메모 내용의 핵심만 간결하게 요약해줘. 원문의 1/3 이하로 줄여줘.")
                                     appendLine("요약문만 출력해. $noMarkdownRule")
                                     appendLine()
@@ -879,7 +925,7 @@ class MemoPlainNavigationImpl @Inject constructor(
                                 else -> return@launch
                             }
                             aiApiService.generateContentStream(prompt).collect { accumulated ->
-                                aiAssistStreamingText = accumulated
+                                aiAssistStreamingText = stripMarkdown(accumulated)
                             }
                             aiAssistStreamingText = null
                             aiUsageDao.insert(AiUsage(feature = FEATURE_AI_ASSIST))
@@ -893,74 +939,6 @@ class MemoPlainNavigationImpl @Inject constructor(
                     }
                 },
             )
-
-            // AI 직접 입력 바텀시트
-            if (showAiAssistSheet) {
-                me.pecos.memozy.presentation.screen.memo.components.AiAssistBottomSheet(
-                    messages = aiAssistMessages,
-                    streamingText = aiAssistStreamingText,
-                    isLoading = isAiAssistLoading,
-                    onSendMessage = { userMessage ->
-                        aiAssistMessages = aiAssistMessages + me.pecos.memozy.presentation.screen.memo.components.AiAssistMessage("user", userMessage)
-                        aiAssistJob?.cancel()
-                        aiAssistJob = scope.launch {
-                            isAiAssistLoading = true
-                            aiAssistStreamingText = ""
-                            try {
-                                val memoContent = finalMemo.content.replace(Regex("<[^>]*>"), "").trim()
-                                val memoBody = if (memoContent.length > MAX_MEMO_CONTEXT_CHARS) {
-                                    memoContent.take(2000) + "\n...(중략)...\n" + memoContent.takeLast(1000)
-                                } else memoContent
-                                val noMarkdownRule = "마크다운 문법(**, ##, - 등)을 절대 사용하지 마. 순수 텍스트로만 답해."
-                                val prompt = buildString {
-                                    appendLine("너는 만능 AI 어시스턴트야. 어떤 질문이든 친절하게 답해줘.")
-                                    appendLine("사용자가 현재 메모를 작성 중이니, 메모 내용이 있으면 참고해서 답해줘.")
-                                    appendLine("메모와 관련 없는 질문이어도 자유롭게 답변해. 답변은 간결하게. $noMarkdownRule")
-                                    appendLine()
-                                    if (memoBody.isNotBlank()) {
-                                        appendLine("=== 현재 메모 ===")
-                                        appendLine("제목: ${finalMemo.name}")
-                                        appendLine(memoBody)
-                                        appendLine("=== 메모 끝 ===")
-                                        appendLine()
-                                    }
-                                    appendLine("사용자: $userMessage")
-                                }
-                                aiApiService.generateContentStream(prompt).collect { accumulated ->
-                                    aiAssistStreamingText = accumulated
-                                }
-                                val finalText = aiAssistStreamingText ?: ""
-                                aiAssistStreamingText = null
-                                if (finalText.isNotBlank()) {
-                                    aiAssistMessages = aiAssistMessages + me.pecos.memozy.presentation.screen.memo.components.AiAssistMessage("assistant", finalText)
-                                }
-                                aiUsageDao.insert(AiUsage(feature = FEATURE_AI_ASSIST))
-                                dailyUsageCount++
-                            } catch (e: Exception) {
-                                aiAssistStreamingText = null
-                                if (e is kotlinx.coroutines.CancellationException) return@launch
-                            } finally {
-                                isAiAssistLoading = false
-                            }
-                        }
-                    },
-                    onInsertToMemo = { text ->
-                        // 본문에 삽입 — MemoScreen의 aiAssistStreamingText를 통해 전달
-                        aiAssistStreamingText = text
-                        // 짧은 딜레이 후 null로 → LaunchedEffect가 본문에 삽입 완료
-                        scope.launch {
-                            kotlinx.coroutines.delay(100)
-                            aiAssistStreamingText = null
-                        }
-                    },
-                    onDismiss = {
-                        aiAssistJob?.cancel()
-                        showAiAssistSheet = false
-                        aiAssistStreamingText = null
-                        isAiAssistLoading = false
-                    }
-                )
-            }
 
             if (showLimitBottomSheet) {
                 AiLimitBottomSheet(

--- a/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/MemoScreen.kt
+++ b/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/MemoScreen.kt
@@ -224,11 +224,11 @@ fun MemoScreen(
     webSummaryError: String? = null,
     webPageTitle: String? = null,
     onSummaryStyleSelected: ((SummaryStyle, String) -> Unit)? = null,
-    // AI 어시스트 — (actionName, currentTitle, currentBody)
+    // Memozy AI — (actionName, currentTitle, currentBody)
     onAiPresetAction: ((String, String, String) -> Unit)? = null,
+    onAiCustomSend: ((String, String, String) -> Unit)? = null,
     aiAssistStreamingText: String? = null,
     isAiAssistLoading: Boolean = false,
-    onAiAssistClick: (() -> Unit)? = null,
     existingMemo: MemoUiState = MemoUiState(0, "", 1, "")
 ) {
     val isNewMemo = existingMemo.id <= 0
@@ -332,21 +332,37 @@ fun MemoScreen(
         }
     }
 
-    // AI 어시스트 스트리밍 → 본문 끝에 실시간 반영
-    var aiInsertAnchor by remember { mutableStateOf("") }
+    // Memozy AI 스트리밍 → 본문 끝에 실시간 반영
+    var aiInsertAnchorHtml by remember { mutableStateOf("") }
+    var aiInsertAnchorPlain by remember { mutableStateOf("") }
     var prevStreamingText by remember { mutableStateOf<String?>(null) }
     LaunchedEffect(aiAssistStreamingText) {
         val streaming = aiAssistStreamingText
         if (streaming != null) {
             if (prevStreamingText == null) {
-                aiInsertAnchor = bodyText
+                // 스트리밍 시작 — 현재 본문을 앵커로 저장
+                aiInsertAnchorHtml = richTextState.toHtml()
+                aiInsertAnchorPlain = richTextState.annotatedString.text
             }
-            val separator = if (aiInsertAnchor.isBlank()) "" else "\n\n"
-            val newBody = aiInsertAnchor + separator + streaming
-            bodyText = newBody
-            richTextState.setHtml(newBody.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace("\n", "<br>"))
+            // 스트리밍 중에는 bodyText만 업데이트 (에디터는 건드리지 않음)
+            val separator = if (aiInsertAnchorPlain.isBlank()) "" else "\n\n"
+            bodyText = aiInsertAnchorPlain + separator + streaming
         } else if (prevStreamingText != null) {
-            aiInsertAnchor = ""
+            // 스트리밍 완료 — richTextState에 최종 결과 한 번만 반영
+            val aiText = prevStreamingText ?: ""
+            if (aiText.isNotBlank()) {
+                val escapedAi = aiText.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace("\n", "<br>")
+                val anchorHtml = aiInsertAnchorHtml.trimEnd()
+                val finalHtml = if (anchorHtml.isBlank() || anchorHtml == "<p><br></p>") {
+                    "<p>$escapedAi</p>"
+                } else {
+                    "$anchorHtml<p><br></p><p>$escapedAi</p>"
+                }
+                richTextState.setHtml(finalHtml)
+                bodyText = richTextState.annotatedString.text
+            }
+            aiInsertAnchorHtml = ""
+            aiInsertAnchorPlain = ""
         }
         prevStreamingText = streaming
     }
@@ -391,6 +407,7 @@ fun MemoScreen(
     val fontSettings = LocalFontSettings.current
 
     var showAiActionMenu by remember { mutableStateOf(false) }
+    var showAiCustomInput by remember { mutableStateOf(false) }
 
     // containerColor 명시 → MaterialTheme.colorScheme.surface 무시
     Scaffold(
@@ -500,11 +517,12 @@ fun MemoScreen(
             }
 
             // 본문 영역 — 탭하면 바로 편집 가능
+            val scrollState = rememberScrollState()
             Column(
                 modifier = Modifier
                     .weight(1f)
                     .hazeSource(hazeState)
-                    .verticalScroll(rememberScrollState())
+                    .verticalScroll(scrollState)
                     .padding(horizontal = 32.dp, vertical = 16.dp)
             ) {
                 // 제목 — 개행 시 내용으로 포커스 이동
@@ -624,6 +642,7 @@ fun MemoScreen(
                             detectedYoutubeUrl?.let { onYoutubeSummarize?.invoke(it, altMode) }
                         },
                         onDeleteSummary = { showSummaryDeleteDialog = "youtube" },
+                        onAskAi = if (onAiCustomSend != null) { { showAiCustomInput = true } } else null,
                         colors = colors,
                         context = context,
                         clipboardManager = clipboardManager,
@@ -664,6 +683,7 @@ fun MemoScreen(
                             savedWebUrl?.let { onWebSummarize?.invoke(it, altMode) }
                         },
                         onDeleteSummary = { showSummaryDeleteDialog = "web" },
+                        onAskAi = if (onAiCustomSend != null) { { showAiCustomInput = true } } else null,
                         colors = colors,
                         context = context,
                         clipboardManager = clipboardManager
@@ -704,6 +724,74 @@ fun MemoScreen(
                         }
                     }
                 )
+
+                // Memozy AI 직접 입력바 (본문 내 인라인)
+                LaunchedEffect(showAiCustomInput) {
+                    if (showAiCustomInput) {
+                        kotlinx.coroutines.delay(150) // 입력바 렌더링 대기
+                        scrollState.animateScrollTo(scrollState.maxValue)
+                    }
+                }
+                if (showAiCustomInput && onAiCustomSend != null) {
+                    var aiInputText by remember { mutableStateOf("") }
+                    Spacer(modifier = Modifier.height(12.dp))
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clip(RoundedCornerShape(12.dp))
+                            .background(colors.chipBackground.copy(alpha = 0.4f))
+                            .padding(horizontal = 12.dp, vertical = 8.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        BasicTextField(
+                            value = aiInputText,
+                            onValueChange = { aiInputText = it },
+                            modifier = Modifier.weight(1f),
+                            textStyle = TextStyle(
+                                color = colors.textBody,
+                                fontSize = fontSettings.scaled(14)
+                            ),
+                            cursorBrush = androidx.compose.ui.graphics.SolidColor(colors.textTitle),
+                            singleLine = true,
+                            decorationBox = { innerTextField ->
+                                Box(contentAlignment = Alignment.CenterStart) {
+                                    if (aiInputText.isEmpty()) {
+                                        Text(
+                                            "Memozy AI에게 물어보세요",
+                                            color = colors.textBody.copy(alpha = 0.4f),
+                                            fontSize = fontSettings.scaled(14)
+                                        )
+                                    }
+                                    innerTextField()
+                                }
+                            }
+                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+                        val canSend = aiInputText.isNotBlank() && !isAiAssistLoading
+                        Icon(
+                            Icons.AutoMirrored.Filled.Send,
+                            contentDescription = null,
+                            tint = if (canSend) Color(0xFF7C4DFF) else colors.textBody.copy(alpha = 0.2f),
+                            modifier = Modifier
+                                .size(20.dp)
+                                .clickable(enabled = canSend) {
+                                    val text = aiInputText.trim()
+                                    aiInputText = ""
+                                    onAiCustomSend(text, nameText, bodyText)
+                                }
+                        )
+                        Spacer(modifier = Modifier.width(4.dp))
+                        Icon(
+                            Icons.Default.Close,
+                            contentDescription = null,
+                            tint = colors.textBody.copy(alpha = 0.5f),
+                            modifier = Modifier
+                                .size(18.dp)
+                                .clickable { showAiCustomInput = false }
+                        )
+                    }
+                    Spacer(modifier = Modifier.height(8.dp))
+                }
 
                 // URL 감지 시 제목 가져오기
                 LaunchedEffect(detectedYoutubeUrl) {
@@ -869,9 +957,9 @@ fun MemoScreen(
                                     onYoutubeDialogOpen = { showYoutubeDialog = true },
                                     onWebSummarize = onWebSummarize,
                                     onWebDialogOpen = { showWebDialog = true },
-                                    onAiAssistClick = onAiAssistClick?.let { click ->
+                                    onAiAssistClick = if (onAiPresetAction != null) {
                                         { showAiActionMenu = true }
-                                    }
+                                    } else null
                                 )
                                 Spacer(modifier = Modifier.weight(1f))
                                 FormattingToolbar(richTextState = richTextState, colors = colors)
@@ -888,7 +976,7 @@ fun MemoScreen(
             onPresetSelected = { action ->
                 showAiActionMenu = false
                 if (action == AiPresetAction.CUSTOM) {
-                    onAiAssistClick?.invoke()
+                    showAiCustomInput = true
                 } else {
                     onAiPresetAction(action.name, nameText, bodyText)
                 }

--- a/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/components/AiActionMenu.kt
+++ b/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/components/AiActionMenu.kt
@@ -53,7 +53,7 @@ fun AiActionMenu(
                 .padding(bottom = 24.dp)
         ) {
             Text(
-                text = "AI 어시스트",
+                text = "Memozy AI",
                 fontSize = fontSettings.scaled(16),
                 fontWeight = FontWeight.Bold,
                 color = colors.textTitle,

--- a/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/components/AiAssistBottomSheet.kt
+++ b/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/components/AiAssistBottomSheet.kt
@@ -94,7 +94,7 @@ fun AiAssistBottomSheet(
         ) {
             // 헤더
             Text(
-                text = "AI 어시스트",
+                text = "Memozy AI",
                 fontSize = fontSettings.scaled(16),
                 fontWeight = FontWeight.Bold,
                 color = colors.textTitle,
@@ -140,7 +140,7 @@ fun AiAssistBottomSheet(
                     .fillMaxWidth()
                     .clip(RoundedCornerShape(24.dp))
                     .background(colors.chipBackground.copy(alpha = 0.3f))
-                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                    .padding(horizontal = 16.dp, vertical = 10.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 BasicTextField(
@@ -155,10 +155,12 @@ fun AiAssistBottomSheet(
                     singleLine = false,
                     maxLines = 3,
                     decorationBox = { innerTextField ->
-                        Box {
+                        Box(
+                            contentAlignment = Alignment.CenterStart
+                        ) {
                             if (inputText.isEmpty()) {
                                 Text(
-                                    text = "무엇이든 물어보세요",
+                                    text = "Memozy AI에게 물어보세요",
                                     color = colors.textBody.copy(alpha = 0.4f),
                                     fontSize = fontSettings.scaled(14)
                                 )

--- a/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/components/WebSummaryInlineCard.kt
+++ b/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/components/WebSummaryInlineCard.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.AutoFixHigh
 import androidx.compose.material.icons.filled.Link
 import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material3.CircularProgressIndicator
@@ -55,6 +56,7 @@ fun WebSummaryInlineCard(
     onCancelSummarize: (() -> Unit)?,
     onResummarize: (SummaryMode) -> Unit,
     onDeleteSummary: (() -> Unit)? = null,
+    onAskAi: (() -> Unit)? = null,
     colors: AppColors,
     context: Context,
     clipboardManager: ClipboardManager
@@ -172,22 +174,44 @@ fun WebSummaryInlineCard(
                 Spacer(modifier = Modifier.height(8.dp))
                 Text(summaryText, fontSize = fontSettings.scaled(14), lineHeight = 22.sp, color = colors.textBody)
 
-                // 요약 내용 복사 버튼
+                // 요약 내용 복사 + AI 물어보기 버튼
                 Spacer(modifier = Modifier.height(8.dp))
                 Row(
-                    modifier = Modifier
-                        .clip(RoundedCornerShape(6.dp))
-                        .background(colors.chipBackground)
-                        .clickable {
-                            clipboardManager.setText(AnnotatedString(summaryText))
-                            Toast.makeText(context, context.getString(R.string.memo_copy_done), Toast.LENGTH_SHORT).show()
-                        }
-                        .padding(horizontal = 10.dp, vertical = 5.dp),
-                    verticalAlignment = Alignment.CenterVertically
+                    horizontalArrangement = Arrangement.spacedBy(6.dp)
                 ) {
-                    Icon(Icons.Default.ContentCopy, null, tint = colors.chipText, modifier = Modifier.size(12.dp))
-                    Spacer(modifier = Modifier.width(4.dp))
-                    Text(stringResource(R.string.summary_copy), fontSize = fontSettings.scaled(10), color = colors.chipText, fontWeight = FontWeight.Medium)
+                    Row(
+                        modifier = Modifier
+                            .weight(1f)
+                            .clip(RoundedCornerShape(6.dp))
+                            .background(colors.chipBackground)
+                            .clickable {
+                                clipboardManager.setText(AnnotatedString(summaryText))
+                                Toast.makeText(context, context.getString(R.string.memo_copy_done), Toast.LENGTH_SHORT).show()
+                            }
+                            .padding(vertical = 6.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.Center
+                    ) {
+                        Icon(Icons.Default.ContentCopy, null, tint = colors.chipText, modifier = Modifier.size(12.dp))
+                        Spacer(modifier = Modifier.width(4.dp))
+                        Text(stringResource(R.string.summary_copy), fontSize = fontSettings.scaled(10), color = colors.chipText, fontWeight = FontWeight.Medium)
+                    }
+                    if (onAskAi != null) {
+                        Row(
+                            modifier = Modifier
+                                .weight(1f)
+                                .clip(RoundedCornerShape(6.dp))
+                                .background(Color(0xFF7C4DFF).copy(alpha = 0.1f))
+                                .clickable { onAskAi() }
+                                .padding(vertical = 6.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.Center
+                        ) {
+                            Icon(Icons.Default.AutoFixHigh, null, tint = Color(0xFF7C4DFF), modifier = Modifier.size(12.dp))
+                            Spacer(modifier = Modifier.width(4.dp))
+                            Text("Memozy AI", fontSize = fontSettings.scaled(10), color = Color(0xFF7C4DFF), fontWeight = FontWeight.Medium)
+                        }
+                    }
                 }
             }
 

--- a/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/components/YouTubeSummaryInlineCard.kt
+++ b/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/components/YouTubeSummaryInlineCard.kt
@@ -20,8 +20,9 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
-import androidx.compose.material.icons.filled.Link
 import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material.icons.filled.Link
+import androidx.compose.material.icons.filled.AutoFixHigh
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -58,6 +59,7 @@ fun YouTubeSummaryInlineCard(
     onCancelSummarize: (() -> Unit)?,
     onResummarize: (SummaryMode) -> Unit,
     onDeleteSummary: (() -> Unit)? = null,
+    onAskAi: (() -> Unit)? = null,
     colors: AppColors,
     context: Context,
     clipboardManager: ClipboardManager,
@@ -189,22 +191,44 @@ fun YouTubeSummaryInlineCard(
                     Spacer(modifier = Modifier.height(8.dp))
                     Text(summaryText, fontSize = fontSettings.scaled(14), lineHeight = 22.sp, color = colors.textBody)
 
-                    // 요약 내용 복사 버튼
+                    // 요약 내용 복사 + AI 물어보기 버튼
                     Spacer(modifier = Modifier.height(8.dp))
                     Row(
-                        modifier = Modifier
-                            .clip(RoundedCornerShape(6.dp))
-                            .background(colors.chipBackground)
-                            .clickable {
-                                clipboardManager.setText(AnnotatedString(summaryText))
-                                Toast.makeText(context, context.getString(R.string.memo_copy_done), Toast.LENGTH_SHORT).show()
-                            }
-                            .padding(horizontal = 10.dp, vertical = 5.dp),
-                        verticalAlignment = Alignment.CenterVertically
+                        horizontalArrangement = Arrangement.spacedBy(6.dp)
                     ) {
-                        Icon(Icons.Default.ContentCopy, null, tint = colors.chipText, modifier = Modifier.size(12.dp))
-                        Spacer(modifier = Modifier.width(4.dp))
-                        Text(stringResource(R.string.summary_copy), fontSize = fontSettings.scaled(10), color = colors.chipText, fontWeight = FontWeight.Medium)
+                        Row(
+                            modifier = Modifier
+                                .weight(1f)
+                                .clip(RoundedCornerShape(6.dp))
+                                .background(colors.chipBackground)
+                                .clickable {
+                                    clipboardManager.setText(AnnotatedString(summaryText))
+                                    Toast.makeText(context, context.getString(R.string.memo_copy_done), Toast.LENGTH_SHORT).show()
+                                }
+                                .padding(vertical = 6.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.Center
+                        ) {
+                            Icon(Icons.Default.ContentCopy, null, tint = colors.chipText, modifier = Modifier.size(12.dp))
+                            Spacer(modifier = Modifier.width(4.dp))
+                            Text(stringResource(R.string.summary_copy), fontSize = fontSettings.scaled(10), color = colors.chipText, fontWeight = FontWeight.Medium)
+                        }
+                        if (onAskAi != null) {
+                            Row(
+                                modifier = Modifier
+                                    .weight(1f)
+                                    .clip(RoundedCornerShape(6.dp))
+                                    .background(Color(0xFF7C4DFF).copy(alpha = 0.1f))
+                                    .clickable { onAskAi() }
+                                    .padding(vertical = 6.dp),
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.Center
+                            ) {
+                                Icon(Icons.Default.AutoFixHigh, null, tint = Color(0xFF7C4DFF), modifier = Modifier.size(12.dp))
+                                Spacer(modifier = Modifier.width(4.dp))
+                                Text("Memozy AI", fontSize = fontSettings.scaled(10), color = Color(0xFF7C4DFF), fontWeight = FontWeight.Medium)
+                            }
+                        }
                     }
                 }
 


### PR DESCRIPTION
## Summary

### Memozy AI 리브랜딩
- "AI 어시스트" → **"Memozy AI"** 전면 교체 (바텀시트 헤더, 프롬프트, placeholder)
- 프롬프트에 Memozy AI 정체성 삽입: "너 누구야?" → "Memozy AI입니다!" / 일반 질문에는 자기소개 없이 바로 답변
- Gemini가 다른 AI 서비스 이름으로 자신을 소개하지 않도록 방어

### 직접 입력 → 본문 내 인라인 (C 방식)
- 바텀시트 대화창 제거 → 본문 에디터 아래에 인라인 입력바 배치
- "직접 입력" 선택 시 자동 스크롤로 입력바 위치 안내
- AI 응답이 본문에 직접 스트리밍 삽입 (프리셋과 동일 경로)
- 프리셋/직접입력 모두 동일한 UX: 전부 본문에 바로 삽입

### 마크다운 후처리
- `stripMarkdown()` 함수 추가: Gemini가 프롬프트 무시하고 `**`, `###` 등 마크다운을 넣어도 실시간 제거
- 프롬프트 + 후처리 이중 방어

### 스트리밍 안정성
- 스트리밍 중 `setHtml()` 매번 호출 → **완료 후 1회만** 호출로 변경
- `richTextState` ↔ `bodyText` 경쟁 조건 해소 → 출력 끊김 방지

### 요약 카드 Memozy AI 버튼
- 유튜브/웹 요약 카드 하단에 "Memozy AI" 버튼 추가 (요약 복사와 반반 배치)
- 툴바와 동일한 AutoFixHigh(마법봉) 아이콘 적용

### 기타
- 입력칸 커서 위치 `CenterStart` 정렬
- 입력바 연필 이모지 제거

## Related Issues
- #201 유튜브 요약 타임아웃
- #202 유튜브 요약 스트리밍 전환
- #203 요약 카드 Memozy AI 버튼 무반응

## Test plan
- [ ] AI 바텀시트 메뉴 헤더 "Memozy AI" 표시 확인
- [ ] "너 누구야?" 질문 → "Memozy AI입니다!" 응답 확인
- [ ] 일반 질문 → 자기소개 없이 바로 답변 확인
- [ ] 직접 입력 → 본문 아래 입력바 표시 + 자동 스크롤 확인
- [ ] AI 응답에 **, ### 등 마크다운 제거 확인
- [ ] 설명/정리/요약 프리셋 → 끊김 없이 완료 확인
- [ ] 요약 카드 하단 Memozy AI 버튼 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)