### PR TITLE
Update: #219 Phase 1 인프라 (joda 치환 + iOS CI)

### DIFF
--- a/.github/workflows/kmp-ios-check.yml
+++ b/.github/workflows/kmp-ios-check.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   ios-compile:
     runs-on: macos-latest
-    timeout-minutes: 40
+    timeout-minutes: 25
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/kmp-ios-check.yml
+++ b/.github/workflows/kmp-ios-check.yml
@@ -1,0 +1,36 @@
+name: KMP iOS Compile Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'shared/**'
+      - 'build-logic/**'
+      - 'gradle/libs.versions.toml'
+      - 'gradle.properties'
+      - 'settings.gradle.kts'
+      - '.github/workflows/kmp-ios-check.yml'
+
+jobs:
+  ios-compile:
+    runs-on: macos-latest
+    timeout-minutes: 40
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Compile iOS targets (shared:poc)
+        run: |
+          ./gradlew :shared:poc:compileKotlinIosX64 \
+                    :shared:poc:compileKotlinIosArm64 \
+                    :shared:poc:compileKotlinIosSimulatorArm64 \
+                    --no-daemon --stacktrace

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -62,8 +62,8 @@ dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)
 
-    // MemozyApplication
-    implementation(libs.android.joda)
+    // date/time
+    implementation(libs.kotlinx.datetime)
 
     // work manager
     implementation(libs.work.runtime)

--- a/feature/home/impl/build.gradle.kts
+++ b/feature/home/impl/build.gradle.kts
@@ -39,7 +39,7 @@ dependencies {
     implementation(libs.androidx.appcompat)
     implementation(libs.androidx.compose.navigation)
     implementation(libs.haze)
-    implementation(libs.android.joda)
+    implementation(libs.kotlinx.datetime)
     implementation(libs.montage.android)
     implementation(libs.billing.ktx)
     implementation(libs.play.services.ads)

--- a/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/home/util/TimeUtils.kt
+++ b/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/home/util/TimeUtils.kt
@@ -3,12 +3,16 @@ package me.pecos.memozy.presentation.screen.home.util
 import kotlinx.datetime.Clock
 import kotlinx.datetime.DatePeriod
 import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.minus
 import kotlinx.datetime.toLocalDateTime
 import kotlinx.datetime.todayIn
 
 // ── 시간 포맷 ───────────────────────────────────────────────────────────────────
+
+private fun LocalDate.formatDot(): String =
+    "%04d.%02d.%02d".format(year, monthNumber, dayOfMonth)
 
 fun formatMemoTime(createdAt: Long, languageCode: String): String {
     if (createdAt == 0L) return ""
@@ -46,6 +50,6 @@ fun formatMemoTime(createdAt: Long, languageCode: String): String {
             "ja" -> "昨日"
             else -> "어제"
         }
-        else -> "${createdDate.year}.${createdDate.monthNumber.toString().padStart(2, '0')}.${createdDate.dayOfMonth.toString().padStart(2, '0')}"
+        else -> createdDate.formatDot()
     }
 }

--- a/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/home/util/TimeUtils.kt
+++ b/feature/home/impl/src/main/java/me/pecos/memozy/presentation/screen/home/util/TimeUtils.kt
@@ -1,23 +1,28 @@
 package me.pecos.memozy.presentation.screen.home.util
 
