### PR TITLE
Fix: 유튜브 요약 내용 짤림 수정 (#213)

### DIFF
--- a/datasource/remote/ai/api/src/main/java/me/pecos/memozy/data/datasource/remote/ai/model/AIRequest.kt
+++ b/datasource/remote/ai/api/src/main/java/me/pecos/memozy/data/datasource/remote/ai/model/AIRequest.kt
@@ -14,11 +14,12 @@ data class GenerationConfig(
     val maxOutputTokens: Int? = null,
 ) {
     companion object {
+        private const val MAX_OUTPUT_TOKENS = 16384
         private const val MAX_OUTPUT_TOKENS_LONG = 65536
 
         val THINKING_DISABLED = GenerationConfig(
             thinkingConfig = ThinkingConfig(thinkingBudget = 0),
-            maxOutputTokens = 16384
+            maxOutputTokens = MAX_OUTPUT_TOKENS
         )
         val THINKING_DISABLED_LONG_OUTPUT = GenerationConfig(
             thinkingConfig = ThinkingConfig(thinkingBudget = 0),

--- a/datasource/remote/ai/api/src/main/java/me/pecos/memozy/data/datasource/remote/ai/model/AIRequest.kt
+++ b/datasource/remote/ai/api/src/main/java/me/pecos/memozy/data/datasource/remote/ai/model/AIRequest.kt
@@ -17,7 +17,8 @@ data class GenerationConfig(
         private const val MAX_OUTPUT_TOKENS_LONG = 65536
 
         val THINKING_DISABLED = GenerationConfig(
-            thinkingConfig = ThinkingConfig(thinkingBudget = 0)
+            thinkingConfig = ThinkingConfig(thinkingBudget = 0),
+            maxOutputTokens = 16384
         )
         val THINKING_DISABLED_LONG_OUTPUT = GenerationConfig(
             thinkingConfig = ThinkingConfig(thinkingBudget = 0),

--- a/datasource/remote/ai/impl/src/main/java/me/pecos/memozy/data/datasource/remote/ai/di/AINetworkModule.kt
+++ b/datasource/remote/ai/impl/src/main/java/me/pecos/memozy/data/datasource/remote/ai/di/AINetworkModule.kt
@@ -116,9 +116,9 @@ abstract class AINetworkModule {
         @YouTubeHttpClient
         fun provideYouTubeHttpClient(): HttpClient = HttpClient(OkHttp) {
             install(HttpTimeout) {
-                requestTimeoutMillis = 15_000
-                connectTimeoutMillis = 10_000
-                socketTimeoutMillis = 15_000
+                requestTimeoutMillis = 60_000
+                connectTimeoutMillis = 15_000
+                socketTimeoutMillis = 60_000
             }
             engine {
                 config {

--- a/workers/src/index.ts
+++ b/workers/src/index.ts
@@ -363,8 +363,8 @@ async function handleWebScrape(req: Request): Promise<Response> {
     .replace(/\s+/g, " ")
     .trim();
 
-  if (text.length > 15000) {
-    text = text.substring(0, 15000) + "...";
+  if (text.length > 50000) {
+    text = text.substring(0, 50000) + "...";
   }
 
   return Response.json({ title, text });


### PR DESCRIPTION
## Summary
- THINKING_DISABLED에 maxOutputTokens=16384 추가 (기본 토큰 제한 해제)
- YouTube HTTP 클라이언트 타임아웃 15초 → 60초
- Worker 웹 스크래핑 문자 제한 15,000 → 50,000

## Test plan
- [ ] 긴 유튜브 영상 요약 시 내용이 끝까지 생성되는지 확인
- [ ] 요약 중 타임아웃으로 끊기지 않는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)