### PR TITLE
Update: #231 Wave 2 후속 — memo-plain screen·nav 를 platform/intent·PreferencesProvider 로 교체

### DIFF
--- a/feature/memo-plain/impl/build.gradle.kts
+++ b/feature/memo-plain/impl/build.gradle.kts
@@ -27,6 +27,7 @@ kotlin {
                 implementation(projects.data.repository.memo.api)
                 implementation(projects.datasource.remote.ai.api)
                 implementation(projects.platform.media.api)
+                implementation(projects.platform.intent.api)
                 implementation(libs.montage.android)
                 implementation(libs.androidx.compose.navigation)
                 implementation(libs.kotlinx.coroutines.android)

--- a/feature/memo-plain/impl/src/androidMain/kotlin/me/pecos/memozy/feature/memoplain/impl/MemoPlainNavigationImpl.kt
+++ b/feature/memo-plain/impl/src/androidMain/kotlin/me/pecos/memozy/feature/memoplain/impl/MemoPlainNavigationImpl.kt
@@ -60,6 +60,7 @@ import me.pecos.memozy.platform.media.MediaService
 import org.koin.compose.koinInject
 import me.pecos.memozy.feature.core.viewmodel.model.MemoFormatUi
 import me.pecos.memozy.feature.core.viewmodel.model.MemoUiState
+import me.pecos.memozy.feature.core.viewmodel.settings.PreferencesProvider
 import me.pecos.memozy.presentation.screen.memo.MemoScreen
 import me.pecos.memozy.presentation.screen.memo.components.AiLimitBottomSheet
 import me.pecos.memozy.presentation.theme.LocalAppColors
@@ -308,10 +309,9 @@ class MemoPlainNavigationImpl(
             var summaryState by remember { mutableStateOf<SummaryState>(SummaryState.Idle) }
             var youtubeTitle by remember { mutableStateOf<String?>(null) }
 
-            val preContext = LocalContext.current
+            val preferencesProvider: PreferencesProvider = koinInject()
             val languageCode = remember {
-                preContext.getSharedPreferences("settings", android.content.Context.MODE_PRIVATE)
-                    .getString("language_code", "ko") ?: "ko"
+                preferencesProvider.getString("language_code", "ko")
             }
 
             val scope = rememberCoroutineScope()

--- a/feature/memo-plain/impl/src/androidMain/kotlin/me/pecos/memozy/presentation/screen/memo/MemoScreen.kt
+++ b/feature/memo-plain/impl/src/androidMain/kotlin/me/pecos/memozy/presentation/screen/memo/MemoScreen.kt
@@ -2,7 +2,8 @@ package me.pecos.memozy.presentation.screen.memo
 
 import me.pecos.memozy.presentation.util.decodeHtmlEntities
 import me.pecos.memozy.presentation.util.htmlToPlainText
-import android.content.Intent
+import me.pecos.memozy.platform.intent.Sharer
+import org.koin.compose.koinInject
 import android.net.Uri
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -242,6 +243,7 @@ fun MemoScreen(
 ) {
     val isNewMemo = existingMemo.id <= 0
     val context = LocalContext.current
+    val sharer: Sharer = koinInject()
     val clipboardManager = LocalClipboardManager.current
     val categories = listOf(
         stringResource(R.string.category_general),
@@ -511,11 +513,7 @@ fun MemoScreen(
                                         append(plainContent)
                                     }
                                 }
-                                val shareIntent = Intent(Intent.ACTION_SEND).apply {
-                                    type = "text/plain"
-                                    putExtra(Intent.EXTRA_TEXT, shareText)
-                                }
-                                context.startActivity(Intent.createChooser(shareIntent, null))
+                                sharer.shareText(shareText)
                             }
                     )
                     Spacer(modifier = Modifier.width(16.dp))
@@ -893,7 +891,6 @@ fun MemoScreen(
                         audioPath = effectiveAudioPath,
                         memoTitle = nameText,
                         colors = colors,
-                        context = context,
                         onDismiss = { audioChipDismissed = true }
                     )
                 }

--- a/feature/memo-plain/impl/src/androidMain/kotlin/me/pecos/memozy/presentation/screen/memo/components/AudioPlayerBar.kt
+++ b/feature/memo-plain/impl/src/androidMain/kotlin/me/pecos/memozy/presentation/screen/memo/components/AudioPlayerBar.kt
@@ -1,8 +1,5 @@
 package me.pecos.memozy.presentation.screen.memo.components
 
