### PR TITLE
Add: 비로그인 AI 차단 + 로그인 유도 알림 (#217)

### DIFF
--- a/feature/core/resource/src/main/java/me/pecos/memozy/presentation/theme/AppCompositionLocals.kt
+++ b/feature/core/resource/src/main/java/me/pecos/memozy/presentation/theme/AppCompositionLocals.kt
@@ -1,0 +1,6 @@
+package me.pecos.memozy.presentation.theme
+
+import androidx.compose.runtime.compositionLocalOf
+
+val LocalSubscriptionTier = compositionLocalOf { SubscriptionTier.FREE }
+val LocalIsLoggedIn = compositionLocalOf { false }

--- a/feature/core/resource/src/main/java/me/pecos/memozy/presentation/theme/SubscriptionTier.kt
+++ b/feature/core/resource/src/main/java/me/pecos/memozy/presentation/theme/SubscriptionTier.kt
@@ -1,7 +1,5 @@
 package me.pecos.memozy.presentation.theme
 
-import androidx.compose.runtime.compositionLocalOf
-
 enum class SubscriptionTier {
     FREE, PRO;
 
@@ -13,6 +11,3 @@ enum class SubscriptionTier {
 
     val isPro: Boolean get() = this == PRO
 }
-
-val LocalSubscriptionTier = compositionLocalOf { SubscriptionTier.FREE }
-val LocalIsLoggedIn = compositionLocalOf { false }

--- a/feature/core/resource/src/main/java/me/pecos/memozy/presentation/theme/SubscriptionTier.kt
+++ b/feature/core/resource/src/main/java/me/pecos/memozy/presentation/theme/SubscriptionTier.kt
@@ -15,3 +15,4 @@ enum class SubscriptionTier {
 }
 
 val LocalSubscriptionTier = compositionLocalOf { SubscriptionTier.FREE }
+val LocalIsLoggedIn = compositionLocalOf { false }

--- a/feature/core/resource/src/main/res/values/strings.xml
+++ b/feature/core/resource/src/main/res/values/strings.xml
@@ -263,6 +263,10 @@
     <string name="subscription_manage">구독 관리</string>
     <string name="subscription_restore">구매 복원</string>
 
+    <!-- Login Prompt -->
+    <string name="login_prompt_title">로그인이 필요해요</string>
+    <string name="login_prompt_message">AI 요약 기능을 사용하려면 Google 계정으로 로그인해주세요.\n설정 > 계정에서 로그인할 수 있어요.</string>
+
     <!-- Memozy AI -->
     <string name="memozy_ai">Memozy AI</string>
     <string name="ai_action_explain">이해하기 쉽게 설명해줘</string>

--- a/feature/home/impl/src/main/java/me/pecos/memozy/MainActivity.kt
+++ b/feature/home/impl/src/main/java/me/pecos/memozy/MainActivity.kt
@@ -58,6 +58,7 @@ import dev.chrisbanes.haze.hazeEffect
 import dev.chrisbanes.haze.hazeSource
 import dev.chrisbanes.haze.rememberHazeState
 import me.pecos.memozy.data.billing.BillingManager
+import me.pecos.memozy.data.datasource.remote.auth.AuthState
 import me.pecos.memozy.presentation.theme.LocalRewardAdProvider
 import me.pecos.memozy.presentation.theme.LocalIsLoggedIn
 import me.pecos.memozy.presentation.theme.LocalSubscriptionTier
@@ -164,7 +165,7 @@ class MainActivity : AppCompatActivity() {
 
             val currentTier by billingManager.subscriptionTier.collectAsState()
             val authState by settingsViewModel.authState.collectAsState()
-            val isLoggedIn = authState is me.pecos.memozy.data.datasource.remote.auth.AuthState.Authenticated
+            val isLoggedIn = authState is AuthState.Authenticated
 
             CompositionLocalProvider(
                 LocalActivity provides this@MainActivity,

--- a/feature/home/impl/src/main/java/me/pecos/memozy/MainActivity.kt
+++ b/feature/home/impl/src/main/java/me/pecos/memozy/MainActivity.kt
@@ -59,6 +59,7 @@ import dev.chrisbanes.haze.hazeSource
 import dev.chrisbanes.haze.rememberHazeState
 import me.pecos.memozy.data.billing.BillingManager
 import me.pecos.memozy.presentation.theme.LocalRewardAdProvider
+import me.pecos.memozy.presentation.theme.LocalIsLoggedIn
 import me.pecos.memozy.presentation.theme.LocalSubscriptionTier
 import me.pecos.memozy.feature.home.api.HomeRoute
 import me.pecos.memozy.feature.memoplain.api.MemoPlainNavigation
@@ -162,11 +163,14 @@ class MainActivity : AppCompatActivity() {
             )
 
             val currentTier by billingManager.subscriptionTier.collectAsState()
+            val authState by settingsViewModel.authState.collectAsState()
+            val isLoggedIn = authState is me.pecos.memozy.data.datasource.remote.auth.AuthState.Authenticated
 
             CompositionLocalProvider(
                 LocalActivity provides this@MainActivity,
                 LocalSubscriptionTier provides currentTier,
-                LocalRewardAdProvider provides rewardAdManager
+                LocalRewardAdProvider provides rewardAdManager,
+                LocalIsLoggedIn provides isLoggedIn
             ) {
             OverrideNightMode(isDarkTheme = isDarkTheme) {
                 CompositionLocalProvider(

--- a/feature/memo-plain/impl/src/main/java/me/pecos/memozy/feature/memoplain/impl/MemoPlainNavigationImpl.kt
+++ b/feature/memo-plain/impl/src/main/java/me/pecos/memozy/feature/memoplain/impl/MemoPlainNavigationImpl.kt
@@ -11,8 +11,10 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Box
 import androidx.core.content.ContextCompat
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -23,6 +25,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import me.pecos.memozy.feature.core.resource.R
 import me.pecos.memozy.presentation.screen.memo.SummaryMode
 import me.pecos.memozy.presentation.screen.memo.SummaryStyle
 import androidx.compose.ui.unit.dp
@@ -58,6 +62,7 @@ import me.pecos.memozy.presentation.screen.home.model.MemoUiState
 import me.pecos.memozy.presentation.screen.memo.MemoScreen
 import me.pecos.memozy.presentation.screen.memo.components.AiLimitBottomSheet
 import me.pecos.memozy.presentation.theme.LocalAppColors
+import me.pecos.memozy.presentation.theme.LocalIsLoggedIn
 import me.pecos.memozy.presentation.theme.LocalRewardAdProvider
 import me.pecos.memozy.presentation.theme.LocalSubscriptionTier
 import javax.inject.Inject
@@ -323,7 +328,7 @@ class MemoPlainNavigationImpl @Inject constructor(
             }
 
             // 로그인 여부 체크
-            val isLoggedIn = me.pecos.memozy.presentation.theme.LocalIsLoggedIn.current
+            val isLoggedIn = LocalIsLoggedIn.current
             var showLoginPrompt by remember { mutableStateOf(false) }
 
             // AI 사용량 체크 (티어별 일일 한도)
@@ -342,6 +347,9 @@ class MemoPlainNavigationImpl @Inject constructor(
             val canWatchAd = !subscriptionTier.isPro && dailyAdViewCount < MAX_DAILY_AD_VIEWS
             val remainingAdViews = MAX_DAILY_AD_VIEWS - dailyAdViewCount
             var showLimitBottomSheet by remember { mutableStateOf(false) }
+            val notifyAiBlocked: () -> Unit = {
+                if (!isLoggedIn) showLoginPrompt = true else showLimitBottomSheet = true
+            }
 
             // 이미지 OCR 처리
             var imageOcrState by remember { mutableStateOf<SummaryState>(SummaryState.Idle) }
@@ -637,7 +645,7 @@ class MemoPlainNavigationImpl @Inject constructor(
                 youtubeTitle = youtubeTitle,
                 onStartRecording = {
                     if (!canUseAi) {
-                        if (!isLoggedIn) showLoginPrompt = true else showLimitBottomSheet = true
+                        notifyAiBlocked()
                     } else {
                         startRecording()
                     }
@@ -657,7 +665,7 @@ class MemoPlainNavigationImpl @Inject constructor(
                 },
                 onWebSummarize = { url, mode ->
                     if (!canUseAi) {
-                        if (!isLoggedIn) showLoginPrompt = true else showLimitBottomSheet = true
+                        notifyAiBlocked()
                         return@MemoScreen
                     }
                     currentSummarizeJob = scope.launch {
@@ -862,7 +870,7 @@ class MemoPlainNavigationImpl @Inject constructor(
                 },
                 onAiCustomSend = { userMessage, currentTitle, currentBody ->
                     if (!canUseAi) {
-                        if (!isLoggedIn) showLoginPrompt = true else showLimitBottomSheet = true
+                        notifyAiBlocked()
                         return@MemoScreen
                     }
                     aiAssistJob?.cancel()
@@ -913,7 +921,7 @@ class MemoPlainNavigationImpl @Inject constructor(
                 },
                 onAiPresetAction = { actionName, currentTitle, currentBody ->
                     if (!canUseAi) {
-                        if (!isLoggedIn) showLoginPrompt = true else showLimitBottomSheet = true
+                        notifyAiBlocked()
                         return@MemoScreen
                     }
                     aiAssistJob?.cancel()
@@ -984,13 +992,13 @@ class MemoPlainNavigationImpl @Inject constructor(
             )
 
             if (showLoginPrompt) {
-                androidx.compose.material3.AlertDialog(
+                AlertDialog(
                     onDismissRequest = { showLoginPrompt = false },
-                    title = { androidx.compose.material3.Text(androidx.compose.ui.res.stringResource(me.pecos.memozy.feature.core.resource.R.string.login_prompt_title)) },
-                    text = { androidx.compose.material3.Text(androidx.compose.ui.res.stringResource(me.pecos.memozy.feature.core.resource.R.string.login_prompt_message)) },
+                    title = { Text(stringResource(R.string.login_prompt_title)) },
+                    text = { Text(stringResource(R.string.login_prompt_message)) },
                     confirmButton = {
-                        androidx.compose.material3.TextButton(onClick = { showLoginPrompt = false }) {
-                            androidx.compose.material3.Text(androidx.compose.ui.res.stringResource(me.pecos.memozy.feature.core.resource.R.string.confirm))
+                        TextButton(onClick = { showLoginPrompt = false }) {
+                            Text(stringResource(R.string.confirm))
                         }
                     }
                 )

--- a/feature/memo-plain/impl/src/main/java/me/pecos/memozy/feature/memoplain/impl/MemoPlainNavigationImpl.kt
+++ b/feature/memo-plain/impl/src/main/java/me/pecos/memozy/feature/memoplain/impl/MemoPlainNavigationImpl.kt
@@ -322,6 +322,10 @@ class MemoPlainNavigationImpl @Inject constructor(
                 }
             }
 
+            // 로그인 여부 체크
+            val isLoggedIn = me.pecos.memozy.presentation.theme.LocalIsLoggedIn.current
+            var showLoginPrompt by remember { mutableStateOf(false) }
+
             // AI 사용량 체크 (티어별 일일 한도)
             val subscriptionTier = LocalSubscriptionTier.current
             val rewardAdProvider = LocalRewardAdProvider.current
@@ -333,7 +337,8 @@ class MemoPlainNavigationImpl @Inject constructor(
                 dailyAdViewCount = aiUsageDao.getCountSince(FEATURE_REWARD_AD, startOfToday())
             }
             val dailyLimit = subscriptionTier.dailyAiLimit + adBonusCount
-            val canUseAi = dailyUsageCount < dailyLimit
+            val canUseAiQuota = dailyUsageCount < dailyLimit
+            val canUseAi = isLoggedIn && canUseAiQuota
             val canWatchAd = !subscriptionTier.isPro && dailyAdViewCount < MAX_DAILY_AD_VIEWS
             val remainingAdViews = MAX_DAILY_AD_VIEWS - dailyAdViewCount
             var showLimitBottomSheet by remember { mutableStateOf(false) }
@@ -632,7 +637,7 @@ class MemoPlainNavigationImpl @Inject constructor(
                 youtubeTitle = youtubeTitle,
                 onStartRecording = {
                     if (!canUseAi) {
-                        showLimitBottomSheet = true
+                        if (!isLoggedIn) showLoginPrompt = true else showLimitBottomSheet = true
                     } else {
                         startRecording()
                     }
@@ -652,7 +657,7 @@ class MemoPlainNavigationImpl @Inject constructor(
                 },
                 onWebSummarize = { url, mode ->
                     if (!canUseAi) {
-                        showLimitBottomSheet = true
+                        if (!isLoggedIn) showLoginPrompt = true else showLimitBottomSheet = true
                         return@MemoScreen
                     }
                     currentSummarizeJob = scope.launch {
@@ -857,7 +862,7 @@ class MemoPlainNavigationImpl @Inject constructor(
                 },
                 onAiCustomSend = { userMessage, currentTitle, currentBody ->
                     if (!canUseAi) {
-                        showLimitBottomSheet = true
+                        if (!isLoggedIn) showLoginPrompt = true else showLimitBottomSheet = true
                         return@MemoScreen
                     }
                     aiAssistJob?.cancel()
@@ -908,7 +913,7 @@ class MemoPlainNavigationImpl @Inject constructor(
                 },
                 onAiPresetAction = { actionName, currentTitle, currentBody ->
                     if (!canUseAi) {
-                        showLimitBottomSheet = true
+                        if (!isLoggedIn) showLoginPrompt = true else showLimitBottomSheet = true
                         return@MemoScreen
                     }
                     aiAssistJob?.cancel()
@@ -977,6 +982,19 @@ class MemoPlainNavigationImpl @Inject constructor(
                     }
                 },
             )
+
+            if (showLoginPrompt) {
+                androidx.compose.material3.AlertDialog(
+                    onDismissRequest = { showLoginPrompt = false },
+                    title = { androidx.compose.material3.Text(androidx.compose.ui.res.stringResource(me.pecos.memozy.feature.core.resource.R.string.login_prompt_title)) },
+                    text = { androidx.compose.material3.Text(androidx.compose.ui.res.stringResource(me.pecos.memozy.feature.core.resource.R.string.login_prompt_message)) },
+                    confirmButton = {
+                        androidx.compose.material3.TextButton(onClick = { showLoginPrompt = false }) {
+                            androidx.compose.material3.Text(androidx.compose.ui.res.stringResource(me.pecos.memozy.feature.core.resource.R.string.confirm))
+                        }
+                    }
+                )
+            }
 
             if (showLimitBottomSheet) {
                 AiLimitBottomSheet(


### PR DESCRIPTION
## Summary
- `LocalIsLoggedIn` CompositionLocal 추가하여 로그인 상태를 앱 전체에 전달
- 비로그인 사용자가 AI 기능(유튜브 요약, 웹 요약, 녹음, AI 어시스트) 시도 시 로그인 유도 다이얼로그 표시
- 로그인 사용자는 기존 일일 한도 체크 유지

## Test plan
- [ ] 비로그인 상태에서 유튜브 요약 시도 → 로그인 유도 다이얼로그 표시
- [ ] 비로그인 상태에서 녹음/AI 기능 시도 → 로그인 유도 다이얼로그 표시
- [ ] 로그인 상태에서 AI 기능 정상 동작 확인
- [ ] 한도 초과 시 기존 한도 바텀시트 정상 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)