### PR TITLE
Update: #231 Wave 2 후속 — feature/memo-plain/api KMP 전환

### DIFF
--- a/feature/memo-plain/api/build.gradle.kts
+++ b/feature/memo-plain/api/build.gradle.kts
@@ -1,11 +1,17 @@
-import me.pecos.memozy.convention.extension.setNamespace
-
 plugins {
-    id("memozy.android.library")
+    id("memozy.kmp.library")
 }
 
-setNamespace("feature.memoplain.api")
+kotlin {
+    androidLibrary {
+        namespace = "me.pecos.memozy.feature.memoplain.api"
+    }
 
-dependencies {
-    implementation(libs.androidx.compose.navigation)
+    sourceSets {
+        // MemoPlainRoute는 commonMain(플랫폼 무관), MemoPlainNavigation 인터페이스는
+        // androidx.navigation.NavGraphBuilder에 의존하여 androidMain 전용.
+        androidMain.dependencies {
+            implementation(libs.androidx.compose.navigation)
+        }
+    }
 }

--- a/feature/memo-plain/api/src/androidMain/kotlin/me/pecos/memozy/feature/memoplain/api/MemoPlainNavigation.kt
+++ b/feature/memo-plain/api/src/androidMain/kotlin/me/pecos/memozy/feature/memoplain/api/MemoPlainNavigation.kt
@@ -3,14 +3,8 @@ package me.pecos.memozy.feature.memoplain.api
 import androidx.navigation.NavGraphBuilder
 
 /**
- * 일반 메모 화면으로 진입하기 위한 네비게이션 정의
+ * 일반 메모 화면의 NavGraph 등록 계약. androidx.navigation 의존으로 androidMain 전용.
  */
-object MemoPlainRoute {
-    const val MEMO = "Memo/{memoId}"
-    
-    fun createRoute(memoId: String) = "Memo/$memoId"
-}
-
 interface MemoPlainNavigation {
     fun registerGraph(
         navGraphBuilder: NavGraphBuilder,

--- a/feature/memo-plain/api/src/commonMain/kotlin/me/pecos/memozy/feature/memoplain/api/MemoPlainRoute.kt
+++ b/feature/memo-plain/api/src/commonMain/kotlin/me/pecos/memozy/feature/memoplain/api/MemoPlainRoute.kt
@@ -1,0 +1,10 @@
+package me.pecos.memozy.feature.memoplain.api
+
+/**
+ * 일반 메모 화면으로 진입하기 위한 네비게이션 경로 정의
+ */
+object MemoPlainRoute {
+    const val MEMO = "Memo/{memoId}"
+
+    fun createRoute(memoId: String) = "Memo/$memoId"
+}

--- a/feature/memo-plain/api/src/main/AndroidManifest.xml
+++ b/feature/memo-plain/api/src/main/AndroidManifest.xml
@@ -1,2 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<manifest />


### PR DESCRIPTION
## Summary

`feature/memo-plain/api` 모듈을 `memozy.android.library` → `memozy.kmp.library` 로 전환하고, 세션 ⑤ (`feature/home/api`, PR #262) 와 동일한 split 패턴을 적용.

- **`MemoPlainRoute` (object, 순수 Kotlin) → `commonMain`**
- **`MemoPlainNavigation` (interface, `androidx.navigation.NavGraphBuilder` 의존) → `androidMain`**
- `src/main/AndroidManifest.xml` 삭제 (KMP android library 불필요)
- `build.gradle.kts` 를 KMP sourceSet 문법으로 재작성 (`setNamespace(…)` 확장은 KMP Android plugin 과 비호환 → `kotlin { androidLibrary { namespace = … } }` 로 전환)

> feature/home/api (세션 ⑤ PR #262) 와 동일한 split 패턴 적용 — Route commonMain / Navigation androidMain. 두 PR 이 develop 에 순차 병합되어도 충돌 없음.

## 핵심 전제
- 패키지 경로 `me.pecos.memozy.feature.memoplain.api` 불변 — `MemoPlainRoute`, `MemoPlainNavigation` 두 심볼 모두 동일 패키지로 재배치되어 소비자(impl: `MemoPlainModule`, `MemoPlainNavigationImpl`, 기타 Route import 지점) import 경로 수정 0건.
- `NavGraphBuilder` 를 commonMain 으로 옮기려면 navigation 전략 자체의 공통화가 필요 — 범위 밖. 현재 Wave 2 후속 스코프는 "모듈 KMP 전환 + 구조 재편" 까지로 한정.

## 검증

- ✅ `:feature:memo-plain:api:compileAndroidMain`
- ✅ `:feature:memo-plain:api:compileKotlinIosArm64`
- ✅ `:feature:memo-plain:api:compileKotlinIosX64`
- ✅ `:feature:memo-plain:api:compileKotlinIosSimulatorArm64`
- ✅ `:feature:memo-plain:impl:compileAndroidMain` (다운스트림 소비자)
- ✅ `:app:assembleDebug` (엔드투엔드)

## Test plan
- [ ] CI 빌드 (Android + iOS 3종) 그린
- [ ] 세션 ⑤ (#262) 머지 후 develop rebase → 재검증
- [ ] impl 의 MemoPlainRoute / MemoPlainNavigation import 경로가 수정 없이 그대로 resolve 되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)