-import android.content.Context
-import android.content.Intent
-import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
@@ -37,6 +34,9 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import me.pecos.memozy.feature.core.resource.R
+import me.pecos.memozy.platform.intent.Sharer
+import me.pecos.memozy.platform.intent.ToastDuration
+import me.pecos.memozy.platform.intent.ToastPresenter
 import me.pecos.memozy.platform.media.MediaService
 import me.pecos.memozy.presentation.theme.AppColors
 import me.pecos.memozy.presentation.theme.LocalFontSettings
@@ -47,11 +47,13 @@ fun AudioPlayerBar(
     audioPath: String,
     memoTitle: String,
     colors: AppColors,
-    context: Context,
     onDismiss: () -> Unit
 ) {
     val fontSettings = LocalFontSettings.current
     val mediaService: MediaService = koinInject()
+    val sharer: Sharer = koinInject()
+    val toastPresenter: ToastPresenter = koinInject()
+    val savedToDownloadsText = stringResource(R.string.saved_to_downloads)
     var isPlaying by remember { mutableStateOf(false) }
     val audioPlayer = remember(audioPath) {
         mediaService.createAudioPlayer(audioPath).apply {
@@ -81,14 +83,12 @@ fun AudioPlayerBar(
                     val dest = android.os.Environment.getExternalStoragePublicDirectory(android.os.Environment.DIRECTORY_DOWNLOADS)
                     val target = java.io.File(dest, "memozy_${System.currentTimeMillis()}.m4a")
                     source.copyTo(target, overwrite = true)
-                    Toast.makeText(context, "📁 " + context.getString(R.string.saved_to_downloads), Toast.LENGTH_LONG).show()
+                    toastPresenter.show("📁 $savedToDownloadsText", ToastDuration.Long)
                 })
             Spacer(modifier = Modifier.width(12.dp))
             Icon(Icons.Default.Share, contentDescription = null, tint = colors.textSecondary,
                 modifier = Modifier.size(20.dp).clickable {
-                    val uri = androidx.core.content.FileProvider.getUriForFile(context, "${context.packageName}.fileprovider", java.io.File(audioPath))
-                    val shareIntent = Intent(Intent.ACTION_SEND).apply { type = "audio/mp4"; putExtra(Intent.EXTRA_STREAM, uri); addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION) }
-                    context.startActivity(Intent.createChooser(shareIntent, null))
+                    sharer.shareFile(audioPath, "audio/mp4")
                 })
         }
         Icon(Icons.Default.Close, contentDescription = null, tint = colors.textSecondary,


### PR DESCRIPTION
## Summary
- MemoScreen Sharer 교체 / AudioPlayerBar Sharer+Toast 교체 / MemoPlainNavigationImpl PreferencesProvider 교체
- -18/+16 순감소

## Data compatibility (중요)
- FileProvider authority `${applicationId}.fileprovider` 동일 (AndroidManifest:39-40 ↔ AndroidSharer 의 `${context.packageName}.fileprovider`)
- PreferencesProvider default `prefsName="settings"` 동일 저장소 → 기존 `"language_code"` 값 그대로 읽힘 (마이그레이션 불필요)

## Scope boundary
- `components/*.kt` 와 AiActionMenu HapticService 는 트랙 ⓒ 담당
- `Color.parseColor` 는 트랙 ⓔ 담당

## Test plan
- [x] 빌드 4종 (`:feature:memo-plain:impl:compileAndroidMain` + iOS Arm64/SimulatorArm64/X64)
- [x] `:app:assembleDebug`
- [ ] 메모 텍스트 공유 (수동)
- [ ] 오디오 파일 공유 (수동, FileProvider URI 권한 확인)
- [ ] "다운로드로 저장" 토스트 (수동)
- [ ] youtube URL 자동 시트 (language_code 플래그 기반) (수동)

## Refs
- #231 Wave 2 후속
- #266 (expect services), #250 (PreferencesProvider)
- 동반 PR: ⓒ components (Clipboard/Url/Toast/Haptic), ⓔ parseColor

🤖 Generated with [Claude Code](https://claude.com/claude-code)