### PR TITLE
Fix: 재요약 시 새 카드 생성하도록 변경 (#215)

### DIFF
--- a/app/src/main/java/me/pecos/memozy/widget/MemoWidget.kt
+++ b/app/src/main/java/me/pecos/memozy/widget/MemoWidget.kt
@@ -131,7 +131,10 @@ class MemoWidget : GlanceAppWidget() {
                                         ),
                                         maxLines = 1
                                     )
-                                    val widgetContent = memo.content.ifBlank { memo.summaryContent ?: "" }
+                                    val summaryPreview = memo.summaryContent?.let {
+                                        me.pecos.memozy.presentation.screen.home.model.parseSummaryEntries(it).firstOrNull()?.content
+                                    }
+                                    val widgetContent = memo.content.ifBlank { summaryPreview ?: "" }
                                     if (widgetContent.isNotBlank()) {
                                         Spacer(modifier = GlanceModifier.height(2.dp))
                                         Text(

--- a/feature/core/resource/src/main/java/me/pecos/memozy/presentation/screen/home/model/SummaryEntry.kt
+++ b/feature/core/resource/src/main/java/me/pecos/memozy/presentation/screen/home/model/SummaryEntry.kt
@@ -1,0 +1,44 @@
+package me.pecos.memozy.presentation.screen.home.model
+
+import org.json.JSONArray
+import org.json.JSONObject
+
+data class SummaryEntry(
+    val content: String,
+    val mode: String = "SIMPLE",
+    val createdAt: Long = System.currentTimeMillis()
+)
+
+fun List<SummaryEntry>.toJson(): String {
+    val array = JSONArray()
+    for (entry in this) {
+        array.put(JSONObject().apply {
+            put("content", entry.content)
+            put("mode", entry.mode)
+            put("createdAt", entry.createdAt)
+        })
+    }
+    return array.toString()
+}
+
+fun parseSummaryEntries(json: String?): List<SummaryEntry> {
+    if (json.isNullOrBlank()) return emptyList()
+    return try {
+        if (json.trimStart().startsWith("[")) {
+            val array = JSONArray(json)
+            (0 until array.length()).map { i ->
+                val obj = array.getJSONObject(i)
+                SummaryEntry(
+                    content = obj.getString("content"),
+                    mode = obj.optString("mode", "SIMPLE"),
+                    createdAt = obj.optLong("createdAt", 0L)
+                )
+            }
+        } else {
+            // Legacy: plain text → single entry
+            listOf(SummaryEntry(content = json))
+        }
+    } catch (_: Exception) {
+        if (json.isNotBlank()) listOf(SummaryEntry(content = json)) else emptyList()
+    }
+}

--- a/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/home/components/MemoCard.kt
+++ b/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/home/components/MemoCard.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import me.pecos.memozy.presentation.screen.home.model.MemoUiState
+import me.pecos.memozy.presentation.screen.home.model.parseSummaryEntries
 import me.pecos.memozy.feature.core.resource.R
 import me.pecos.memozy.presentation.screen.home.util.formatMemoTime
 import me.pecos.memozy.presentation.theme.LocalAppColors
@@ -106,7 +107,7 @@ fun MemoCardItem(
                     .replace("&nbsp;", " ")
                     .replace("&amp;", "&")
                     .trim()
-                    .ifBlank { memo.summaryContent?.take(200) ?: "" },
+                    .ifBlank { parseSummaryEntries(memo.summaryContent).firstOrNull()?.content?.take(200) ?: "" },
                 color = colors.textBody,
                 fontFamily = fontSettings.fontFamily,
                 fontSize = fontSettings.bodySize,

--- a/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/MemoScreen.kt
+++ b/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/MemoScreen.kt
@@ -107,7 +107,11 @@ import androidx.compose.ui.unit.sp
 import com.wanted.android.wanted.design.theme.DesignSystemTheme
 import com.wanted.android.wanted.design.input.textinput.textfield.WantedTextField
 import com.wanted.android.wanted.design.input.textinput.textarea.WantedTextArea
+import androidx.compose.runtime.mutableStateListOf
 import me.pecos.memozy.presentation.screen.home.model.MemoUiState
+import me.pecos.memozy.presentation.screen.home.model.SummaryEntry
+import me.pecos.memozy.presentation.screen.home.model.parseSummaryEntries
+import me.pecos.memozy.presentation.screen.home.model.toJson
 import me.pecos.memozy.feature.core.resource.CATEGORY_EMOJIS
 import me.pecos.memozy.feature.core.resource.CATEGORY_RES_IDS
 import me.pecos.memozy.feature.core.resource.R
@@ -293,9 +297,12 @@ fun MemoScreen(
     var selectedSummaryStyle by remember { mutableStateOf(SummaryStyle.SIMPLE) }
 
     // 요약 콘텐츠 접기/펼치기 상태 (summaryContent 별도 컬럼에서 로드)
-    val initialSummary = remember(existingMemo.id) { existingMemo.summaryContent }
-    var summaryText by remember { mutableStateOf(initialSummary) }
-    var isSummaryExpanded by remember { mutableStateOf(if (initialSummary == null) true else existingMemo.isSummaryExpanded) }
+    val summaryEntries = remember { mutableStateListOf<SummaryEntry>() }
+    LaunchedEffect(existingMemo.id) {
+        summaryEntries.clear()
+        summaryEntries.addAll(parseSummaryEntries(existingMemo.summaryContent))
+    }
+    var isSummaryExpanded by remember { mutableStateOf(if (existingMemo.summaryContent == null) true else existingMemo.isSummaryExpanded) }
     var webSummaryText by remember { mutableStateOf<String?>(null) }
     var isWebSummaryExpanded by remember { mutableStateOf(initialSummary == null) }
 
@@ -312,8 +319,9 @@ fun MemoScreen(
             val newText = YOUTUBE_URL_REGEX.replace(bodyText, "").trim()
             bodyText = newText
             richTextState.setHtml(newText.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace("\n", "<br>"))
-            // 요약 텍스트를 별도 상태에 저장
-            summaryText = summaryResult
+            // 요약 텍스트를 리스트에 추가 (덮어쓰지 않음)
+            val mode = currentSummaryMode?.name ?: "SIMPLE"
+            summaryEntries.add(0, SummaryEntry(content = summaryResult, mode = mode))
             isSummaryExpanded = true  // 새 요약 완료 시 펼침
             if (youtubeTitle != null && nameText.isBlank()) {
                 nameText = youtubeTitle
@@ -384,10 +392,13 @@ fun MemoScreen(
         val editorHtml = richTextState.toHtml().trim()
         return if (editorHtml.isNotBlank() && editorHtml != "<p><br></p>") editorHtml else ""
     }
-    fun safeSummaryContent(): String? = summaryText ?: webSummaryText
+    fun safeSummaryContent(): String? {
+        if (summaryEntries.isNotEmpty()) return summaryEntries.toJson()
+        return webSummaryText
+    }
     fun safeStyles(): String? = richTextState.toHtml().takeIf { it.isNotBlank() }
 
-    val canAutoSave = nameText.isNotBlank() || bodyText.isNotBlank() || summaryText != null || webSummaryText != null
+    val canAutoSave = nameText.isNotBlank() || bodyText.isNotBlank() || summaryEntries.isNotEmpty() || webSummaryText != null
 
     // ON_PAUSE 라이프사이클 저장 — 화면 이탈 시에만 저장 (snapshotFlow 제거)
     if (onAutoSave != null) {
@@ -471,7 +482,7 @@ fun MemoScreen(
                 Spacer(modifier = Modifier.weight(1f))
 
                 // 공유 버튼 (기존 메모 또는 요약이 있을 때)
-                val hasSharableContent = !isNewMemo || summaryText != null || webSummaryText != null
+                val hasSharableContent = !isNewMemo || summaryEntries.isNotEmpty() || webSummaryText != null
                 if (hasSharableContent) {
                     Icon(
                         imageVector = Icons.Default.Share,
@@ -486,7 +497,7 @@ fun MemoScreen(
                                         appendLine(ytUrl)
                                         appendLine()
                                     }
-                                    val summary = summaryText ?: webSummaryText
+                                    val summary = summaryEntries.firstOrNull()?.content ?: webSummaryText
                                     if (summary != null) {
                                         append(summary)
                                     } else {
@@ -634,7 +645,7 @@ fun MemoScreen(
                 val ytVideoId = remember(youtubeUrlDisplay) {
                     Regex("""(?:v=|youtu\.be/|shorts/)([a-zA-Z0-9_-]{11})""").find(youtubeUrlDisplay)?.groupValues?.get(1)
                 }
-                val showYoutubeInline = summaryText != null || (youtubeUrlDisplay.isNotBlank() && !youtubeChipDismissed && (savedYoutubeUrl != null || summaryResult != null || youtubeTitle != null))
+                val showYoutubeInline = summaryEntries.isNotEmpty() || (youtubeUrlDisplay.isNotBlank() && !youtubeChipDismissed && (savedYoutubeUrl != null || summaryResult != null || youtubeTitle != null))
                 if (showYoutubeInline) {
                     YouTubeSummaryInlineCard(
                         youtubeUrl = youtubeUrlDisplay,
@@ -643,18 +654,23 @@ fun MemoScreen(
                         memoTitle = nameText,
                         isExpanded = isSummaryExpanded,
                         onExpandToggle = { isSummaryExpanded = it },
-                        summaryText = if (isSummarizing && summaryResult != null) summaryResult else summaryText,
+                        summaryEntries = summaryEntries.toList(),
+                        streamingText = if (isSummarizing && summaryResult != null) summaryResult else null,
                         isSummarizing = isSummarizing,
                         currentSummaryMode = currentSummaryMode,
                         onSummarize = onYoutubeSummarize,
                         onCancelSummarize = onCancelSummarize,
                         onResummarize = { altMode ->
-                            summaryText = null
                             summaryApplied = false
                             currentSummaryMode = altMode
                             detectedYoutubeUrl?.let { onYoutubeSummarize?.invoke(it, altMode) }
                         },
-                        onDeleteSummary = { showSummaryDeleteDialog = "youtube" },
+                        onDeleteSummary = { index ->
+                            if (index < summaryEntries.size) {
+                                summaryEntries.removeAt(index)
+                            }
+                        },
+                        onDeleteAllSummaries = { showSummaryDeleteDialog = "youtube" },
                         onAskAi = if (onAiCustomSend != null) { {
                             showAiCustomInput = true
                         } } else null,
@@ -1085,7 +1101,7 @@ fun MemoScreen(
                 TextButton(onClick = {
                     when (showSummaryDeleteDialog) {
                         "youtube" -> {
-                            summaryText = null
+                            summaryEntries.clear()
                             summaryApplied = false
                         }
                         "web" -> {

--- a/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/components/YouTubeSummaryInlineCard.kt
+++ b/feature/memo-plain/impl/src/main/java/me/pecos/memozy/presentation/screen/memo/components/YouTubeSummaryInlineCard.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import me.pecos.memozy.feature.core.resource.R
+import me.pecos.memozy.presentation.screen.home.model.SummaryEntry
 import me.pecos.memozy.presentation.screen.memo.SummaryMode
 import me.pecos.memozy.presentation.theme.AppColors
 import me.pecos.memozy.presentation.theme.LocalFontSettings
@@ -53,13 +54,15 @@ fun YouTubeSummaryInlineCard(
     memoTitle: String,
     isExpanded: Boolean,
     onExpandToggle: (Boolean) -> Unit,
-    summaryText: String?,
+    summaryEntries: List<SummaryEntry>,
+    streamingText: String?,
     isSummarizing: Boolean,
     currentSummaryMode: SummaryMode?,
     onSummarize: ((String, SummaryMode) -> Unit)?,
     onCancelSummarize: (() -> Unit)?,
     onResummarize: (SummaryMode) -> Unit,
-    onDeleteSummary: (() -> Unit)? = null,
+    onDeleteSummary: ((Int) -> Unit)? = null,
+    onDeleteAllSummaries: (() -> Unit)? = null,
     onAskAi: (() -> Unit)? = null,
     colors: AppColors,
     context: Context,
@@ -67,6 +70,7 @@ fun YouTubeSummaryInlineCard(
     onStyleSelect: (() -> Unit)? = null
 ) {
     val fontSettings = LocalFontSettings.current
+    val hasSummary = summaryEntries.isNotEmpty()
 
     // 접힌 상태
     if (!isExpanded) {
@@ -160,7 +164,7 @@ fun YouTubeSummaryInlineCard(
                         Spacer(modifier = Modifier.width(3.dp))
                         Text(stringResource(R.string.memo_copy), fontSize = fontSettings.scaled(10), color = colors.chipText, fontWeight = FontWeight.Medium)
                     }
-                    if (onSummarize != null && summaryText == null && onStyleSelect != null) {
+                    if (onSummarize != null && onStyleSelect != null) {
                         Row(
                             modifier = Modifier.weight(1f).clip(RoundedCornerShape(6.dp)).background(Color(0xFF2196F3).copy(alpha = 0.1f))
                                 .clickable { onStyleSelect() }
@@ -183,14 +187,51 @@ fun YouTubeSummaryInlineCard(
                         Icon(Icons.Default.Close, contentDescription = null, tint = colors.textSecondary,
                             modifier = Modifier.size(16.dp).clickable { onCancelSummarize?.invoke() })
                     }
+                    // 스트리밍 텍스트 표시
+                    if (streamingText != null) {
+                        Spacer(modifier = Modifier.height(8.dp))
+                        HorizontalDivider(color = colors.cardBorder)
+                        Spacer(modifier = Modifier.height(8.dp))
+                        Text(streamingText, fontSize = fontSettings.scaled(14), lineHeight = 22.sp, color = colors.textBody)
+                    }
                 }
 
-                // 요약 텍스트
-                if (summaryText != null) {
+                // 요약 엔트리들 (각각 별도 섹션)
+                summaryEntries.forEachIndexed { index, entry ->
                     Spacer(modifier = Modifier.height(10.dp))
                     HorizontalDivider(color = colors.cardBorder)
                     Spacer(modifier = Modifier.height(8.dp))
-                    Text(summaryText, fontSize = fontSettings.scaled(14), lineHeight = 22.sp, color = colors.textBody)
+
+                    // 모드 라벨 + 삭제 버튼
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        val modeLabel = when (entry.mode) {
+                            "DETAILED" -> stringResource(R.string.summary_style_detailed)
+                            else -> stringResource(R.string.summary_style_simple)
+                        }
+                        Text(
+                            text = modeLabel,
+                            fontSize = fontSettings.scaled(11),
+                            fontWeight = FontWeight.Medium,
+                            color = Color(0xFF2196F3)
+                        )
+                        if (onDeleteSummary != null) {
+                            Icon(
+                                Icons.Default.Close,
+                                contentDescription = null,
+                                tint = colors.textSecondary,
+                                modifier = Modifier
+                                    .size(16.dp)
+                                    .clickable { onDeleteSummary(index) }
+                            )
+                        }
+                    }
+
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text(entry.content, fontSize = fontSettings.scaled(14), lineHeight = 22.sp, color = colors.textBody)
 
                     // 요약 내용 복사 + AI 물어보기 버튼
                     Spacer(modifier = Modifier.height(8.dp))
@@ -203,7 +244,7 @@ fun YouTubeSummaryInlineCard(
                                 .clip(RoundedCornerShape(6.dp))
                                 .background(colors.chipBackground)
                                 .clickable {
-                                    clipboardManager.setText(AnnotatedString(summaryText))
+                                    clipboardManager.setText(AnnotatedString(entry.content))
                                     Toast.makeText(context, context.getString(R.string.memo_copy_done), Toast.LENGTH_SHORT).show()
                                 }
                                 .padding(vertical = 6.dp),
@@ -234,7 +275,7 @@ fun YouTubeSummaryInlineCard(
                 }
 
                 // 접기 버튼
-                if (summaryText != null) {
+                if (hasSummary) {
                     Spacer(modifier = Modifier.height(8.dp))
                     Row(
                         modifier = Modifier.fillMaxWidth().clickable { onExpandToggle(false) },
@@ -246,8 +287,8 @@ fun YouTubeSummaryInlineCard(
                 }
             }
         }
-        // X 삭제 버튼 (요약 있을 때만)
-        if (summaryText != null && onDeleteSummary != null) {
+        // X 삭제 버튼 (요약 있을 때만 — 전체 삭제)
+        if (hasSummary && onDeleteAllSummaries != null) {
             Icon(
                 Icons.Default.Close,
                 contentDescription = null,
@@ -256,7 +297,7 @@ fun YouTubeSummaryInlineCard(
                     .size(28.dp)
                     .align(Alignment.TopEnd)
                     .padding(6.dp)
-                    .clickable { onDeleteSummary() }
+                    .clickable { onDeleteAllSummaries() }
             )
         }
         }


### PR DESCRIPTION
## Summary
- SummaryEntry 모델 추가 + JSON 직렬화/역직렬화
- summaryContent를 JSON 배열로 저장하여 다중 요약 지원
- 재요약 시 기존 요약을 덮어쓰지 않고 리스트에 추가
- 각 요약 카드에 모드 라벨(간단/상세) + 개별 삭제 버튼
- MemoCard, MemoWidget에서 JSON 파싱 처리

## Test plan
- [ ] 같은 영상 간단/상세 요약 시 각각 별도 카드 생성 확인
- [ ] 앱 재시작 후 모든 요약 카드 유지 확인
- [ ] 개별 요약 삭제 동작 확인
- [ ] 홈 카드 미리보기에 JSON이 아닌 요약 텍스트 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)