### PR TITLE
유튜브 스트리밍 요약 + Supadata 전환 + AI UX 개선

### DIFF
--- a/datasource/remote/ai/api/src/main/java/me/pecos/memozy/data/datasource/remote/ai/AIApiService.kt
+++ b/datasource/remote/ai/api/src/main/java/me/pecos/memozy/data/datasource/remote/ai/AIApiService.kt
@@ -6,6 +6,7 @@ interface AIApiService {
     suspend fun generateContent(prompt: String): String
     suspend fun generateContentWithVideo(prompt: String, videoUrl: String): String
     fun generateContentStream(prompt: String): Flow<String>
+    fun generateContentStreamLong(prompt: String): Flow<String>
     suspend fun transcribeAudio(audioBase64: String, mimeType: String, durationSeconds: Long = 0): String
     suspend fun describeImage(imageBase64: String, mimeType: String): String
 }

--- a/datasource/remote/ai/api/src/main/java/me/pecos/memozy/data/datasource/remote/ai/AIApiService.kt
+++ b/datasource/remote/ai/api/src/main/java/me/pecos/memozy/data/datasource/remote/ai/AIApiService.kt
@@ -5,8 +5,7 @@ import kotlinx.coroutines.flow.Flow
 interface AIApiService {
     suspend fun generateContent(prompt: String): String
     suspend fun generateContentWithVideo(prompt: String, videoUrl: String): String
-    fun generateContentStream(prompt: String): Flow<String>
-    fun generateContentStreamLong(prompt: String): Flow<String>
+    fun generateContentStream(prompt: String, longOutput: Boolean = false): Flow<String>
     suspend fun transcribeAudio(audioBase64: String, mimeType: String, durationSeconds: Long = 0): String
     suspend fun describeImage(imageBase64: String, mimeType: String): String
 }

