### PR TITLE
Add: #231 Wave 2 후속 — feature/home/impl Preview Composable 복원 (옵션 A 채택)

### DIFF
--- a/feature/home/impl/build.gradle.kts
+++ b/feature/home/impl/build.gradle.kts
@@ -132,6 +132,7 @@ kotlin {
                 implementation(libs.kotlinx.coroutines.android)
                 implementation(compose.materialIconsExtended)
                 implementation(libs.koin.androidx.compose)
+                implementation(libs.androidx.compose.ui.tooling.preview)
             }
         }
     }

--- a/feature/home/impl/src/androidMain/kotlin/me/pecos/memozy/presentation/components/BottomNavBar.kt
+++ b/feature/home/impl/src/androidMain/kotlin/me/pecos/memozy/presentation/components/BottomNavBar.kt
@@ -1,25 +1,40 @@
 package me.pecos.memozy.presentation.components
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.wanted.android.wanted.design.theme.DesignSystemTheme
 import dev.chrisbanes.haze.HazeState
 import dev.chrisbanes.haze.HazeStyle
+import dev.chrisbanes.haze.HazeTint
+import dev.chrisbanes.haze.rememberHazeState
+import me.pecos.memozy.feature.core.resource.R as ResourceR
 import me.pecos.memozy.presentation.theme.LocalAppColors
 
 // ── 바텀 네비게이션 ─────────────────────────────────────────────────────────────
@@ -63,6 +78,59 @@ fun FloatingNavPill(
                     modifier = Modifier.size(24.dp),
                     tint = if (selected) colors.navIconSelected else colors.navIconUnselected
                 )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true, backgroundColor = 0xFFF0F0F0)
+@Composable
+fun FloatingNavPillPreview() {
+    DesignSystemTheme {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(120.dp)
+                .background(Color(0xFFF0F0F0)),
+            contentAlignment = Alignment.BottomCenter
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 12.dp)
+                    .height(IntrinsicSize.Max),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                FloatingNavPill(
+                    selectedRoute = "main",
+                    onItemSelected = {},
+                    hazeState = rememberHazeState(),
+                    glassStyle = HazeStyle(
+                        blurRadius = 20.dp,
+                        backgroundColor = Color.White,
+                        tints = listOf(HazeTint(color = Color.White.copy(alpha = 0.4f)))
+                    ),
+                    modifier = Modifier.weight(1f)
+                )
+                Spacer(modifier = Modifier.width(12.dp))
+                Box(
+                    modifier = Modifier
+                        .fillMaxHeight()
+                        .aspectRatio(1f)
+                        .shadow(10.dp, CircleShape)
+                        .background(Color.White.copy(alpha = 0.88f), CircleShape)
+                        .border(0.5.dp, Color.White.copy(alpha = 0.7f), CircleShape)
+                        .clip(CircleShape),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Image(
+                        painter = painterResource(id = ResourceR.drawable.icon_add),
+                        contentDescription = "메모 추가",
+                        colorFilter = ColorFilter.tint(Color.Black),
+                        modifier = Modifier.size(42.dp)
+                    )
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- 옵션 A 채택 — androidMain deps 에 ui-tooling-preview 직접 추가

## Scope
- 복원 대상 1건: BottomNavBar.kt 의 FloatingNavPillPreview
- Home/Settings/Login 3개 Screen 은 원래부터 Preview 없음 (오해 바로잡음)

## Why Option A
- KMP androidLibrary(AGP 9.0) 가 ui-tooling-preview 를 androidMain implementation 으로 정상 수용함을 빌드로 확증
- 옵션 B(androidDebug sourceSet) / C(별도 모듈) 불요

## Dependency
- libs.androidx.compose.ui.tooling.preview (catalog 에 이미 존재, 버전 bump 없음, libs.versions.toml 미수정)

## Side effects
- androidMain 바이너리에 ui-tooling-preview 가 포함됨. 기존 앱에 이미 포함된 의존이면 영향 없음, 아니면 APK 크기 소폭 증가. release 프록시/ShrinkResources 시 strip 대상 확인 필요 (PR 리뷰 포인트로만 명시, 이 PR 에서 수정 X)

## Test plan
- [x] :feature:home:impl:compileAndroidMain
- [x] :feature:home:impl:assembleAndroidMain
- [x] :app:assembleDebug
- [ ] Android Studio 에서 FloatingNavPillPreview 렌더 수동 확인 (사용자)

## Refs
- #231 Wave 2 후속 A-4
- 세션 ④ (memo-plain Preview) 와 동일 옵션 A 수렴

🤖 Generated with [Claude Code](https://claude.com/claude-code)