-import org.joda.time.DateTime
-import org.joda.time.LocalDate
-import org.joda.time.format.DateTimeFormat
+import kotlinx.datetime.Clock
+import kotlinx.datetime.DatePeriod
+import kotlinx.datetime.Instant
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.minus
+import kotlinx.datetime.toLocalDateTime
+import kotlinx.datetime.todayIn
 
 // ── 시간 포맷 ───────────────────────────────────────────────────────────────────
 
 fun formatMemoTime(createdAt: Long, languageCode: String): String {
     if (createdAt == 0L) return ""
 
-    val created = DateTime(createdAt)
-    val today = LocalDate.now()
-    val yesterday = today.minusDays(1)
-    val createdDate = created.toLocalDate()
+    val tz = TimeZone.currentSystemDefault()
+    val createdLdt = Instant.fromEpochMilliseconds(createdAt).toLocalDateTime(tz)
+    val createdDate = createdLdt.date
+    val today = Clock.System.todayIn(tz)
+    val yesterday = today.minus(DatePeriod(days = 1))
 
-    return when {
-        createdDate.isEqual(today) -> {
-            val hour = created.hourOfDay
-            val minute = created.minuteOfHour
+    return when (createdDate) {
+        today -> {
+            val hour = createdLdt.hour
+            val minute = createdLdt.minute
             when (languageCode) {
                 "en" -> {
                     val ampm = if (hour < 12) "AM" else "PM"
@@ -36,11 +41,11 @@ fun formatMemoTime(createdAt: Long, languageCode: String): String {
                 }
             }
         }
-        createdDate.isEqual(yesterday) -> when (languageCode) {
+        yesterday -> when (languageCode) {
             "en" -> "Yesterday"
             "ja" -> "昨日"
             else -> "어제"
         }
-        else -> DateTimeFormat.forPattern("yyyy.MM.dd").print(created)
+        else -> "${createdDate.year}.${createdDate.monthNumber.toString().padStart(2, '0')}.${createdDate.dayOfMonth.toString().padStart(2, '0')}"
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ composeBom = "2025.05.00"
 ksp = "2.3.6"
 billingKtx = "7.1.1"
 playServicesAds = "24.4.0"
-androidJoda = "2.12.7"
+kotlinxDatetime = "0.6.2"
 haze = "1.7.2"
 montageAndroid = "3.3.0"
 room = "2.7.0"
@@ -41,7 +41,7 @@ gradlePlugin-ksp = { module = "com.google.devtools.ksp:com.google.devtools.ksp.g
 gradlePlugin-kotlinSerialization = { module = "org.jetbrains.kotlin:kotlin-serialization", version.ref = "kotlin" }
 gradlePlugin-kotlinMultiplatform = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 sqlite-bundled = { group = "androidx.sqlite", name = "sqlite-bundled", version.ref = "sqliteBundled" }
-android-joda = { module = "net.danlew:android.joda", version.ref = "androidJoda" }
+kotlinx-datetime = { group = "org.jetbrains.kotlinx", name = "kotlinx-datetime", version.ref = "kotlinxDatetime" }
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 billing-ktx = { module = "com.android.billingclient:billing-ktx", version.ref = "billingKtx" }
 play-services-ads = { module = "com.google.android.gms:play-services-ads", version.ref = "playServicesAds" }


### PR DESCRIPTION
## Summary

#219 Phase 1 인프라 중 **이번 PR에 포함한 부분**:
- `joda-time` → `kotlinx-datetime` 치환 (A-0 조사 + B 실제 치환)
- KMP iOS compile check CI workflow 추가

## 의도적으로 이번 PR에서 제외한 항목 (이슈에 남겨둠)

다음 작업은 현재 Phase 2(#220, datasource 마이그레이션)에 필요하지 않아 **feature 모듈 KMP화 시점(Phase 3)으로 연기**합니다:
- Compose Multiplatform convention plugin — feature 모듈 KMP화 시 도입
- Koin convention — Phase 4 DI 전환 시 도입 (현재 Hilt 유지)
- \`:feature:core:resource\` → KMP 전환 — feature 모듈 KMP화 시 (res/google-fonts는 Android 전용이라 이득이 작음)
- \`:shared:poc\` 삭제 — #220 datasource 마이그레이션 완료 후

## 변경 사항

### joda → kotlinx-datetime (commit 8ba45b7)
- \`libs.versions.toml\`: \`androidJoda\` 제거, \`kotlinxDatetime = 0.6.2\` 추가
- \`app/build.gradle.kts\`, \`feature/home/impl/build.gradle.kts\`: 의존성 치환
- \`feature/home/impl/.../TimeUtils.kt\`: joda \`DateTime\`/\`LocalDate\` → kotlinx-datetime \`Instant\`/\`LocalDate\` 전면 재작성
  - \`TimeZone.currentSystemDefault()\` + \`Instant.fromEpochMilliseconds\` 기반
  - 다국어(ko/en/ja) 오늘/어제/YYYY.MM.DD 포맷 동일 동작 유지

### iOS CI workflow (commit fbc928f)
- \`.github/workflows/kmp-ios-check.yml\`
- macos-latest 러너, JDK 21
- trigger: \`shared/**\`, \`build-logic/**\`, \`gradle/libs.versions.toml\`, \`gradle.properties\`, \`settings.gradle.kts\` 변경시
- \`:shared:poc\` iosX64/iosArm64/iosSimulatorArm64 3타겟 컴파일 검증

## A-0 사전 조사 결과
- joda 사용처: **1개 파일만** — \`feature/home/impl/.../TimeUtils.kt\` (display-only 포맷팅)
- DB 저장: \`createdAt\`은 \`Long\` (epoch ms) 그대로 저장 — **포맷 변경 영향 없음**
- 정렬: epoch ms long 비교 — 영향 없음
- 위험 포인트: display 포맷만 바뀌는데 모든 언어(ko/en/ja)가 AM/PM + HH:mm 포맷 유지라 UI 변화 없음

## 회귀 테스트
display-only 변경이며 \`:feature:home:impl\` 모듈에 기존 테스트 인프라가 없어 **이번 PR에서는 회귀 테스트 추가 생략** (저장 포맷 변화 없음 + 리스크 낮음). 테스트 인프라는 별도 이슈로 분리 가능.

## Test plan
- [x] \`./gradlew :feature:home:impl:compileDebugKotlin :app:compileDebugKotlin\` BUILD SUCCESSFUL
- [x] Android Studio sync 통과
- [ ] 머지 후 CI workflow가 다음 KMP 변경 PR에서 실제로 트리거되는지 확인 (#220 첫 PR에서 검증)

🤖 Generated with [Claude Code](https://claude.com/claude-code)