### PR TITLE
Add: #231 Wave 2 후속 — platform/media 에 AudioFileStore expect 신설

### DIFF
--- a/app/src/main/java/me/pecos/memozy/di/MediaPlatformModule.kt
+++ b/app/src/main/java/me/pecos/memozy/di/MediaPlatformModule.kt
@@ -1,10 +1,13 @@
 package me.pecos.memozy.di
 
+import me.pecos.memozy.platform.media.AndroidAudioFileStore
 import me.pecos.memozy.platform.media.AndroidMediaService
+import me.pecos.memozy.platform.media.AudioFileStore
 import me.pecos.memozy.platform.media.MediaService
 import org.koin.android.ext.koin.androidContext
 import org.koin.dsl.module
 
 val mediaPlatformModule = module {
     single<MediaService> { AndroidMediaService(androidContext()) }
+    single<AudioFileStore> { AndroidAudioFileStore(androidContext()) }
 }

--- a/platform/media/api/src/commonMain/kotlin/me/pecos/memozy/platform/media/AudioFileStore.kt
+++ b/platform/media/api/src/commonMain/kotlin/me/pecos/memozy/platform/media/AudioFileStore.kt
@@ -1,0 +1,19 @@
+package me.pecos.memozy.platform.media
+
+/**
+ * 오디오 파일 저장 경로/복사 추상화. 기존 java.io.File 직접 접근을 대체하기 위한 plat-agnostic 계약.
+ * - cachePath: 녹음 임시 파일용 캐시 경로
+ * - permanentPath: 영구 보존용 경로 (앱 내부 저장소)
+ * - downloadsPath: 공용 Downloads 경로. iOS 등 샌드박스 환경에서는 null 반환 가능.
+ */
+interface AudioFileStore {
+    fun cachePath(name: String): String
+
+    fun permanentPath(safeName: String): String
+
+    fun downloadsPath(name: String): String?
+
+    fun exists(path: String): Boolean
+
+    fun copy(srcPath: String, dstPath: String): Boolean
+}

--- a/platform/media/impl/src/androidMain/kotlin/me/pecos/memozy/platform/media/AndroidAudioFileStore.kt
+++ b/platform/media/impl/src/androidMain/kotlin/me/pecos/memozy/platform/media/AndroidAudioFileStore.kt
@@ -1,0 +1,45 @@
+package me.pecos.memozy.platform.media
+
+import android.content.Context
+import android.os.Environment
+import java.io.File
+
+class AndroidAudioFileStore(
+    private val context: Context,
+) : AudioFileStore {
+    override fun cachePath(name: String): String =
+        File(context.cacheDir, name).absolutePath
+
+    override fun permanentPath(safeName: String): String {
+        val audioDir = File(context.filesDir, AUDIO_SUBDIR).apply {
+            if (!exists()) mkdirs()
+        }
+        return File(audioDir, "$safeName.$AUDIO_EXT").absolutePath
+    }
+
+    override fun downloadsPath(name: String): String? {
+        @Suppress("DEPRECATION")
+        val downloads = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
+        return File(downloads, name).absolutePath
+    }
+
+    override fun exists(path: String): Boolean = File(path).exists()
+
+    override fun copy(srcPath: String, dstPath: String): Boolean {
+        val src = File(srcPath)
+        if (!src.exists()) return false
+        val dst = File(dstPath)
+        dst.parentFile?.let { if (!it.exists()) it.mkdirs() }
+        src.inputStream().use { input ->
+            dst.outputStream().use { output ->
+                input.copyTo(output)
+            }
+        }
+        return true
+    }
+
+    private companion object {
+        const val AUDIO_SUBDIR = "audio"
+        const val AUDIO_EXT = "m4a"
+    }
+}

--- a/platform/media/impl/src/iosMain/kotlin/me/pecos/memozy/platform/media/IosAudioFileStore.kt
+++ b/platform/media/impl/src/iosMain/kotlin/me/pecos/memozy/platform/media/IosAudioFileStore.kt
@@ -1,0 +1,57 @@
+package me.pecos.memozy.platform.media
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.Foundation.NSCachesDirectory
+import platform.Foundation.NSDocumentDirectory
+import platform.Foundation.NSFileManager
+import platform.Foundation.NSSearchPathForDirectoriesInDomains
+import platform.Foundation.NSUserDomainMask
+
+/**
+ * iOS 구현. NSFileManager + NSCachesDirectory / NSDocumentDirectory 기반.
+ * 공용 Downloads 디렉터리는 iOS 샌드박스에 존재하지 않으므로 downloadsPath 는 null 을 반환한다.
+ */
+@OptIn(ExperimentalForeignApi::class)
+class IosAudioFileStore : AudioFileStore {
+    private val fileManager: NSFileManager get() = NSFileManager.defaultManager
+
+    override fun cachePath(name: String): String {
+        val dir = firstPath(NSCachesDirectory)
+        return "$dir/$name"
+    }
+
+    override fun permanentPath(safeName: String): String {
+        val dir = firstPath(NSDocumentDirectory)
+        val audioDir = "$dir/$AUDIO_SUBDIR"
+        fileManager.createDirectoryAtPath(
+            audioDir,
+            withIntermediateDirectories = true,
+            attributes = null,
+            error = null,
+        )
+        return "$audioDir/$safeName.$AUDIO_EXT"
+    }
+
+    override fun downloadsPath(name: String): String? = null
+
+    override fun exists(path: String): Boolean = fileManager.fileExistsAtPath(path)
+
+    override fun copy(srcPath: String, dstPath: String): Boolean {
+        if (!fileManager.fileExistsAtPath(srcPath)) return false
+        // 기존 파일이 있으면 덮어쓰기: 먼저 제거 시도.
+        if (fileManager.fileExistsAtPath(dstPath)) {
+            fileManager.removeItemAtPath(dstPath, error = null)
+        }
+        return fileManager.copyItemAtPath(srcPath, toPath = dstPath, error = null)
+    }
+
+    private fun firstPath(directory: platform.Foundation.NSSearchPathDirectory): String {
+        val paths = NSSearchPathForDirectoriesInDomains(directory, NSUserDomainMask, true)
+        return paths.firstOrNull() as? String ?: ""
+    }
+
+    private companion object {
+        const val AUDIO_SUBDIR = "audio"
+        const val AUDIO_EXT = "m4a"
+    }
+}


### PR DESCRIPTION
## Summary
- commonMain `AudioFileStore` interface + Android actual + iOS actual
- #266 스파이크의 "scope excluded" 항목 중 하나 소화

## iOS semantics (리뷰 포인트)
- `cachePath`: `NSCachesDirectory`
- `permanentPath`: `NSDocumentDirectory` (Files app 노출 가능)
- `downloadsPath`: `null` 반환 (iOS 샌드박스, 호출부가 대체 경로 결정해야 함)

## Scope limitation
- `MemoPlainNavigationImpl` / `AudioPlayerBar` / `MemoScreen` 의 `java.io.File` 사용부는 그대로. 실 교체는 A-1 memo-plain commonMain 이전 PR 에서

## Test plan
- [x] 빌드 4종 x 2모듈 (`:platform:media:api` Android + iOS 3종, `:platform:media:impl` 동일)
- [x] `:app:assembleDebug` (Koin 와이어링)
- [ ] Android 앱 실행 행동 변화 없음 확인 (사용처 미교체)

## Refs
- #266 expect services spike 의 follow-up