### PR TITLE
Update: #231 Wave 2 후속 — feature/home/impl 의 Android 직접 호출을 platform/intent 서비스로 교체

### DIFF
--- a/feature/home/impl/build.gradle.kts
+++ b/feature/home/impl/build.gradle.kts
@@ -123,6 +123,7 @@ kotlin {
                 implementation(projects.platform.billing.api)
                 implementation(projects.platform.ads.api)
                 implementation(projects.platform.credential.api)
+                implementation(projects.platform.intent.api)
                 implementation(libs.androidx.lifecycle.runtime.ktx)
                 implementation(libs.androidx.activity.compose)
                 implementation(libs.androidx.compose.navigation)

--- a/feature/home/impl/src/androidMain/kotlin/me/pecos/memozy/presentation/screen/login/LoginScreen.kt
+++ b/feature/home/impl/src/androidMain/kotlin/me/pecos/memozy/presentation/screen/login/LoginScreen.kt
@@ -1,6 +1,5 @@
 package me.pecos.memozy.presentation.screen.login
 
-import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -34,6 +33,7 @@ import me.pecos.memozy.feature.core.resource.R
 import me.pecos.memozy.feature.home.impl.BuildConstants
 import me.pecos.memozy.platform.credential.CredentialService
 import me.pecos.memozy.platform.credential.GoogleSignInResult
+import me.pecos.memozy.platform.intent.ToastPresenter
 import me.pecos.memozy.presentation.theme.LocalActivity
 import me.pecos.memozy.presentation.theme.LocalAppColors
 import me.pecos.memozy.presentation.theme.LocalFontSettings
@@ -50,6 +50,7 @@ fun LoginScreen(
     val activity = LocalActivity.current
     val scope = rememberCoroutineScope()
     val credentialService: CredentialService = koinInject()
+    val toastPresenter: ToastPresenter = koinInject()
 
     Scaffold(
         containerColor = colors.screenBackground
@@ -92,11 +93,7 @@ fun LoginScreen(
                             is GoogleSignInResult.Cancelled -> Unit
                             is GoogleSignInResult.Error -> {
                                 android.util.Log.e("LoginScreen", "Sign-in failed: ${result.message}")
-                                Toast.makeText(
-                                    context,
-                                    context.getString(R.string.sign_in_error),
-                                    Toast.LENGTH_SHORT
-                                ).show()
+                                toastPresenter.show(context.getString(R.string.sign_in_error))
                             }
                         }
                     }

--- a/feature/home/impl/src/androidMain/kotlin/me/pecos/memozy/presentation/screen/settings/SettingsScreen.kt
+++ b/feature/home/impl/src/androidMain/kotlin/me/pecos/memozy/presentation/screen/settings/SettingsScreen.kt
@@ -1,6 +1,5 @@
 package me.pecos.memozy.presentation.screen.settings
 
-import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.clickable
@@ -80,6 +79,8 @@ import me.pecos.memozy.feature.core.viewmodel.settings.LANGUAGES
 import me.pecos.memozy.feature.core.viewmodel.settings.ThemeMode
 import me.pecos.memozy.platform.credential.CredentialService
 import me.pecos.memozy.platform.credential.GoogleSignInResult
+import me.pecos.memozy.platform.intent.AppInfo
+import me.pecos.memozy.platform.intent.ToastPresenter
 import me.pecos.memozy.presentation.theme.LocalActivity
 import org.koin.compose.koinInject
 import me.pecos.memozy.presentation.theme.LocalAppColors
@@ -119,6 +120,8 @@ fun SettingsScreen(
     val activity = LocalActivity.current
     val scope = rememberCoroutineScope()
     val credentialService: CredentialService = koinInject()
+    val toastPresenter: ToastPresenter = koinInject()
+    val appInfo: AppInfo = koinInject()
 
     // 로그인 상태 변경 시 마지막 백업 시간 로드
     LaunchedEffect(authState) {
@@ -140,20 +143,14 @@ fun SettingsScreen(
     LaunchedEffect(backupResult) {
         when (val result = backupResult) {
             is BackupResult.Success -> {
-                Toast.makeText(
-                    context,
-                    context.getString(R.string.backup_success, result.message.toIntOrNull() ?: 0),
-                    Toast.LENGTH_SHORT
-                ).show()
+                toastPresenter.show(
+                    context.getString(R.string.backup_success, result.message.toIntOrNull() ?: 0)
+                )
                 settingsViewModel.clearBackupResult()
             }
 
             is BackupResult.Error -> {
-                Toast.makeText(
-                    context,
-                    context.getString(R.string.backup_error),
-                    Toast.LENGTH_SHORT
-                ).show()
+                toastPresenter.show(context.getString(R.string.backup_error))
                 settingsViewModel.clearBackupResult()
             }
 
@@ -165,32 +162,26 @@ fun SettingsScreen(
     LaunchedEffect(cloudBackupState) {
         when (val state = cloudBackupState) {
             is CloudBackupState.UploadSuccess -> {
-                Toast.makeText(
-                    context,
-                    context.getString(R.string.cloud_backup_success, state.memoCount),
-                    Toast.LENGTH_SHORT
-                ).show()
+                toastPresenter.show(
+                    context.getString(R.string.cloud_backup_success, state.memoCount)
+                )
                 settingsViewModel.clearCloudBackupState()
             }
             is CloudBackupState.RestoreSuccess -> {
-                Toast.makeText(
-                    context,
-                    context.getString(R.string.cloud_backup_restore_success, state.memoCount),
-                    Toast.LENGTH_SHORT
-                ).show()
+                toastPresenter.show(
+                    context.getString(R.string.cloud_backup_restore_success, state.memoCount)
+                )
                 settingsViewModel.clearCloudBackupState()
             }
             is CloudBackupState.Error -> {
-                Toast.makeText(context, state.message, Toast.LENGTH_SHORT).show()
+                toastPresenter.show(state.message)
                 settingsViewModel.clearCloudBackupState()
             }
             else -> {}
         }
     }
 
-    val versionName = remember {
-        context.packageManager.getPackageInfo(context.packageName, 0).versionName
-    }
+    val versionName = remember(appInfo) { appInfo.versionName }
 
     if (showThemeDialog) {
         val themeOptions = listOf(
@@ -616,11 +607,7 @@ fun SettingsScreen(
                                                 "SettingsAuth",
                                                 "Sign-in failed: ${result.message}"
                                             )
-                                            Toast.makeText(
-                                                context,
-                                                context.getString(R.string.sign_in_error),
-                                                Toast.LENGTH_SHORT
-                                            ).show()
+                                            toastPresenter.show(context.getString(R.string.sign_in_error))
                                         }
                                     }
                                 }

--- a/feature/home/impl/src/androidMain/kotlin/me/pecos/memozy/presentation/screen/subscription/SubscriptionScreen.kt
+++ b/feature/home/impl/src/androidMain/kotlin/me/pecos/memozy/presentation/screen/subscription/SubscriptionScreen.kt
@@ -1,7 +1,5 @@
 package me.pecos.memozy.presentation.screen.subscription
 
-import android.content.Intent
-import android.net.Uri
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -36,7 +34,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -44,6 +41,7 @@ import androidx.compose.ui.unit.dp
 import me.pecos.memozy.feature.core.resource.R
 import me.pecos.memozy.platform.billing.BillingService
 import me.pecos.memozy.platform.billing.PurchaseState
+import me.pecos.memozy.platform.intent.UrlLauncher
 import org.koin.compose.koinInject
 import me.pecos.memozy.presentation.components.AppPopup
 import me.pecos.memozy.presentation.components.PopupActionArea
@@ -65,7 +63,7 @@ fun SubscriptionScreen(
     val colors = LocalAppColors.current
     val fontSettings = LocalFontSettings.current
     val activity = LocalActivity.current
-    val context = LocalContext.current
+    val urlLauncher: UrlLauncher = koinInject()
     val isSystemDark = colors.screenBackground == Color(0xFF1C1C1E)
 
     if (purchaseState is PurchaseState.Success) {
@@ -301,9 +299,7 @@ fun SubscriptionScreen(
                     modifier = Modifier
                         .fillMaxWidth()
                         .clickable {
-                            context.startActivity(
-                                Intent(Intent.ACTION_VIEW, Uri.parse("https://play.google.com/store/account/subscriptions"))
-                            )
+                            urlLauncher.open("https://play.google.com/store/account/subscriptions")
                         }
                         .padding(12.dp)
                 )


### PR DESCRIPTION
## Summary

#231 Wave 2 후속 — 선행③(#266)에서 도입한 `platform/intent` expect 서비스를 `feature/home/impl` 의 3개 화면에 배선. Android 직접 호출(Toast/Intent/packageManager) 9건을 모두 Koin 주입 서비스로 교체.

- `ToastPresenter` × 7 (Login×1, Settings×6 — backup/cloud backup 5 + sign-in error 1)
- `UrlLauncher` × 1 (Subscription → Play Store 구독 관리)
- `AppInfo` × 1 (Settings → versionName)

## Replaced call sites

| File | Before | After |
|---|---|---|
| `login/LoginScreen.kt` | `Toast.makeText(context, R.string.sign_in_error, SHORT).show()` | `toastPresenter.show(context.getString(R.string.sign_in_error))` |
| `subscription/SubscriptionScreen.kt` | `context.startActivity(Intent(ACTION_VIEW, Uri.parse(playStoreUrl)))` | `urlLauncher.open(playStoreUrl)` |
| `settings/SettingsScreen.kt` — BackupResult | `Toast.makeText(...).show()` × 2 (Success/Error) | `toastPresenter.show(...)` × 2 |
| `settings/SettingsScreen.kt` — CloudBackupState | `Toast.makeText(...).show()` × 3 (Upload/Restore/Error) | `toastPresenter.show(...)` × 3 |
| `settings/SettingsScreen.kt` — Sign-in error | `Toast.makeText(...).show()` | `toastPresenter.show(...)` |
| `settings/SettingsScreen.kt` — versionName | `context.packageManager.getPackageInfo(context.packageName, 0).versionName` | `appInfo.versionName` |

### 주입 방식

- 기존 `koinInject<CredentialService>()` 패턴과 동일하게 `koinInject<ToastPresenter>()` / `koinInject<UrlLauncher>()` / `koinInject<AppInfo>()` 로 Composable 진입 직후 주입.
- `platformIntentModule()` 은 MemozyApplication 에 PR #266 시점에 이미 등록됨 → 앱 측 추가 배선 불필요.

### build.gradle.kts

- `feature/home/impl/build.gradle.kts` 의 androidMain dependencies 에 `implementation(projects.platform.intent.api)` 추가. impl 은 Koin 으로만 소비하므로 api 만 의존.

## Scope boundary

- **MainActivity 의 Intent 수신(onNewIntent, ACTION_SEND 공유 수신)은 그대로 보존.** UrlLauncher 는 *발신* 서비스이며, Activity 레벨의 inbound Intent 는 expect 서비스 스코프에 포함되지 않음.
- `feature/memo-plain/**` 는 건드리지 않음 (별도 트랙).
- `platform/intent` 의 actual 구현 자체는 수정 없음.
- `libs.versions.toml` 변경 없음.

## Test plan

- [x] `:feature:home:impl:compileAndroidMain` — BUILD SUCCESSFUL
- [x] `:feature:home:impl:compileKotlinIosX64` / `IosArm64` / `IosSimulatorArm64` — BUILD SUCCESSFUL
- [x] `:app:assembleDebug` — BUILD SUCCESSFUL
- [ ] 회귀 체크 (머지 후 수동):
  - [ ] Settings 백업/복원 토스트 정상 노출
  - [ ] Settings 클라우드 백업 결과 토스트 정상 노출
  - [ ] Login/Settings 구글 로그인 실패 토스트 정상 노출
  - [ ] Subscription 의 "구독 관리" 링크 → Play Store 이동
  - [ ] Settings 하단 버전 표시(`v1.2603.0`) 정상

## Refs

- #266 expect/actual 플랫폼 서비스 스파이크 (merged, cd6959f)
- #231 Wave 2 KMP 마이그레이션

🤖 Generated with [Claude Code](https://claude.com/claude-code)