### PR TITLE
Update: #232 Lifecycle 2.8.7 + Activity Compose 1.9.3 업그레이드 — ViewModel KMP 이전 선행

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,8 +4,8 @@ coreKtx = "1.10.1"
 junit = "4.13.2"
 junitVersion = "1.1.5"
 espressoCore = "3.5.1"
-lifecycleRuntimeKtx = "2.6.1"
-activityCompose = "1.8.0"
+lifecycleRuntimeKtx = "2.8.7"
+activityCompose = "1.9.3"
 kotlin = "2.3.20"
 composeBom = "2025.05.00"
 ksp = "2.3.6"
@@ -52,6 +52,8 @@ androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "j
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
 androidx-lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "lifecycleRuntimeKtx" }
+androidx-lifecycle-viewmodel = { group = "androidx.lifecycle", name = "lifecycle-viewmodel", version.ref = "lifecycleRuntimeKtx" }
+androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycleRuntimeKtx" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
 androidx-compose-ui = { group = "androidx.compose.ui", name = "ui" }


### PR DESCRIPTION
## Summary
- `androidx.lifecycle` **2.6.1 → 2.8.7**
- `androidx.activity` **1.8.0 → 1.9.3** (lifecycle 2.8 연동 호환 버전)
- version catalog에 `androidx-lifecycle-viewmodel`, `androidx-lifecycle-viewmodel-compose` alias 추가 (**2.8부터 KMP 지원**)

이슈 #232 Phase 3B의 ViewModel commonMain 이전 **선행 작업**.

## 배경
현재 `feature/home/impl`, `feature/memo-plain/impl`의 ViewModel을 commonMain으로 이전하려면 `lifecycle-viewmodel` KMP 버전이 필요. androidx.lifecycle은 **2.8.0부터** KMP 지원. 본 PR은 버전 bump만 수행하고 ViewModel 실제 이전은 차기 PR로 분리.

## 검증
- [x] `:app:compileDebugKotlin` 통과 — 기존 Android 코드(`collectAsStateWithLifecycle`, `HiltViewModel`, `ViewModel()` 상속 등)가 2.8 API와 호환
- [x] `Locale` deprecation 경고는 lifecycle 버전 bump와 무관 (기존부터 존재, `MainActivity.kt:117`)

## Test plan
- [ ] Android 런타임: 앱 시작/홈/메모 상세/설정 화면 네비게이션 모두 정상
- [ ] Process death → restore 시 ViewModel state 복구 (기본 `SavedStateHandle` 동작 확인)
- [ ] Compose lifecycle 관련 재조합 동작 (foreground/background 전환 시 flow 수집 정지/재개)

## 다음 단계
차기 PR에서:
1. `TrashViewModel`, `MainViewModel` → commonMain 이전 (Android 독립 확인됨)
2. `lifecycle-viewmodel-compose` KMP 버전으로 Hilt Navigation 대체 전략 결정
3. `SettingsViewModel`은 SharedPreferences/Uri 의존 있어 `PreferencesProvider` 추상화 필요 — 별도 이슈로

🤖 Generated with [Claude Code](https://claude.com/claude-code)