### PR TITLE
Update: #231 Wave 2 후속 — TextStyleModel kotlinx-serialization 전환 + commonMain 이전

### DIFF
--- a/feature/memo-plain/impl/build.gradle.kts
+++ b/feature/memo-plain/impl/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("memozy.kmp.library")
     id("memozy.cmp.library")
+    alias(libs.plugins.kotlin.serialization)
 }
 
 kotlin {
@@ -12,7 +13,9 @@ kotlin {
     }
 
     sourceSets {
-        // commonMain은 현재 비어 있음.
+        commonMain.dependencies {
+            implementation(libs.kotlinx.serialization.json)
+        }
         // 순수 Composable commonMain 이전은 후속 PR에서 R.*→compose-resources
         // 마이그레이션과 함께 진행 (Issue #231 Wave 2 follow-up).
         androidMain.configure {

--- a/feature/memo-plain/impl/src/commonMain/kotlin/me/pecos/memozy/presentation/screen/memo/TextStyleModel.kt
+++ b/feature/memo-plain/impl/src/commonMain/kotlin/me/pecos/memozy/presentation/screen/memo/TextStyleModel.kt
@@ -7,48 +7,36 @@ import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
-import org.json.JSONArray
-import org.json.JSONObject
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.json.Json
 
+@Serializable
 data class TextSpanStyle(
-    val start: Int,
-    val end: Int,
-    val bold: Boolean = false,
-    val italic: Boolean = false,
-    val strikethrough: Boolean = false,
-    val color: String? = null
+    @SerialName("s") val start: Int,
+    @SerialName("e") val end: Int,
+    @SerialName("b") val bold: Boolean = false,
+    @SerialName("i") val italic: Boolean = false,
+    @SerialName("st") val strikethrough: Boolean = false,
+    @SerialName("c") val color: String? = null
 )
 
-fun List<TextSpanStyle>.toJson(): String {
-    val arr = JSONArray()
-    for (s in this) {
-        val obj = JSONObject()
-        obj.put("s", s.start)
-        obj.put("e", s.end)
-        if (s.bold) obj.put("b", true)
-        if (s.italic) obj.put("i", true)
-        if (s.strikethrough) obj.put("st", true)
-        if (s.color != null) obj.put("c", s.color)
-        arr.put(obj)
-    }
-    return arr.toString()
+private val styleJson = Json {
+    ignoreUnknownKeys = true
+    explicitNulls = false
+    encodeDefaults = false
 }
+
+private val styleListSerializer = ListSerializer(TextSpanStyle.serializer())
+
+fun List<TextSpanStyle>.toJson(): String =
+    styleJson.encodeToString(styleListSerializer, this)
 
 fun String?.toTextSpanStyles(): List<TextSpanStyle> {
     if (this.isNullOrBlank()) return emptyList()
     return try {
-        val arr = JSONArray(this)
-        (0 until arr.length()).map { idx ->
-            val obj = arr.getJSONObject(idx)
-            TextSpanStyle(
-                start = obj.getInt("s"),
-                end = obj.getInt("e"),
-                bold = obj.optBoolean("b", false),
-                italic = obj.optBoolean("i", false),
-                strikethrough = obj.optBoolean("st", false),
-                color = obj.optString("c", null)
-            )
-        }
+        styleJson.decodeFromString(styleListSerializer, this)
     } catch (_: Exception) {
         emptyList()
     }
@@ -120,7 +108,23 @@ fun toggleStyle(
 
 private fun parseHexColor(hex: String): Color {
     return try {
-        Color(android.graphics.Color.parseColor(hex))
+        val cleaned = hex.removePrefix("#")
+        when (cleaned.length) {
+            6 -> {
+                val r = cleaned.substring(0, 2).toInt(16)
+                val g = cleaned.substring(2, 4).toInt(16)
+                val b = cleaned.substring(4, 6).toInt(16)
+                Color(red = r, green = g, blue = b)
+            }
+            8 -> {
+                val a = cleaned.substring(0, 2).toInt(16)
+                val r = cleaned.substring(2, 4).toInt(16)
+                val g = cleaned.substring(4, 6).toInt(16)
+                val b = cleaned.substring(6, 8).toInt(16)
+                Color(red = r, green = g, blue = b, alpha = a)
+            }
+            else -> Color.Unspecified
+        }
     } catch (_: Exception) {
         Color.Unspecified
     }


### PR DESCRIPTION
## Summary

`feature/memo-plain/impl` 의 `TextStyleModel` 을 Android 전용 `org.json.JSONArray/JSONObject` 의존에서 **kotlinx-serialization** 으로 전환하고 `androidMain` → `commonMain` 으로 이전.

Android 전용 의존 (`org.json`, `android.graphics.Color.parseColor`) 제거가 목표. UI 레이어 commonMain 이전의 첫 물꼬.

---

## Wire compatibility (핵심)

이 PR 의 가장 큰 리스크는 **기존 유저 DB 에 저장된 `TextSpanStyle` JSON 이 그대로 읽히는가**. 아래 3중 방어로 구 포맷과의 비트 호환을 보장.

### 1. `@SerialName` 매핑으로 와이어 키 완전 보존

| Kotlin 필드      | 저장 키 | 구 org.json 코드                       |
|------------------|---------|----------------------------------------|
| `start: Int`     | `"s"`   | `obj.put("s", s.start)`                |
| `end: Int`       | `"e"`   | `obj.put("e", s.end)`                  |
| `bold: Boolean`  | `"b"`   | `if (s.bold) obj.put("b", true)`       |
| `italic: Boolean`| `"i"`   | `if (s.italic) obj.put("i", true)`     |
| `strikethrough`  | `"st"`  | `if (s.strikethrough) obj.put("st",…)` |
| `color: String?` | `"c"`   | `if (s.color != null) obj.put("c", …)` |

### 2. `encodeDefaults = false` 로 기본값 필드 출력 생략

구 org.json 은 `bold=true` 인 경우에만 `"b":true` 를 put. kotlinx-serialization 기본 동작은 `bold=false` 까지 전부 직렬화 → 포맷 drift 발생. `encodeDefaults = false` 로 **기본값(`false` / `null`) 필드는 출력 생략** → 구 출력과 동일.

### 3. `ignoreUnknownKeys = true` + 기본값 필드로 누락/미지 키 내성

- 구 데이터에 `"b"` 가 빠져있어도 → `bold: Boolean = false` 기본값으로 복원
- 향후 새 필드를 추가하고 구버전 앱이 읽어도 → 미지 키 무시

### 바이트 비교 예시

구 org.json 출력:
```json
[{"s":10,"e":20,"b":true},{"s":25,"e":30,"c":"#FF0000"}]
```

신 kotlinx-serialization 출력 (동일 입력):
```json
[{"s":10,"e":20,"b":true},{"s":25,"e":30,"c":"#FF0000"}]
```

→ 바이트 수준에서 동일. 구→신 / 신→구 양방향 호환.

---

## Changes

### `feature/memo-plain/impl/build.gradle.kts`
- `alias(libs.plugins.kotlin.serialization)` 플러그인 추가
- `commonMain.dependencies { implementation(libs.kotlinx.serialization.json) }` 추가
- "commonMain 은 현재 비어 있음" 주석 제거

### `TextStyleModel.kt` (androidMain → commonMain 이동 + 재작성)
- `@Serializable` + `@SerialName` 매핑
- `Json { ignoreUnknownKeys = true, explicitNulls = false, encodeDefaults = false }`
- `ListSerializer(TextSpanStyle.serializer())` 명시 사용 (reified inline encode/decode 회피 → 네이티브 타깃 안전)
- `parseHexColor` 수동 구현: `#RRGGBB` / `#AARRGGBB` 지원, 실패 시 `Color.Unspecified` 폴백 (기존 동작과 동일)

---

## Scope limitation

`MemoScreen.kt` / `FormattingToolbar.kt` 에도 `Color(android.graphics.Color.parseColor(hex))` 호출이 남아 있지만 — 해당 파일들은 아직 `androidMain` 전용이므로 이 PR 범위 밖. UI commonMain 이전 단계에서 본 `parseHexColor` 로 통일하는 별도 PR 로 정리 예정.

---

## Test plan

- [x] `compileAndroidMain` 통과
- [x] `compileKotlinIosArm64` 통과
- [x] `compileKotlinIosSimulatorArm64` 통과
- [x] `compileKotlinIosX64` 통과
- [ ] 메모 저장/재진입 회귀 — 구버전에서 저장한 `TextSpanStyle` JSON 을 신버전이 정확히 렌더하는지 (수동)
- [ ] 신버전에서 저장한 JSON 을 구버전 앱이 읽어도 깨지지 않는지 (수동)

---

## Refs

- #231 Wave 2 후속 B-1 (TextStyleModel kotlinx-serialization 전환)

🤖 Generated with [Claude Code](https://claude.com/claude-code)