### PR TITLE
Add: #222 Wave 3 스파이크 — shared/umbrella CMP 적용 + iOS MainScreen 렌더

### DIFF
--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -1,20 +1,18 @@
 import SwiftUI
 import Shared
 
-struct ContentView: View {
-    private let viewModel: MainViewModel = SharedKoinKt.provideMainViewModel()
+struct ComposeView: UIViewControllerRepresentable {
+    func makeUIViewController(context: Context) -> UIViewController {
+        MainViewControllerKt.MainViewController()
+    }
 
+    func updateUIViewController(_ uiViewController: UIViewController, context: Context) {}
+}
+
+struct ContentView: View {
     var body: some View {
-        VStack(spacing: 16) {
-            Text("Memozy iOS shell")
-                .font(.title2)
-                .bold()
-            Text("KMP framework wired")
-            Text("MainViewModel: \(String(describing: type(of: viewModel)))")
-                .font(.caption)
-                .foregroundColor(.secondary)
-        }
-        .padding()
+        ComposeView()
+            .ignoresSafeArea(.keyboard)
     }
 }
 

--- a/shared/umbrella/build.gradle.kts
+++ b/shared/umbrella/build.gradle.kts
@@ -1,4 +1,5 @@
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.XCFramework
 
 // `:shared:umbrella` ─ iOS framework `Shared` export용 umbrella 모듈.
 // `:shared:poc`와 공존: poc는 Room KMP 스파이크(CI kmp-ios-check.yml 검증 대상),
@@ -7,6 +8,7 @@ import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 // 전부 `iosMain`에만 배치해 Android compileClasspath에 절대 유입되지 않도록 격리한다.
 plugins {
     id("memozy.kmp.library")
+    id("memozy.cmp.library")
 }
 
 kotlin {
@@ -14,10 +16,13 @@ kotlin {
         namespace = "me.pecos.memozy.shared.umbrella"
     }
 
+    val xcf = XCFramework("Shared")
+
     targets.withType<KotlinNativeTarget>().configureEach {
         binaries.framework {
             baseName = "Shared"
             isStatic = true
+            xcf.add(this)
             export(projects.feature.core.viewmodel)
             export(projects.data.repository.memo.api)
         }

--- a/shared/umbrella/src/commonMain/kotlin/me/pecos/memozy/shared/umbrella/MainScreen.kt
+++ b/shared/umbrella/src/commonMain/kotlin/me/pecos/memozy/shared/umbrella/MainScreen.kt
@@ -1,0 +1,47 @@
+package me.pecos.memozy.shared.umbrella
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+// Wave 3 C-1 스파이크 진입용 최소 Composable. Composition·인터랙션·MaterialTheme이
+// iOS 런타임에서 살아있는지만 확인한다. 실제 feature 화면은 #231 Wave 2 A-1
+// (UI commonMain 이전)이 끝난 뒤 후속 PR로 연결한다.
+@Composable
+fun MainScreen() {
+    MaterialTheme {
+        Surface(modifier = Modifier.fillMaxSize()) {
+            var count by remember { mutableStateOf(0) }
+            Column(
+                modifier = Modifier.fillMaxSize().padding(24.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp, Alignment.CenterVertically),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                Text(
+                    text = "Hello CMP from iOS",
+                    style = MaterialTheme.typography.headlineSmall,
+                )
+                Text(
+                    text = "Composition alive — tap count: $count",
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+                Button(onClick = { count += 1 }) {
+                    Text("Tap me")
+                }
+            }
+        }
+    }
+}

--- a/shared/umbrella/src/iosMain/kotlin/me/pecos/memozy/shared/umbrella/MainViewController.kt
+++ b/shared/umbrella/src/iosMain/kotlin/me/pecos/memozy/shared/umbrella/MainViewController.kt
@@ -1,0 +1,10 @@
+package me.pecos.memozy.shared.umbrella
+
+import androidx.compose.ui.window.ComposeUIViewController
+import platform.UIKit.UIViewController
+
+// Swift(UIViewControllerRepresentable)에서 호출할 CMP 진입점.
+// Koin 초기화(`doInitKoin`)는 iOSApp.swift에서 선행 호출됨.
+fun MainViewController(): UIViewController = ComposeUIViewController {
+    MainScreen()
+}


### PR DESCRIPTION
## Summary
- shared/umbrella 를 CMP 로 전환 (`id(\"memozy.cmp.library\")`) + `XCFramework(\"Shared\")` 선언 추가.
- `MainScreen` Composable (MaterialTheme + tap counter) commonMain 신설.
- iOS `MainViewController` 팩토리 + Swift `ContentView` `UIViewControllerRepresentable` 래퍼 연결.

## Why XCFramework inline
- CMP 플러그인만 추가로는 iOS artifact 가 만들어지지 않음. 이 PR 의 목적 자체가 iOS 렌더 경로 연결이라 `XCFramework(\"Shared\")` 선언을 스코프 내로 판단해 포함.

## Scope limitation
- feature/home·memo-plain 실 화면 렌더는 #231 Wave 2 A-1 완료 후 별도 PR.
- `MainViewModel` 실 연결은 DI 경로 검증용 별도 PR 로 분리.

## Test plan
- [x] `./gradlew :shared:umbrella:assembleSharedXCFramework` — debug + release XCFramework 생성 확인
- [x] `xcodebuild -project iosApp/iosApp.xcodeproj -scheme iosApp -configuration Debug -destination 'generic/platform=iOS Simulator' build` — BUILD SUCCEEDED
- [x] `./gradlew :app:assembleDebug` — Android 리그레션 없음
- [ ] Xcode 시뮬레이터 Run — \"Hello CMP from iOS\" 텍스트 + tap 카운터 증가 확인 (사용자 수동, 스크린샷 PR 코멘트 첨부)

## Known warnings (무관)
- \`Cannot infer a bundle ID from packages of source files and exported dependencies, use the bundle name instead: Shared\` — framework bundle ID 명시 권장 경고. 빌드/실행 영향 없음. 별 이슈로 분리 예정.

## Refs
- #222 KMP Phase 4 — iOS 앱 셸
- PR #251 (iOS Xcode shell 초기 셋업) 의 후속

🤖 Generated with [Claude Code](https://claude.com/claude-code)