--- a/datasource/remote/ai/api/src/main/java/me/pecos/memozy/data/datasource/remote/ai/model/AIRequest.kt
+++ b/datasource/remote/ai/api/src/main/java/me/pecos/memozy/data/datasource/remote/ai/model/AIRequest.kt
@@ -11,10 +11,15 @@ data class GeminiRequest(
 @Serializable
 data class GenerationConfig(
     val thinkingConfig: ThinkingConfig? = null,
+    val maxOutputTokens: Int? = null,
 ) {
     companion object {
         val THINKING_DISABLED = GenerationConfig(
             thinkingConfig = ThinkingConfig(thinkingBudget = 0)
+        )
+        val THINKING_DISABLED_LONG_OUTPUT = GenerationConfig(
+            thinkingConfig = ThinkingConfig(thinkingBudget = 0),
+            maxOutputTokens = 65536
         )
     }
 }

--- a/datasource/remote/ai/api/src/main/java/me/pecos/memozy/data/datasource/remote/ai/model/AIRequest.kt
+++ b/datasource/remote/ai/api/src/main/java/me/pecos/memozy/data/datasource/remote/ai/model/AIRequest.kt
@@ -14,12 +14,14 @@ data class GenerationConfig(
     val maxOutputTokens: Int? = null,
 ) {
     companion object {
+        private const val MAX_OUTPUT_TOKENS_LONG = 65536
+
         val THINKING_DISABLED = GenerationConfig(
             thinkingConfig = ThinkingConfig(thinkingBudget = 0)
         )
         val THINKING_DISABLED_LONG_OUTPUT = GenerationConfig(
             thinkingConfig = ThinkingConfig(thinkingBudget = 0),
-            maxOutputTokens = 65536
+            maxOutputTokens = MAX_OUTPUT_TOKENS_LONG
         )
     }
 }

--- a/datasource/remote/ai/impl/src/main/java/me/pecos/memozy/data/datasource/remote/ai/AIApiServiceImpl.kt
+++ b/datasource/remote/ai/impl/src/main/java/me/pecos/memozy/data/datasource/remote/ai/AIApiServiceImpl.kt
@@ -61,11 +61,12 @@ class AIApiServiceImpl @Inject constructor(
         return executeRequest(request)
     }
 
-    override fun generateContentStream(prompt: String): Flow<String> =
-        generateContentStreamInternal(prompt, GenerationConfig.THINKING_DISABLED)
-
-    override fun generateContentStreamLong(prompt: String): Flow<String> =
-        generateContentStreamInternal(prompt, GenerationConfig.THINKING_DISABLED_LONG_OUTPUT)
+    override fun generateContentStream(prompt: String, longOutput: Boolean): Flow<String> =
+        generateContentStreamInternal(
+            prompt,
+            if (longOutput) GenerationConfig.THINKING_DISABLED_LONG_OUTPUT
+            else GenerationConfig.THINKING_DISABLED
+        )
 
     private fun generateContentStreamInternal(prompt: String, config: GenerationConfig): Flow<String> = flow {
         val request = GeminiRequest(

--- a/datasource/remote/ai/impl/src/main/java/me/pecos/memozy/data/datasource/remote/ai/AIApiServiceImpl.kt
+++ b/datasource/remote/ai/impl/src/main/java/me/pecos/memozy/data/datasource/remote/ai/AIApiServiceImpl.kt
@@ -16,6 +16,7 @@ import me.pecos.memozy.data.datasource.remote.ai.model.GeminiContent
 import me.pecos.memozy.data.datasource.remote.ai.model.GeminiFileData
 import me.pecos.memozy.data.datasource.remote.ai.model.GeminiInlineData
 import me.pecos.memozy.data.datasource.remote.ai.model.GeminiPart
+import me.pecos.memozy.data.datasource.remote.ai.model.GenerationConfig
 import me.pecos.memozy.data.datasource.remote.ai.model.GeminiRequest
 import me.pecos.memozy.data.datasource.remote.ai.model.GeminiResponse
 
@@ -60,16 +61,23 @@ class AIApiServiceImpl @Inject constructor(
         return executeRequest(request)
     }
 
-    override fun generateContentStream(prompt: String): Flow<String> = flow {
+    override fun generateContentStream(prompt: String): Flow<String> =
+        generateContentStreamInternal(prompt, GenerationConfig.THINKING_DISABLED)
+
+    override fun generateContentStreamLong(prompt: String): Flow<String> =
+        generateContentStreamInternal(prompt, GenerationConfig.THINKING_DISABLED_LONG_OUTPUT)
+
+    private fun generateContentStreamInternal(prompt: String, config: GenerationConfig): Flow<String> = flow {
         val request = GeminiRequest(
             contents = listOf(
                 GeminiContent(
                     parts = listOf(GeminiPart(text = prompt))
                 )
-            )
+            ),
+            generationConfig = config
         )
 
-        val accumulated = StringBuilder()
+        var hasContent = false
         httpClient.preparePost("gemini-stream") {
             contentType(ContentType.Application.Json)
             setBody(request)
@@ -89,8 +97,8 @@ class AIApiServiceImpl @Inject constructor(
                                 ?.firstOrNull()
                                 ?.text
                             if (text != null) {
-                                accumulated.append(text)
-                                emit(accumulated.toString())
+                                hasContent = true
+                                emit(text) // 델타만 emit (O(n) 최적화)
                             }
                         } catch (_: Exception) { }
                     }
@@ -98,7 +106,7 @@ class AIApiServiceImpl @Inject constructor(
             }
         }
 
-        if (accumulated.isEmpty()) {
+        if (!hasContent) {
             throw AIException.UnknownException("Empty streaming response from Gemini")
         }
     }

--- a/datasource/remote/ai/impl/src/main/java/me/pecos/memozy/data/datasource/remote/ai/YouTubeCaptionServiceImpl.kt
+++ b/datasource/remote/ai/impl/src/main/java/me/pecos/memozy/data/datasource/remote/ai/YouTubeCaptionServiceImpl.kt
@@ -4,8 +4,6 @@ import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 import io.ktor.client.request.parameter
 import io.ktor.client.statement.bodyAsText
-import kotlinx.coroutines.async
-import kotlinx.coroutines.coroutineScope
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -24,25 +22,31 @@ class YouTubeCaptionServiceImpl @Inject constructor(
 
     override suspend fun extractVideoInfo(videoId: String): YouTubeVideoInfo? {
         return try {
-            coroutineScope {
-                // 제목과 자막을 병렬로 가져오기
-                val titleDeferred = async { fetchTitle(videoId) }
-                val captionsDeferred = async {
-                    fetchCaptionsFromWorker(videoId, "ko")
-                        ?: fetchCaptionsFromWorker(videoId, "en")
-                }
+            // 1번의 API 호출로 자막 + 제목 동시 획득
+            // Worker가 내부에서 ko→en 폴백 처리 + 응답에 title 포함
+            val responseText = httpClient.get("youtube-captions") {
+                parameter("url", "https://www.youtube.com/watch?v=$videoId")
+                parameter("lang", "ko")
+            }.bodyAsText()
 
-                YouTubeVideoInfo(
-                    title = titleDeferred.await() ?: "YouTube 영상",
-                    captions = captionsDeferred.await()
-                )
-            }
+            val root = json.parseToJsonElement(responseText).jsonObject
+            if (root.containsKey("error")) return null
+
+            val captions = root["content"]?.jsonPrimitive?.content?.takeIf { it.isNotBlank() }
+            val title = root["title"]?.jsonPrimitive?.content?.takeIf { it != "null" && it.isNotBlank() }
+                ?: "YouTube 영상"
+
+            YouTubeVideoInfo(
+                title = title,
+                captions = captions
+            )
         } catch (e: Exception) {
             null
         }
     }
 
     override suspend fun fetchTitle(videoId: String): String? {
+        // oembed API로 제목만 빠르게 가져오기 (자막 추출 없이)
         return try {
             val responseText = httpClient.get("youtube-title") {
                 parameter("videoId", videoId)
@@ -51,21 +55,6 @@ class YouTubeCaptionServiceImpl @Inject constructor(
             val root = json.parseToJsonElement(responseText).jsonObject
             val title = root["title"]?.jsonPrimitive?.content
             title?.takeIf { it != "null" }
-        } catch (e: Exception) {
-            null
-        }
-    }
-
-    private suspend fun fetchCaptionsFromWorker(videoId: String, lang: String = "ko"): String? {
-        return try {
-            val responseText = httpClient.get("youtube-captions") {
-                parameter("url", "https://www.youtube.com/watch?v=$videoId")
-                parameter("lang", lang)
-            }.bodyAsText()
-
-            val root = json.parseToJsonElement(responseText).jsonObject
-            if (root.containsKey("error")) return null
-            root["content"]?.jsonPrimitive?.content?.takeIf { it.isNotBlank() }
         } catch (e: Exception) {
             null
         }

--- a/feature/memo-plain/impl/src/main/java/me/pecos/memozy/feature/memoplain/impl/MemoPlainNavigationImpl.kt
+++ b/feature/memo-plain/impl/src/main/java/me/pecos/memozy/feature/memoplain/impl/MemoPlainNavigationImpl.kt
@@ -1061,7 +1061,7 @@ class MemoPlainNavigationImpl @Inject constructor(
             val fullPrompt = "$prompt\n\n아래는 영상의 자막입니다:\n\n$captions"
             var result = ""
             val sb = StringBuilder()
-            aiApiService.generateContentStreamLong(fullPrompt).collect { delta ->
+            aiApiService.generateContentStream(fullPrompt, longOutput = true).collect { delta ->
                 sb.append(delta)
                 result = stripMarkdown(sb.toString())
                 onStreamUpdate?.invoke(result)

--- a/feature/memo-plain/impl/src/main/java/me/pecos/memozy/feature/memoplain/impl/MemoPlainNavigationImpl.kt
+++ b/feature/memo-plain/impl/src/main/java/me/pecos/memozy/feature/memoplain/impl/MemoPlainNavigationImpl.kt
@@ -80,7 +80,7 @@ class MemoPlainNavigationImpl @Inject constructor(
         private const val FEATURE_AI_ASSIST = "ai_assist"
         private const val MAX_DAILY_AD_VIEWS = 3
         private const val MAX_MEMO_CONTEXT_CHARS = 3000
-        private const val MEMOZY_AI_SYSTEM_ROLE = "너는 Memozy AI야. 메모지 앱의 AI 어시스턴트로, 사용자의 메모 작성을 돕는 게 너의 역할이야. 너의 이름은 'Memozy AI'이고, 다른 AI 서비스의 이름으로 자신을 소개하면 안 돼. 사용자가 '너 누구야?' 등 정체를 물어볼 때만 'Memozy AI입니다! 메모 작성을 도와드릴게요' 라고 답해. 그 외에는 자기소개 없이 바로 답변해."
+        private const val MEMOZY_AI_SYSTEM_ROLE = "너는 Memozy AI야. 메모지 앱의 AI 어시스턴트로, 사용자의 메모 작성을 돕는 게 너의 역할이야. 너의 이름은 'Memozy AI'이고, 다른 AI 서비스의 이름으로 자신을 소개하면 안 돼. 사용자가 '너 누구야?' 등 정체를 물어볼 때만 'Memozy AI입니다! 메모 작성을 도와드릴게요' 라고 답해. 그 외에는 자기소개 없이 바로 답변해. 인사말, 도입부('도와드릴게요', '해결책을 찾아볼게요', '물론이죠', '네!' 등) 없이 핵심 내용부터 바로 시작해."
         private const val NO_MARKDOWN_RULE = "마크다운 문법(**, ##, - 등)을 절대 사용하지 마. 순수 텍스트로만 답해."
 
         private fun stripMarkdown(text: String): String = text
@@ -622,8 +622,12 @@ class MemoPlainNavigationImpl @Inject constructor(
                         }
                     }
                 },
-                isSummarizing = inlineSummaryState is SummaryState.Loading,
-                summaryResult = (inlineSummaryState as? SummaryState.Success)?.text,
+                isSummarizing = inlineSummaryState is SummaryState.Loading || inlineSummaryState is SummaryState.Streaming,
+                summaryResult = when (inlineSummaryState) {
+                    is SummaryState.Streaming -> (inlineSummaryState as SummaryState.Streaming).text
+                    is SummaryState.Success -> (inlineSummaryState as SummaryState.Success).text
+                    else -> null
+                },
                 summaryError = (inlineSummaryState as? SummaryState.Error)?.message,
                 youtubeTitle = youtubeTitle,
                 onStartRecording = {
@@ -704,11 +708,14 @@ class MemoPlainNavigationImpl @Inject constructor(
                         inlineSummaryState = SummaryState.Loading
                         try {
                             val summary = if (videoId != null) {
-                                summarizeVideo(
+                                summarizeVideoStream(
                                     videoId, url,
                                     style = style,
                                     lang = languageCode,
-                                    onTitleFound = { title -> youtubeTitle = title }
+                                    onTitleFound = { title -> youtubeTitle = title },
+                                    onStreamUpdate = { partial ->
+                                        inlineSummaryState = SummaryState.Streaming(partial)
+                                    }
                                 )
                             } else {
                                 aiApiService.generateContentWithVideo(
@@ -742,6 +749,12 @@ class MemoPlainNavigationImpl @Inject constructor(
                     }
                 },
                 onYoutubeSummarize = { url, mode ->
+                    // mode → activeSummaryStyle 동기화
+                    val style = when (mode) {
+                        SummaryMode.SIMPLE -> SummaryStyle.SIMPLE
+                        SummaryMode.DETAILED -> SummaryStyle.DETAILED
+                    }
+                    activeSummaryStyle = style
                     currentSummarizeJob = scope.launch {
                         if (!canUseAi) {
                             showLimitBottomSheet = true
@@ -749,7 +762,7 @@ class MemoPlainNavigationImpl @Inject constructor(
                         }
                         val videoId = extractVideoId(url)
                         // 캐시 조회 (style + language 기반)
-                        val cached = videoId?.let { youtubeSummaryDao.getByKey(it, activeSummaryStyle.name, languageCode) }
+                        val cached = videoId?.let { youtubeSummaryDao.getByKey(it, style.name, languageCode) }
                         if (cached != null) {
                             inlineSummaryState = SummaryState.Success(cached.summary)
                             return@launch
@@ -758,11 +771,14 @@ class MemoPlainNavigationImpl @Inject constructor(
                         val ytPrompt = buildYoutubePrompt(activeSummaryStyle, languageCode)
                         try {
                             val summary = if (videoId != null) {
-                                summarizeVideo(
+                                summarizeVideoStream(
                                     videoId, url,
                                     style = activeSummaryStyle,
                                     lang = languageCode,
-                                    onTitleFound = { title -> youtubeTitle = title }
+                                    onTitleFound = { title -> youtubeTitle = title },
+                                    onStreamUpdate = { partial ->
+                                        inlineSummaryState = SummaryState.Streaming(partial)
+                                    }
                                 )
                             } else {
                                 aiApiService.generateContentWithVideo(
@@ -858,7 +874,7 @@ class MemoPlainNavigationImpl @Inject constructor(
                             val noMarkdownRule = NO_MARKDOWN_RULE
                             val prompt = buildString {
                                 appendLine(systemRole)
-                                appendLine("어떤 질문이든 친절하게 답해줘.")
+                                appendLine("답변은 간결하고 핵심적으로.")
                                 appendLine("사용자가 현재 메모를 작성 중이니, 메모 내용이 있으면 참고해서 답해줘.")
                                 appendLine("메모와 관련 없는 질문이어도 자유롭게 답변해. 답변은 간결하게. $noMarkdownRule")
                                 appendLine()
@@ -871,9 +887,14 @@ class MemoPlainNavigationImpl @Inject constructor(
                                 }
                                 appendLine("사용자: $userMessage")
                             }
-                            aiApiService.generateContentStream(prompt).collect { accumulated ->
-                                aiAssistStreamingText = stripMarkdown(accumulated)
+                            val sb = StringBuilder()
+                            aiApiService.generateContentStream(prompt).collect { delta ->
+                                sb.append(delta)
+                                aiAssistStreamingText = stripMarkdown(sb.toString())
                             }
+                            // UI가 마지막 스트리밍 텍스트를 반영할 시간 확보
+                            kotlinx.coroutines.yield()
+                            kotlinx.coroutines.delay(50)
                             aiAssistStreamingText = null
                             aiUsageDao.insert(AiUsage(feature = FEATURE_AI_ASSIST))
                             dailyUsageCount++
@@ -936,9 +957,14 @@ class MemoPlainNavigationImpl @Inject constructor(
                                 }
                                 else -> return@launch
                             }
-                            aiApiService.generateContentStream(prompt).collect { accumulated ->
-                                aiAssistStreamingText = stripMarkdown(accumulated)
+                            val sb = StringBuilder()
+                            aiApiService.generateContentStream(prompt).collect { delta ->
+                                sb.append(delta)
+                                aiAssistStreamingText = stripMarkdown(sb.toString())
                             }
+                            // UI가 마지막 스트리밍 텍스트를 반영할 시간 확보
+                            kotlinx.coroutines.yield()
+                            kotlinx.coroutines.delay(50)
                             aiAssistStreamingText = null
                             aiUsageDao.insert(AiUsage(feature = FEATURE_AI_ASSIST))
                             dailyUsageCount++
@@ -1015,12 +1041,13 @@ class MemoPlainNavigationImpl @Inject constructor(
         throw lastException!!
     }
 
-    private suspend fun summarizeVideo(
+    private suspend fun summarizeVideoStream(
         videoId: String,
         videoUrl: String,
         style: SummaryStyle = SummaryStyle.SIMPLE,
         lang: String = "ko",
-        onTitleFound: ((String) -> Unit)? = null
+        onTitleFound: ((String) -> Unit)? = null,
+        onStreamUpdate: ((String) -> Unit)? = null
     ): String {
         val prompt = buildYoutubePrompt(style, lang)
         // 1. 자막 + 제목 추출 시도
@@ -1028,16 +1055,21 @@ class MemoPlainNavigationImpl @Inject constructor(
         if (videoInfo != null) {
             onTitleFound?.invoke(videoInfo.title)
         }
-        val captions = videoInfo?.captions?.take(15000)
+        val captions = videoInfo?.captions
         if (captions != null) {
-            // 자막 기반 요약 (텍스트만, 빠르고 저렴)
-            return retryOn503 {
-                aiApiService.generateContent(
-                    "$prompt\n\n아래는 영상의 자막입니다:\n\n$captions"
-                )
+            // 자막 기반 요약 — 스트리밍
+            val fullPrompt = "$prompt\n\n아래는 영상의 자막입니다:\n\n$captions"
+            var result = ""
+            val sb = StringBuilder()
+            aiApiService.generateContentStreamLong(fullPrompt).collect { delta ->
+                sb.append(delta)
+                result = stripMarkdown(sb.toString())
+                onStreamUpdate?.invoke(result)
             }
+            if (result.isBlank()) throw me.pecos.memozy.data.datasource.remote.ai.AIException.UnknownException("Empty streaming response")
+            return result
         }
-        // 2. 자막 없으면 fallback — 영상 직접 분석
+        // 2. 자막 없으면 fallback — 비스트리밍 (영상 직접 분석은 스트리밍 미지원)
         return retryOn503 {
             aiApiService.generateContentWithVideo(
                 prompt = prompt,
@@ -1050,6 +1082,7 @@ class MemoPlainNavigationImpl @Inject constructor(
 private sealed class SummaryState {
     data object Idle : SummaryState()
     data object Loading : SummaryState()
+    data class Streaming(val text: String) : SummaryState()
     data class Success(val text: String) : SummaryState()
     data class Error(val message: String) : SummaryState()
 }

--- a/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/MemoScreen.kt
+++ b/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/MemoScreen.kt
@@ -27,7 +27,7 @@ import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.material.icons.Icons
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.automirrored.filled.Send
+import androidx.compose.material.icons.filled.ArrowUpward
 import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Close
@@ -338,34 +338,33 @@ fun MemoScreen(
     // Memozy AI 스트리밍 → 본문 끝에 실시간 반영
     var aiInsertAnchorHtml by remember { mutableStateOf("") }
     var aiInsertAnchorPlain by remember { mutableStateOf("") }
-    var prevStreamingText by remember { mutableStateOf<String?>(null) }
+    var lastStreamedText by remember { mutableStateOf("") }
+
+    // aiAssistStreamingText 변경될 때마다 직접 반응
     LaunchedEffect(aiAssistStreamingText) {
         val streaming = aiAssistStreamingText
         if (streaming != null) {
-            if (prevStreamingText == null) {
-                // 스트리밍 시작 — 현재 본문을 앵커로 저장
+            if (aiInsertAnchorHtml.isEmpty()) {
+                // 스트리밍 시작 — 앵커 저장 (1회)
                 aiInsertAnchorHtml = richTextState.toHtml()
                 aiInsertAnchorPlain = richTextState.annotatedString.text
+                lastStreamedText = ""
             }
-            // 스트리밍 중에는 bodyText만 업데이트 (에디터는 건드리지 않음)
-            val separator = if (aiInsertAnchorPlain.isBlank()) "" else "\n\n"
-            bodyText = aiInsertAnchorPlain + separator + streaming
-        } else if (prevStreamingText != null) {
+            // 스트리밍 중 — bodyText 업데이트
+            if (streaming.isNotBlank()) {
+                lastStreamedText = streaming
+                val separator = if (aiInsertAnchorPlain.isBlank()) "" else "\n\n"
+                bodyText = aiInsertAnchorPlain + separator + streaming
+            }
+        } else if (aiInsertAnchorHtml.isNotEmpty()) {
+            // 스트리밍 완료 또는 취소
             if (isAiCancelled) {
                 // 취소 — 본문 원복
-                if (aiInsertAnchorHtml.isNotBlank()) {
-                    richTextState.setHtml(aiInsertAnchorHtml)
-                    bodyText = richTextState.annotatedString.text
-                }
-                aiInsertAnchorHtml = ""
-                aiInsertAnchorPlain = ""
-                prevStreamingText = streaming
-                return@LaunchedEffect
-            }
-            // 스트리밍 완료 — richTextState에 최종 결과 한 번만 반영
-            val aiText = prevStreamingText ?: ""
-            if (aiText.isNotBlank()) {
-                val escapedAi = aiText.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace("\n", "<br>")
+                richTextState.setHtml(aiInsertAnchorHtml)
+                bodyText = richTextState.annotatedString.text
+            } else if (lastStreamedText.isNotBlank()) {
+                // 완료 — richTextState에 최종 결과 반영
+                val escapedAi = lastStreamedText.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace("\n", "<br>")
                 val anchorHtml = aiInsertAnchorHtml.trimEnd()
                 val finalHtml = if (anchorHtml.isBlank() || anchorHtml == "<p><br></p>") {
                     "<p>$escapedAi</p>"
@@ -377,8 +376,8 @@ fun MemoScreen(
             }
             aiInsertAnchorHtml = ""
             aiInsertAnchorPlain = ""
+            lastStreamedText = ""
         }
-        prevStreamingText = streaming
     }
 
     fun safeContent(): String {
@@ -644,7 +643,7 @@ fun MemoScreen(
                         memoTitle = nameText,
                         isExpanded = isSummaryExpanded,
                         onExpandToggle = { isSummaryExpanded = it },
-                        summaryText = summaryText,
+                        summaryText = if (isSummarizing && summaryResult != null) summaryResult else summaryText,
                         isSummarizing = isSummarizing,
                         currentSummaryMode = currentSummaryMode,
                         onSummarize = onYoutubeSummarize,
@@ -656,7 +655,9 @@ fun MemoScreen(
                             detectedYoutubeUrl?.let { onYoutubeSummarize?.invoke(it, altMode) }
                         },
                         onDeleteSummary = { showSummaryDeleteDialog = "youtube" },
-                        onAskAi = if (onAiCustomSend != null) { { showAiCustomInput = true } } else null,
+                        onAskAi = if (onAiCustomSend != null) { {
+                            showAiCustomInput = true
+                        } } else null,
                         colors = colors,
                         context = context,
                         clipboardManager = clipboardManager,
@@ -697,7 +698,9 @@ fun MemoScreen(
                             savedWebUrl?.let { onWebSummarize?.invoke(it, altMode) }
                         },
                         onDeleteSummary = { showSummaryDeleteDialog = "web" },
-                        onAskAi = if (onAiCustomSend != null) { { showAiCustomInput = true } } else null,
+                        onAskAi = if (onAiCustomSend != null) { {
+                            showAiCustomInput = true
+                        } } else null,
                         colors = colors,
                         context = context,
                         clipboardManager = clipboardManager
@@ -739,105 +742,28 @@ fun MemoScreen(
                     }
                 )
 
-                // Memozy AI 직접 입력바 (본문 내 인라인)
-                LaunchedEffect(showAiCustomInput) {
-                    if (showAiCustomInput) {
-                        kotlinx.coroutines.delay(150) // 입력바 렌더링 대기
-                        scrollState.animateScrollTo(scrollState.maxValue)
-                    }
-                }
-                if (showAiCustomInput && onAiCustomSend != null) {
-                    var aiInputText by remember { mutableStateOf("") }
+                // Memozy AI 응답 중 표시 (본문 내 인라인, X 없음)
+                if (isAiAssistLoading) {
                     Spacer(modifier = Modifier.height(12.dp))
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .clip(RoundedCornerShape(12.dp))
-                            .background(colors.chipBackground.copy(alpha = 0.4f))
-                            .padding(horizontal = 12.dp, vertical = 8.dp),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        BasicTextField(
-                            value = aiInputText,
-                            onValueChange = { aiInputText = it },
-                            modifier = Modifier.weight(1f),
-                            textStyle = TextStyle(
-                                color = colors.textBody,
-                                fontSize = fontSettings.scaled(14)
-                            ),
-                            cursorBrush = androidx.compose.ui.graphics.SolidColor(colors.textTitle),
-                            singleLine = true,
-                            decorationBox = { innerTextField ->
-                                Box(contentAlignment = Alignment.CenterStart) {
-                                    if (aiInputText.isEmpty()) {
-                                        Text(
-                                            stringResource(R.string.ai_input_placeholder),
-                                            color = colors.textBody.copy(alpha = 0.4f),
-                                            fontSize = fontSettings.scaled(14)
-                                        )
-                                    }
-                                    innerTextField()
-                                }
-                            }
-                        )
-                        Spacer(modifier = Modifier.width(8.dp))
-                        val canSend = aiInputText.isNotBlank() && !isAiAssistLoading
-                        Icon(
-                            Icons.AutoMirrored.Filled.Send,
-                            contentDescription = null,
-                            tint = if (canSend) Color(0xFF7C4DFF) else colors.textBody.copy(alpha = 0.2f),
-                            modifier = Modifier
-                                .size(20.dp)
-                                .clickable(enabled = canSend) {
-                                    val text = aiInputText.trim()
-                                    aiInputText = ""
-                                    onAiCustomSend(text, nameText, bodyText)
-                                }
-                        )
-                        Spacer(modifier = Modifier.width(4.dp))
-                        Icon(
-                            Icons.Default.Close,
-                            contentDescription = null,
-                            tint = colors.textBody.copy(alpha = 0.5f),
-                            modifier = Modifier
-                                .size(18.dp)
-                                .clickable { showAiCustomInput = false }
-                        )
-                    }
-                    Spacer(modifier = Modifier.height(8.dp))
-                }
-
-                // Memozy AI 응답 중 표시 + 취소 버튼
-                if (isAiAssistLoading && onAiCancel != null) {
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
                             .clip(RoundedCornerShape(8.dp))
-                            .background(Color(0xFF7C4DFF).copy(alpha = 0.08f))
+                            .background(colors.chipBackground)
                             .padding(horizontal = 12.dp, vertical = 8.dp),
                         verticalAlignment = Alignment.CenterVertically
                     ) {
                         CircularProgressIndicator(
                             modifier = Modifier.size(14.dp),
                             strokeWidth = 2.dp,
-                            color = Color(0xFF7C4DFF)
+                            color = colors.chipText
                         )
                         Spacer(modifier = Modifier.width(8.dp))
                         Text(
                             stringResource(R.string.ai_loading),
                             fontSize = fontSettings.scaled(13),
-                            color = Color(0xFF7C4DFF),
+                            color = colors.chipText,
                             modifier = Modifier.weight(1f)
-                        )
-                        Icon(
-                            Icons.Default.Close,
-                            contentDescription = null,
-                            tint = Color(0xFF7C4DFF),
-                            modifier = Modifier
-                                .size(18.dp)
-                                .clickable {
-                                    onAiCancel()
-                                }
                         )
                     }
                     Spacer(modifier = Modifier.height(8.dp))
@@ -964,9 +890,9 @@ fun MemoScreen(
                 Spacer(modifier = Modifier.height(20.dp))
             }
 
-            // 서식 툴바 — 키보드가 올라올 때만 표시 (키보드 위 고정 바)
+            // 서식 툴바 — 키보드 또는 AI 입력바 활성 시 표시
             AnimatedVisibility(
-                visible = isKeyboardVisible,
+                visible = isKeyboardVisible || showAiCustomInput || isAiAssistLoading,
                 enter = slideInVertically(initialOffsetY = { it }) + fadeIn(),
                 exit = slideOutVertically(targetOffsetY = { it }) + fadeOut()
             ) {
@@ -977,6 +903,78 @@ fun MemoScreen(
                         .hazeEffect(state = hazeState, style = glassStyle)
                 ) {
                     HorizontalDivider(color = keyboardBarBorder, thickness = 0.5.dp)
+
+                    // Memozy AI 직접 입력바 (툴바 위 고정)
+                    if (showAiCustomInput && onAiCustomSend != null) {
+                        var aiInputText by remember { mutableStateOf("") }
+                        val aiInputFocusRequester = remember { FocusRequester() }
+                        LaunchedEffect(Unit) {
+                            kotlinx.coroutines.delay(100)
+                            aiInputFocusRequester.requestFocus()
+                        }
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 12.dp, vertical = 6.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            BasicTextField(
+                                value = aiInputText,
+                                onValueChange = { aiInputText = it },
+                                modifier = Modifier
+                                    .weight(1f)
+                                    .focusRequester(aiInputFocusRequester)
+                                    .clip(RoundedCornerShape(20.dp))
+                                    .background(colors.chipBackground.copy(alpha = 0.4f))
+                                    .padding(horizontal = 14.dp, vertical = 10.dp),
+                                textStyle = TextStyle(
+                                    color = colors.textBody,
+                                    fontSize = fontSettings.scaled(14)
+                                ),
+                                cursorBrush = androidx.compose.ui.graphics.SolidColor(colors.textTitle),
+                                singleLine = true,
+                                decorationBox = { innerTextField ->
+                                    Box(contentAlignment = Alignment.CenterStart) {
+                                        if (aiInputText.isEmpty()) {
+                                            Text(
+                                                stringResource(R.string.ai_input_placeholder),
+                                                color = colors.textBody.copy(alpha = 0.4f),
+                                                fontSize = fontSettings.scaled(14)
+                                            )
+                                        }
+                                        innerTextField()
+                                    }
+                                }
+                            )
+                            Spacer(modifier = Modifier.width(8.dp))
+                            val canSend = aiInputText.isNotBlank() && !isAiAssistLoading
+                            Icon(
+                                Icons.Default.ArrowUpward,
+                                contentDescription = null,
+                                tint = if (canSend) colors.chipText else colors.textBody.copy(alpha = 0.2f),
+                                modifier = Modifier
+                                    .size(28.dp)
+                                    .clip(RoundedCornerShape(14.dp))
+                                    .background(if (canSend) colors.chipBackground else Color.Transparent)
+                                    .clickable(enabled = canSend) {
+                                        val text = aiInputText.trim()
+                                        aiInputText = ""
+                                        showAiCustomInput = false
+                                        onAiCustomSend(text, nameText, bodyText)
+                                    }
+                                    .padding(4.dp)
+                            )
+                            Spacer(modifier = Modifier.width(4.dp))
+                            Icon(
+                                Icons.Default.Close,
+                                contentDescription = null,
+                                tint = colors.textBody.copy(alpha = 0.5f),
+                                modifier = Modifier
+                                    .size(18.dp)
+                                    .clickable { showAiCustomInput = false }
+                            )
+                        }
+                    }
 
                     // 액션 버튼 (왼쪽) + 서식 툴바 (오른쪽) — 한 줄 배치
                     Box {
@@ -1069,6 +1067,10 @@ fun MemoScreen(
                 bodyText = if (bodyText.isBlank()) url else "$bodyText\n$url"
                 savedYoutubeUrl = url
                 showYoutubeDialog = false
+                // 제목 가져오기 — 다이얼로그에서 URL 추가 시에도 즉시 호출
+                val videoIdRegex = Regex("""(?:youtube\.com/watch\?v=|youtu\.be/|youtube\.com/shorts/)([\w-]+)""")
+                val vid = videoIdRegex.find(url)?.groupValues?.get(1)
+                if (vid != null) onYoutubeDetected?.invoke(vid)
             }
         )
     }

--- a/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/components/MemoActionBar.kt
+++ b/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/components/MemoActionBar.kt
@@ -84,7 +84,7 @@ fun MemoActionBar(
                 modifier = Modifier.size(36.dp).clip(RoundedCornerShape(8.dp))
                     .background(
                         if (isSummarizing || isWebSummarizing) colors.chipBackground.copy(alpha = 0.3f)
-                        else if (hasYoutubeUrl) Color(0xFF2196F3).copy(alpha = 0.1f)
+                        else if (hasYoutubeUrl) colors.chipText.copy(alpha = 0.1f)
                         else colors.chipBackground.copy(alpha = 0.4f)
                     )
                     .clickable(enabled = !isSummarizing && !isWebSummarizing) {
@@ -94,7 +94,7 @@ fun MemoActionBar(
             ) {
                 Icon(
                     Icons.Default.SmartDisplay, contentDescription = null,
-                    tint = if (hasYoutubeUrl) Color(0xFF2196F3) else colors.chipText,
+                    tint = colors.chipText,
                     modifier = Modifier.size(20.dp)
                 )
             }
@@ -123,7 +123,7 @@ fun MemoActionBar(
                     .clickable(enabled = !isSummarizing && !isWebSummarizing) { onAiAssistClick() },
                 contentAlignment = Alignment.Center
             ) {
-                Icon(Icons.Default.AutoFixHigh, contentDescription = null, tint = Color(0xFF7C4DFF), modifier = Modifier.size(20.dp))
+                Icon(Icons.Default.AutoFixHigh, contentDescription = null, tint = colors.chipText, modifier = Modifier.size(20.dp))
             }
         }
 

--- a/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/components/MemoDialogs.kt
+++ b/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/components/MemoDialogs.kt
@@ -73,7 +73,8 @@ fun YouTubeUrlDialog(
 ) {
     val fontSettings = LocalFontSettings.current
     var urlInput by remember { mutableStateOf("") }
-    val clipText = remember { getSystemClipboardText(context) }
+    // 다이얼로그가 열릴 때마다 최신 클립보드를 읽도록 key 없이 매번 실행
+    val clipText = getSystemClipboardText(context)
     val isValid = YOUTUBE_URL_REGEX.containsMatchIn(urlInput)
 
     AppPopup(
@@ -158,7 +159,7 @@ fun WebUrlDialog(
     val context = LocalContext.current
     val fontSettings = LocalFontSettings.current
     var webUrlInput by remember { mutableStateOf("") }
-    val clipText = remember { getSystemClipboardText(context) }
+    val clipText = getSystemClipboardText(context)
     val colors = me.pecos.memozy.presentation.theme.LocalAppColors.current
     val isValid = webUrlInput.startsWith("http")
 

--- a/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/components/WebSummaryInlineCard.kt
+++ b/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/components/WebSummaryInlineCard.kt
@@ -201,15 +201,15 @@ fun WebSummaryInlineCard(
                             modifier = Modifier
                                 .weight(1f)
                                 .clip(RoundedCornerShape(6.dp))
-                                .background(Color(0xFF7C4DFF).copy(alpha = 0.1f))
+                                .background(colors.chipBackground)
                                 .clickable { onAskAi() }
                                 .padding(vertical = 6.dp),
                             verticalAlignment = Alignment.CenterVertically,
                             horizontalArrangement = Arrangement.Center
                         ) {
-                            Icon(Icons.Default.AutoFixHigh, null, tint = Color(0xFF7C4DFF), modifier = Modifier.size(12.dp))
+                            Icon(Icons.Default.AutoFixHigh, null, tint = colors.chipText, modifier = Modifier.size(12.dp))
                             Spacer(modifier = Modifier.width(4.dp))
-                            Text(stringResource(R.string.memozy_ai), fontSize = fontSettings.scaled(10), color = Color(0xFF7C4DFF), fontWeight = FontWeight.Medium)
+                            Text(stringResource(R.string.memozy_ai), fontSize = fontSettings.scaled(10), color = colors.chipText, fontWeight = FontWeight.Medium)
                         }
                     }
                 }

--- a/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/components/YouTubeSummaryInlineCard.kt
+++ b/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/components/YouTubeSummaryInlineCard.kt
@@ -22,6 +22,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.Link
+import androidx.compose.material.icons.filled.SmartDisplay
 import androidx.compose.material.icons.filled.AutoFixHigh
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
@@ -142,7 +143,7 @@ fun YouTubeSummaryInlineCard(
                         verticalAlignment = Alignment.CenterVertically,
                         horizontalArrangement = Arrangement.Center
                     ) {
-                        Text("🔗", fontSize = fontSettings.scaled(10)); Spacer(modifier = Modifier.width(3.dp))
+                        Icon(Icons.Default.SmartDisplay, null, tint = colors.chipText, modifier = Modifier.size(12.dp)); Spacer(modifier = Modifier.width(3.dp))
                         Text(stringResource(R.string.summary_card_open), fontSize = fontSettings.scaled(10), color = colors.chipText, fontWeight = FontWeight.Medium)
                     }
                     Row(
@@ -218,15 +219,15 @@ fun YouTubeSummaryInlineCard(
                                 modifier = Modifier
                                     .weight(1f)
                                     .clip(RoundedCornerShape(6.dp))
-                                    .background(Color(0xFF7C4DFF).copy(alpha = 0.1f))
+                                    .background(colors.chipBackground)
                                     .clickable { onAskAi() }
                                     .padding(vertical = 6.dp),
                                 verticalAlignment = Alignment.CenterVertically,
                                 horizontalArrangement = Arrangement.Center
                             ) {
-                                Icon(Icons.Default.AutoFixHigh, null, tint = Color(0xFF7C4DFF), modifier = Modifier.size(12.dp))
+                                Icon(Icons.Default.AutoFixHigh, null, tint = colors.chipText, modifier = Modifier.size(12.dp))
                                 Spacer(modifier = Modifier.width(4.dp))
-                                Text(stringResource(R.string.memozy_ai), fontSize = fontSettings.scaled(10), color = Color(0xFF7C4DFF), fontWeight = FontWeight.Medium)
+                                Text(stringResource(R.string.memozy_ai), fontSize = fontSettings.scaled(10), color = colors.chipText, fontWeight = FontWeight.Medium)
                             }
                         }
                     }

--- a/workers/src/index.ts
+++ b/workers/src/index.ts
@@ -154,26 +154,64 @@ async function handleGeminiStream(req: Request, env: Env): Promise<Response> {
   });
 }
 
-// --- YouTube InnerTube (ANDROID client) ---
+// --- YouTube Captions (Supadata API) ---
 
-const YOUTUBE_CLIENT_VERSION = "20.10.38";
-const INNERTUBE_API_URL = "https://www.youtube.com/youtubei/v1/player?key=AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8"; // YouTube 공개 키
-const INNERTUBE_CONTEXT = {
-  client: {
-    clientName: "ANDROID",
-    clientVersion: YOUTUBE_CLIENT_VERSION,
-    androidSdkVersion: 30,
-  },
-};
-const ANDROID_USER_AGENT = `com.google.android.youtube/${YOUTUBE_CLIENT_VERSION} (Linux; U; Android 11) gzip`;
+const SUPADATA_BASE_URL = "https://api.supadata.ai/v1";
 
-interface CaptionTrack {
-  baseUrl: string;
-  languageCode: string;
-  kind?: string;
+async function fetchSupadataTranscript(
+  env: Env,
+  url: string
+): Promise<{ content?: string; lang?: string; availableLangs?: string[] } | null> {
+  const res = await fetch(url, {
+    headers: { "x-api-key": env.SUPADATA_API_KEY },
+  });
+
+  console.log(`Supadata request: status=${res.status}, url=${url}`);
+
+  if (res.ok) {
+    const data = await res.json<{ content?: string; lang?: string; availableLangs?: string[] }>();
+    console.log(`Supadata OK: lang=${data?.lang}, contentLen=${data?.content?.length ?? 0}`);
+    return data;
+  }
+
+  if (res.status === 202) {
+    // 비동기 처리 — jobId로 폴링 (최대 60초, 3초 간격)
+    const { jobId } = await res.json<{ jobId: string }>();
+    console.log(`Supadata async job: ${jobId}, polling...`);
+
+    for (let i = 0; i < 20; i++) {
+      await new Promise(r => setTimeout(r, 3000));
+      const pollRes = await fetch(`${SUPADATA_BASE_URL}/youtube/transcript/${jobId}`, {
+        headers: { "x-api-key": env.SUPADATA_API_KEY },
+      });
+
+      if (pollRes.ok) {
+        const pollData = await pollRes.json<{ status?: string; content?: string; lang?: string; availableLangs?: string[] }>();
+        console.log(`Supadata poll #${i + 1}: status=${pollData.status}`);
+
+        if (pollData.status === "completed" && pollData.content) {
+          return pollData;
+        }
+        if (pollData.status === "failed") {
+          console.log("Supadata job failed");
+          return null;
+        }
+        // queued/active → 계속 폴링
+      } else {
+        console.log(`Supadata poll error: ${pollRes.status}`);
+        return null;
+      }
+    }
+    console.log("Supadata poll timeout");
+    return null;
+  }
+
+  const errorBody = await res.text();
+  console.log(`Supadata error: status=${res.status}, body=${errorBody}`);
+  return null;
 }
 
-async function handleYoutubeCaptions(req: Request, _env: Env): Promise<Response> {
+async function handleYoutubeCaptions(req: Request, env: Env): Promise<Response> {
   const reqUrl = new URL(req.url);
   const videoUrl = reqUrl.searchParams.get("url");
   const lang = reqUrl.searchParams.get("lang") ?? "ko";
@@ -188,93 +226,53 @@ async function handleYoutubeCaptions(req: Request, _env: Env): Promise<Response>
     return Response.json({ error: "Invalid YouTube URL" }, { status: 400 });
   }
 
-  // 1. InnerTube Player API (ANDROID client)
-  const playerRes = await fetch(INNERTUBE_API_URL, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      "User-Agent": ANDROID_USER_AGENT,
-    },
-    body: JSON.stringify({
-      context: INNERTUBE_CONTEXT,
-      videoId,
-    }),
+  // 1. Supadata API로 자막 추출 (text=true → plain text)
+  const supadataUrl = `${SUPADATA_BASE_URL}/youtube/transcript?url=${encodeURIComponent(videoUrl)}&lang=${lang}&text=true`;
+  const supadataRes = await fetch(supadataUrl, {
+    headers: { "x-api-key": env.SUPADATA_API_KEY },
   });
 
-  if (!playerRes.ok) {
-    return Response.json({ error: `InnerTube error: ${playerRes.status}` }, { status: 502 });
+  // Supadata 응답 처리 (200 → 즉시, 202 → 비동기 폴링)
+  let captionData: { content?: string; lang?: string; availableLangs?: string[] } | null = null;
+
+  captionData = await fetchSupadataTranscript(env, supadataUrl);
+
+  // lang 폴백: 요청 언어 실패 시 en 시도
+  if (!captionData?.content && lang !== "en") {
+    const fallbackUrl = `${SUPADATA_BASE_URL}/youtube/transcript?url=${encodeURIComponent(videoUrl)}&lang=en&text=true`;
+    captionData = await fetchSupadataTranscript(env, fallbackUrl);
   }
 
-  const playerData = await playerRes.json<{
-    playabilityStatus?: { status?: string };
-    videoDetails?: { lengthSeconds?: string; title?: string };
-    captions?: {
-      playerCaptionsTracklistRenderer?: {
-        captionTracks?: CaptionTrack[];
-      };
-    };
-  }>();
-
-  if (playerData.playabilityStatus?.status !== "OK") {
-    return Response.json({ error: "video_unavailable" }, { status: 404 });
-  }
-
-  const tracks = playerData.captions?.playerCaptionsTracklistRenderer?.captionTracks;
-  if (!tracks || tracks.length === 0) {
+  if (!captionData?.content) {
     return Response.json({ error: "no_captions" }, { status: 404 });
   }
 
-  // 2. 자막 트랙 선택 (수동 우선, ASR fallback)
-  const findTrack = (targetLang: string): CaptionTrack | undefined => {
-    const manual = tracks.find(t => t.languageCode === targetLang && t.kind !== "asr");
-    if (manual) return manual;
-    return tracks.find(t => t.languageCode === targetLang);
-  };
+  // HTML entity 디코딩 (&amp;#39; 등 이중 인코딩 대응 — &amp; 먼저 처리)
+  captionData.content = captionData.content
+    .replace(/&amp;/g, "&")
+    .replace(/&#39;/g, "'")
+    .replace(/&quot;/g, '"')
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">");
 
-  let track = findTrack(lang);
-  if (!track && lang !== "en") track = findTrack("en");
-  if (!track) track = tracks[0];
-
-  // 3. 자막 XML fetch (baseUrl에서 fmt=srv3 제거)
-  const captionUrlObj = new URL(track.baseUrl);
-  captionUrlObj.searchParams.delete("fmt");
-  const captionUrl = captionUrlObj.toString();
-  const captionRes = await fetch(captionUrl);
-
-  if (!captionRes.ok) {
-    return Response.json({ error: `Caption fetch error: ${captionRes.status}` }, { status: 502 });
+  // 2. oembed로 제목 가져오기 (Supadata는 title 미제공)
+  let title: string | null = null;
+  try {
+    const oembedRes = await fetch(
+      `https://www.youtube.com/oembed?url=https://www.youtube.com/watch?v=${videoId}&format=json`
+    );
+    if (oembedRes.ok) {
+      const oembedData = await oembedRes.json<{ title?: string }>();
+      title = oembedData?.title ?? null;
+    }
+  } catch {
+    // title은 필수가 아니므로 실패해도 무시
   }
-
-  const xml = await captionRes.text();
-
-  // 4. XML → 텍스트 추출
-  const textParts: string[] = [];
-  const regex = /<text[^>]*>([\s\S]*?)<\/text>/g;
-  let match: RegExpExecArray | null;
-  while ((match = regex.exec(xml)) !== null) {
-    const text = match[1]
-      .replace(/&amp;/g, "&")
-      .replace(/&lt;/g, "<")
-      .replace(/&gt;/g, ">")
-      .replace(/&quot;/g, '"')
-      .replace(/&#39;/g, "'")
-      .replace(/\n/g, " ")
-      .trim();
-    if (text) textParts.push(text);
-  }
-
-  if (textParts.length === 0) {
-    return Response.json({ error: "no_captions" }, { status: 404 });
-  }
-
-  const durationSeconds = parseInt(playerData.videoDetails?.lengthSeconds ?? "0") || 0;
-  const videoTitle = playerData.videoDetails?.title ?? null;
 
   return Response.json({
-    lang: track.languageCode,
-    content: textParts.join(" "),
-    durationSeconds,
-    title: videoTitle,
+    lang: captionData.lang ?? lang,
+    content: captionData.content,
+    title,
   });
 }
 


### PR DESCRIPTION
## Summary
- Worker: InnerTube → Supadata API 전환으로 유튜브 자막 추출 안정화
- 유튜브 요약을 스트리밍으로 전환하여 실시간 표시 + 자막 길이 제한 제거
- AI 스트리밍 본문 삽입 버그 수정 (빠른 응답 시 삽입 누락)
- AI 입력바 툴바 위 고정, 아이콘 색상 통일, UX 개선

## Changes
- **Worker**: InnerTube 직접 파싱 → Supadata API (비동기 폴링, ko→en 폴백)
- **스트리밍**: `generateContentStreamLong` 분리 (maxOutputTokens 65536, 요약 전용)
- **상태관리**: `SummaryState.Streaming` 추가, `snapshotFlow` → `LaunchedEffect` 전환
- **UI**: AI 입력바 툴바 고정, 클립보드 최신화, 툴바 아이콘 chipText 통일
- **프롬프트**: 인사말 금지 규칙 추가, 간결한 응답 지시

## Test plan
- [ ] 유튜브 영상 간단/상세/노트/언어 요약 스트리밍 확인
- [ ] 50분+ 긴 영상 상세요약 잘림 없이 완료 확인
- [ ] AI 직접입력 + 프리셋(핵심요약 등) 본문 삽입 확인
- [ ] 클립보드에서 유튜브 URL 복사 후 다이얼로그 최신화 확인
- [ ] 다크모드/라이트모드 아이콘 색상 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)