### PR TITLE
Update: #231 Wave 2 후속 — Color.parseColor → commonMain parseHexColor 통일

### DIFF
--- a/feature/memo-plain/impl/src/androidMain/kotlin/me/pecos/memozy/presentation/screen/memo/MemoScreen.kt
+++ b/feature/memo-plain/impl/src/androidMain/kotlin/me/pecos/memozy/presentation/screen/memo/MemoScreen.kt
@@ -164,9 +164,7 @@ private class StyleVisualTransformation(
                         fontWeight = if (style.bold) FontWeight.Bold else null,
                         fontStyle = if (style.italic) FontStyle.Italic else null,
                         textDecoration = if (style.strikethrough) TextDecoration.LineThrough else null,
-                        color = style.color?.let {
-                            try { Color(android.graphics.Color.parseColor(it)) } catch (_: Exception) { Color.Unspecified }
-                        } ?: Color.Unspecified
+                        color = style.color?.let { parseHexColor(it) } ?: Color.Unspecified
                     ),
                     start = style.start,
                     end = style.end

--- a/feature/memo-plain/impl/src/androidMain/kotlin/me/pecos/memozy/presentation/screen/memo/components/FormattingToolbar.kt
+++ b/feature/memo-plain/impl/src/androidMain/kotlin/me/pecos/memozy/presentation/screen/memo/components/FormattingToolbar.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.mohamedrejeb.richeditor.model.RichTextState
+import me.pecos.memozy.presentation.screen.memo.parseHexColor
 import me.pecos.memozy.presentation.theme.AppColors
 import me.pecos.memozy.presentation.theme.LocalFontSettings
 
@@ -103,11 +104,11 @@ fun FormattingToolbar(
             listOf("#000000", "#FF0000", "#FF9800", "#FFEB3B", "#4CAF50", "#2196F3", "#9C27B0", "#795548", "#607D8B").forEach { hex ->
                 Box(
                     modifier = Modifier.size(22.dp).clip(CircleShape)
-                        .background(Color(android.graphics.Color.parseColor(hex)))
+                        .background(parseHexColor(hex))
                         .pointerInput(hex) {
                             detectTapGestures(onPress = {
                                 if (savedColorSelection.start != savedColorSelection.end) {
-                                    richTextState.addSpanStyle(SpanStyle(color = Color(android.graphics.Color.parseColor(hex))), savedColorSelection)
+                                    richTextState.addSpanStyle(SpanStyle(color = parseHexColor(hex)), savedColorSelection)
                                 }
                                 showColorPicker = false; tryAwaitRelease()
                             })

--- a/feature/memo-plain/impl/src/commonMain/kotlin/me/pecos/memozy/presentation/screen/memo/ColorHex.kt
+++ b/feature/memo-plain/impl/src/commonMain/kotlin/me/pecos/memozy/presentation/screen/memo/ColorHex.kt
@@ -1,0 +1,30 @@
+package me.pecos.memozy.presentation.screen.memo
+
+import androidx.compose.ui.graphics.Color
+
+// 저장된 span 색상(String hex)·툴바 팔레트 hex 를 Compose Color 로 변환하는 commonMain 유틸.
+// #RRGGBB / #AARRGGBB 지원. 파싱 실패 시 Color.Unspecified 반환.
+// android.graphics.Color.parseColor 를 대체해 androidMain 의존을 제거한다.
+internal fun parseHexColor(hex: String): Color {
+    return try {
+        val cleaned = hex.removePrefix("#")
+        when (cleaned.length) {
+            6 -> {
+                val r = cleaned.substring(0, 2).toInt(16)
+                val g = cleaned.substring(2, 4).toInt(16)
+                val b = cleaned.substring(4, 6).toInt(16)
+                Color(red = r, green = g, blue = b)
+            }
+            8 -> {
+                val a = cleaned.substring(0, 2).toInt(16)
+                val r = cleaned.substring(2, 4).toInt(16)
+                val g = cleaned.substring(4, 6).toInt(16)
+                val b = cleaned.substring(6, 8).toInt(16)
+                Color(red = r, green = g, blue = b, alpha = a)
+            }
+            else -> Color.Unspecified
+        }
+    } catch (_: Exception) {
+        Color.Unspecified
+    }
+}

--- a/feature/memo-plain/impl/src/commonMain/kotlin/me/pecos/memozy/presentation/screen/memo/TextStyleModel.kt
+++ b/feature/memo-plain/impl/src/commonMain/kotlin/me/pecos/memozy/presentation/screen/memo/TextStyleModel.kt
@@ -105,27 +105,3 @@ fun toggleStyle(
 
     return result.sortedBy { it.start }
 }
-
-private fun parseHexColor(hex: String): Color {
-    return try {
-        val cleaned = hex.removePrefix("#")
-        when (cleaned.length) {
-            6 -> {
-                val r = cleaned.substring(0, 2).toInt(16)
-                val g = cleaned.substring(2, 4).toInt(16)
-                val b = cleaned.substring(4, 6).toInt(16)
-                Color(red = r, green = g, blue = b)
-            }
-            8 -> {
-                val a = cleaned.substring(0, 2).toInt(16)
-                val r = cleaned.substring(2, 4).toInt(16)
-                val g = cleaned.substring(4, 6).toInt(16)
-                val b = cleaned.substring(6, 8).toInt(16)
-                Color(red = r, green = g, blue = b, alpha = a)
-            }
-            else -> Color.Unspecified
-        }
-    } catch (_: Exception) {
-        Color.Unspecified
-    }
-}


### PR DESCRIPTION
## Summary
- `ColorHex.kt` 신설(commonMain), `TextStyleModel` 의 private `parseHexColor` 중복 제거
- androidMain 의 3 호출 지점 전부 `parseHexColor` 로 통일 (MemoScreen ×1, FormattingToolbar ×2)

## Equivalence
- `MemoScreen`: 기존 `try { Color(android.graphics.Color.parseColor(it)) } catch ...` 동작 동등 (실패 시 `Color.Unspecified` 반환)
- `FormattingToolbar`: 하드코딩 hex 9색(#000000~#607D8B), 파싱 경로 동일

## Test plan
- [x] `:feature:memo-plain:impl:compileKotlinIosArm64 / IosX64 / IosSimulatorArm64`
- [x] `:app:assembleDebug` (Android 빌드 성공, memo-plain androidMain 컴파일 포함)
- [ ] 메모 색상 span 렌더 수동 확인 (저장된 span 색상 동일)
- [ ] 서식 툴바 색상 팔레트 수동 확인 (9색 버튼 배경 + 선택 시 span 색 적용)

## Refs
- #260 `parseHexColor` 도입 PR
- 동반 트랙: ⓓ (MemoScreen line-level 잠재 rebase — 서로 다른 라인, 자동 merge 예상)

🤖 Generated with [Claude Code](https://claude.com/claude-code)