### PR TITLE
Fix: 미리보기 카드 HTML 엔티티 노출 버그 수정 (#212)

### DIFF
--- a/feature/core/resource/src/main/java/me/pecos/memozy/presentation/util/HtmlUtils.kt
+++ b/feature/core/resource/src/main/java/me/pecos/memozy/presentation/util/HtmlUtils.kt
@@ -31,3 +31,13 @@ fun String.htmlToPlainText(): String =
             HTML5_ENTITIES[match.groupValues[1]] ?: match.value
         }
         .trim()
+
+// HTML 구조에 필요한 엔티티는 유지하고 나머지만 디코딩
+private val PRESERVE_ENTITIES = setOf("amp", "lt", "gt", "quot")
+
+fun String.decodeHtmlEntities(): String =
+    replace(ENTITY_REGEX) { match ->
+        val name = match.groupValues[1]
+        if (name in PRESERVE_ENTITIES) match.value
+        else HTML5_ENTITIES[name] ?: match.value
+    }

--- a/feature/core/resource/src/main/java/me/pecos/memozy/presentation/util/HtmlUtils.kt
+++ b/feature/core/resource/src/main/java/me/pecos/memozy/presentation/util/HtmlUtils.kt
@@ -1,0 +1,33 @@
+package me.pecos.memozy.presentation.util
+
+import android.text.Html
+
+private val HTML5_ENTITIES = mapOf(
+    "excl" to "!", "quot" to "\"", "num" to "#", "dollar" to "$",
+    "percnt" to "%", "amp" to "&", "apos" to "'", "lpar" to "(",
+    "rpar" to ")", "ast" to "*", "plus" to "+", "comma" to ",",
+    "period" to ".", "sol" to "/", "colon" to ":", "semi" to ";",
+    "lt" to "<", "equals" to "=", "gt" to ">", "quest" to "?",
+    "commat" to "@", "lsqb" to "[", "bsol" to "\\", "rsqb" to "]",
+    "Hat" to "^", "lowbar" to "_", "grave" to "`", "lbrace" to "{",
+    "vert" to "|", "rbrace" to "}", "tilde" to "~",
+    "nbsp" to " ", "iexcl" to "\u00A1", "cent" to "\u00A2",
+    "pound" to "\u00A3", "yen" to "\u00A5", "copy" to "\u00A9",
+    "reg" to "\u00AE", "deg" to "\u00B0", "micro" to "\u00B5",
+    "middot" to "\u00B7", "laquo" to "\u00AB", "raquo" to "\u00BB",
+    "ndash" to "\u2013", "mdash" to "\u2014",
+    "lsquo" to "\u2018", "rsquo" to "\u2019",
+    "ldquo" to "\u201C", "rdquo" to "\u201D",
+    "bull" to "\u2022", "hellip" to "\u2026", "trade" to "\u2122",
+)
+
+private val ENTITY_REGEX = Regex("&(\\w+);")
+
+fun String.htmlToPlainText(): String =
+    this
+        .replace(Regex("<br\\s*/?>"), "\n")
+        .replace(Regex("<[^>]+>"), "")
+        .replace(ENTITY_REGEX) { match ->
+            HTML5_ENTITIES[match.groupValues[1]] ?: match.value
+        }
+        .trim()

--- a/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/home/components/MemoCard.kt
+++ b/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/home/components/MemoCard.kt
@@ -1,5 +1,6 @@
 package me.pecos.memozy.presentation.screen.home.components
 
+import me.pecos.memozy.presentation.util.htmlToPlainText
 import android.content.Context
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
@@ -100,12 +101,7 @@ fun MemoCardItem(
             }
             Spacer(modifier = Modifier.height(8.dp))
             Text(
-                text = memo.content
-                    .replace(Regex("<br\\s*/?>"), "\n")
-                    .replace(Regex("<[^>]+>"), "")
-                    .replace("&nbsp;", " ")
-                    .replace("&amp;", "&")
-                    .trim()
+                text = memo.content.htmlToPlainText()
                     .ifBlank { memo.summaryContent?.take(200) ?: "" },
                 color = colors.textBody,
                 fontFamily = fontSettings.fontFamily,

--- a/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/trash/TrashScreen.kt
+++ b/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/trash/TrashScreen.kt
@@ -1,5 +1,6 @@
 package me.pecos.memozy.presentation.screen.trash
 
+import me.pecos.memozy.presentation.util.htmlToPlainText
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -217,13 +218,7 @@ private fun TrashMemoItem(
         if (memo.content.isNotBlank()) {
             Spacer(modifier = Modifier.height(4.dp))
             Text(
-                text = memo.content
-                    .replace(Regex("<br\\s*/?>"), "\n")
-                    .replace(Regex("<[^>]+>"), "")
-                    .replace("&nbsp;", " ")
-                    .replace("&amp;", "&")
-                    .trim()
-                    .take(100),
+                text = memo.content.htmlToPlainText().take(100),
                 fontSize = fontSettings.scaled(13),
                 color = colors.textBody,
                 maxLines = 2,

--- a/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/MemoScreen.kt
+++ b/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/MemoScreen.kt
@@ -1,5 +1,6 @@
 package me.pecos.memozy.presentation.screen.memo
 
+import me.pecos.memozy.presentation.util.decodeHtmlEntities
 import me.pecos.memozy.presentation.util.htmlToPlainText
 import android.content.Intent
 import android.net.Uri
@@ -597,7 +598,7 @@ fun MemoScreen(
                 // 초기 내용 로드 — 본문만 setHtml + initialHtml 캡처
                 var contentInitialized by remember { mutableStateOf(false) }
                 LaunchedEffect(Unit) {
-                    val editorContent = existingMemo.content
+                    val editorContent = existingMemo.content.decodeHtmlEntities()
                     if (editorContent.isNotEmpty()) {
                         val html = if (editorContent.contains("<") && editorContent.contains(">")) {
                             editorContent

--- a/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/MemoScreen.kt
+++ b/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/MemoScreen.kt
@@ -1,5 +1,6 @@
 package me.pecos.memozy.presentation.screen.memo
 
+import me.pecos.memozy.presentation.util.htmlToPlainText
 import android.content.Intent
 import android.net.Uri
 import androidx.compose.foundation.background
@@ -494,14 +495,7 @@ fun MemoScreen(
                                             appendLine(nameText)
                                             appendLine()
                                         }
-                                        val plainContent = safeContent()
-                                            .replace(Regex("<br\\s*/?>"), "\n")
-                                            .replace(Regex("<[^>]+>"), "")
-                                            .replace("&nbsp;", " ")
-                                            .replace("&amp;", "&")
-                                            .replace("&lt;", "<")
-                                            .replace("&gt;", ">")
-                                            .trim()
+                                        val plainContent = safeContent().htmlToPlainText()
                                         append(plainContent)
                                     }
                                 }


### PR DESCRIPTION
## Summary
- `htmlToPlainText()` 확장 함수 추가 (HTML5 named entity 맵 기반 직접 디코딩)
- `decodeHtmlEntities()` 추가 — 메모 재로드 시 `setHtml()` 전에 엔티티 디코딩
- MemoCard, TrashScreen, MemoScreen(공유) 3곳에 적용

## Test plan
- [ ] 메모에 `@`, `#`, `$`, `!` 등 특수문자 입력 후 저장
- [ ] 홈 화면 미리보기 카드에서 정상 표시 확인
- [ ] 앱 재시작 후 편집 화면에서 정상 표시 확인
- [ ] 휴지통 미리보기에서 정상 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)