### PR TITLE
Fix: BackupModule dbVersion 하드코딩 제거, MEMO_DB_VERSION 상수 통일

### DIFF
--- a/app/src/main/java/me/pecos/memozy/di/BackupModule.kt
+++ b/app/src/main/java/me/pecos/memozy/di/BackupModule.kt
@@ -13,14 +13,13 @@ import me.pecos.memozy.data.backup.BackupRepository
 import me.pecos.memozy.data.backup.BackupRepositoryImpl
 import me.pecos.memozy.data.datasource.local.AiUsageDao
 import me.pecos.memozy.data.datasource.local.CategoryDao
+import me.pecos.memozy.data.datasource.local.MEMO_DB_VERSION
 import me.pecos.memozy.data.datasource.local.MemoDao
 import me.pecos.memozy.data.datasource.local.YoutubeSummaryDao
 import me.pecos.memozy.data.datasource.local.chat.ChatMessageDao
 import me.pecos.memozy.data.datasource.local.chat.ChatSessionDao
 import me.pecos.memozy.data.datasource.remote.auth.AuthService
 import javax.inject.Singleton
-
-private const val BACKUP_DB_VERSION = 17
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -54,7 +53,7 @@ object BackupModule {
             supabaseClient = supabaseClient,
             deviceName = deviceName,
             appVersion = appVersion,
-            dbVersion = BACKUP_DB_VERSION,
+            dbVersion = MEMO_DB_VERSION,
         )
     }
 }

--- a/datasource/local/memo/api/src/commonMain/kotlin/me/pecos/memozy/data/datasource/local/MemoDbVersion.kt
+++ b/datasource/local/memo/api/src/commonMain/kotlin/me/pecos/memozy/data/datasource/local/MemoDbVersion.kt
@@ -1,0 +1,3 @@
+package me.pecos.memozy.data.datasource.local
+
+const val MEMO_DB_VERSION = 18

--- a/datasource/local/memo/impl/src/commonMain/kotlin/me/pecos/memozy/data/datasource/local/MemoDatabase.kt
+++ b/datasource/local/memo/impl/src/commonMain/kotlin/me/pecos/memozy/data/datasource/local/MemoDatabase.kt
@@ -24,7 +24,7 @@ import me.pecos.memozy.data.datasource.local.entity.YoutubeSummary
         YoutubeSummary::class,
         AiUsage::class
     ],
-    version = 18,
+    version = MEMO_DB_VERSION,
     exportSchema = true
 )
 @TypeConverters(MemoFormatConverter::class)


### PR DESCRIPTION
## Summary
- `datasource/local/memo/api`에 `const val MEMO_DB_VERSION = 18` 선언
- `MemoDatabase.kt`의 `@Database(version = 18, ...)` → `@Database(version = MEMO_DB_VERSION, ...)`
- `app/di/BackupModule.kt`의 `private const val BACKUP_DB_VERSION = 17` 제거하고 `MEMO_DB_VERSION` import 사용

## 배경
PR #244 리뷰 중 발견: `BackupModule`의 `BACKUP_DB_VERSION = 17`이 실제 DB 스키마 버전(`MemoDatabase.version = 18`)과 불일치. 클라우드 백업 메타데이터에 잘못된 DB 버전이 기록되어 왔음 (복원 시 버전 호환성 판단 오류 가능).

## 효과
- 향후 DB 버전 bump 시 `MemoDbVersion.kt` 한 군데만 수정하면 `@Database` 어노테이션 + BackupModule 둘 다 동시 반영
- Room KSP2가 `const val` 참조를 annotation 인자로 정상 해석 확인 (`18.json` 스키마 파일 정상 생성)

## Test plan
- [x] `:datasource:local:memo:api·impl` + `:app` compile 성공
- [x] Room schema `schemas/.../18.json` 생성 확인
- [ ] Android 런타임 회귀: 백업 업로드 → Supabase `backup_metadata.db_version = 18` 확인
- [ ] 복원 동작 회귀 (DB 버전 체크 로직 있으면 그쪽도)

🤖 Generated with [Claude Code](https://claude.com/claude-code)