### PR TITLE
Update: #231 Wave 2 후속 — richeditor-compose 를 commonMain 의존으로 이동 (rc11 KMP variant 확인)

### DIFF
--- a/feature/memo-plain/impl/build.gradle.kts
+++ b/feature/memo-plain/impl/build.gradle.kts
@@ -15,6 +15,11 @@ kotlin {
     sourceSets {
         commonMain.dependencies {
             implementation(libs.kotlinx.serialization.json)
+            // richeditor-compose rc11은 iosArm64/iosX64/iosSimulatorArm64 KMP
+            // variant를 이미 제공하므로 commonMain에서 노출한다. 실제 사용처
+            // (MemoScreen, FormattingToolbar)는 후속 PR에서 commonMain으로
+            // 이전 예정 — 현 PR은 의존 구조만 정리 (Issue #231 Wave 2 follow-up).
+            implementation(libs.richeditor.compose)
         }
         // 순수 Composable commonMain 이전은 후속 PR에서 R.*→compose-resources
         // 마이그레이션과 함께 진행 (Issue #231 Wave 2 follow-up).
@@ -34,7 +39,6 @@ kotlin {
                 implementation(libs.koin.androidx.compose)
                 implementation(libs.androidx.lifecycle.runtime.compose)
                 implementation(compose.materialIconsExtended)
-                implementation(libs.richeditor.compose)
                 implementation(libs.coil.compose)
                 implementation(libs.haze)
                 implementation(libs.androidx.compose.ui.tooling.preview)


### PR DESCRIPTION
## Summary
- richeditor-compose 의존을 androidMain → commonMain 으로 상승.
- 실 사용 코드 무변경, A-1 memo-plain commonMain 이전 선행 준비.

## Why no version bump
- rc11 Gradle module metadata 에 iOS native variant 3종 확인 완료.

## Test plan
- [x] 빌드 4종
- [x] :app:assembleDebug
- [ ] 런타임 회귀 — 예상 0 (androidMain classpath 무변화)

## Refs
- #231 Wave 2 후속 B-2