### PR TITLE
Add: #231 Wave 2 후속 — feature/memo-plain/impl Preview Composable 복원

### DIFF
--- a/feature/memo-plain/impl/build.gradle.kts
+++ b/feature/memo-plain/impl/build.gradle.kts
@@ -34,6 +34,7 @@ kotlin {
                 implementation(libs.richeditor.compose)
                 implementation(libs.coil.compose)
                 implementation(libs.haze)
+                implementation(libs.androidx.compose.ui.tooling.preview)
             }
         }
     }

--- a/feature/memo-plain/impl/src/androidMain/kotlin/me/pecos/memozy/presentation/screen/memo/MemoScreen.kt
+++ b/feature/memo-plain/impl/src/androidMain/kotlin/me/pecos/memozy/presentation/screen/memo/MemoScreen.kt
@@ -102,9 +102,11 @@ import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
+import com.wanted.android.wanted.design.theme.DesignSystemTheme
 import com.wanted.android.wanted.design.input.textinput.textfield.WantedTextField
 import com.wanted.android.wanted.design.input.textinput.textarea.WantedTextArea
 import androidx.compose.runtime.mutableStateListOf
@@ -1116,3 +1118,13 @@ fun MemoScreen(
     }
 }
 
+@Preview(showBackground = true)
+@Composable
+fun MemoScreenPreview() {
+    DesignSystemTheme {
+        MemoScreen(
+            onSave = {},
+            existingMemo = MemoUiState(1, "테스트 제목", 2, "테스트 내용")
+        )
+    }
+}

--- a/feature/memo-plain/impl/src/androidMain/kotlin/me/pecos/memozy/presentation/screen/memo/components/SummaryStyleBottomSheet.kt
+++ b/feature/memo-plain/impl/src/androidMain/kotlin/me/pecos/memozy/presentation/screen/memo/components/SummaryStyleBottomSheet.kt
@@ -16,7 +16,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.wanted.android.wanted.design.theme.DesignSystemTheme
 import me.pecos.memozy.presentation.screen.memo.SummaryStyle
 import me.pecos.memozy.presentation.theme.LocalAppColors
 import me.pecos.memozy.presentation.theme.LocalFontSettings
@@ -82,5 +84,16 @@ fun SummaryStyleBottomSheet(
                 }
             }
         }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun SummaryStyleBottomSheetPreview() {
+    DesignSystemTheme {
+        SummaryStyleBottomSheet(
+            onSelect = {},
+            onDismiss = {}
+        )
     }
 }


### PR DESCRIPTION
## Summary
- 옵션 A 채택 — androidMain deps 에 ui-tooling-preview 직접 추가 (KMP androidLibrary 에서 동작 확인)

## Restored
- MemoScreenPreview (PR #259 이전 원본)
- SummaryStyleBottomSheetPreview (신규)

## Dependency
- libs.androidx.compose.ui.tooling.preview 추가 (androidMain only)

## Test plan
- [x] 빌드 4종
- [ ] Android Studio 에서 Preview 렌더 수동 확인 (사용자)

## Refs
- #231 Wave 2 후속 A-4
- 세션 ③ (home Preview) 도 동일 옵션 A 로 수렴 예상

🤖 Generated with [Claude Code](https://claude.com/claude-code)