### PR TITLE
Add: #231 Wave 2 선행② compose-resources 노출 (A-1 블로커 해제)

### DIFF
--- a/feature/core/resource/build.gradle.kts
+++ b/feature/core/resource/build.gradle.kts
@@ -23,3 +23,8 @@ kotlin {
         }
     }
 }
+
+compose.resources {
+    publicResClass = true
+    packageOfResClass = "me.pecos.memozy.feature.core.resource.generated.resources"
+}

--- a/feature/core/resource/src/commonMain/composeResources/values-en/strings.xml
+++ b/feature/core/resource/src/commonMain/composeResources/values-en/strings.xml
@@ -1,0 +1,275 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Settings -->
+    <string name="settings">Settings</string>
+    <string name="section_theme">Theme</string>
+    <string name="section_data">Data</string>
+    <string name="section_other">Other</string>
+    <string name="language_settings">Language</string>
+    <string name="open_source_license">Open Source Licenses</string>
+    <string name="reset_memos">Reset Memos</string>
+    <string name="reset_confirm">All saved memos will be deleted.\nAre you sure you want to reset?</string>
+    <string name="reset">Reset</string>
+    <string name="cancel">Cancel</string>
+    <string name="close">Close</string>
+    <string name="theme_settings">Theme</string>
+    <string name="theme_light">Light Mode</string>
+    <string name="theme_dark">Dark Mode</string>
+    <string name="theme_system">System Default</string>
+    <string name="license_content">• Jetpack Compose - Apache 2.0\n• Room Database - Apache 2.0\n• Kotlin Coroutines - Apache 2.0\n• Navigation Compose - Apache 2.0</string>
+
+    <!-- Categories -->
+    <string name="category_all">All</string>
+    <string name="category_settings">Category</string>
+    <string name="category_general">General</string>
+    <string name="category_work">Work</string>
+    <string name="category_idea">Idea</string>
+    <string name="category_todo">To-Do</string>
+    <string name="category_study">Study</string>
+    <string name="category_schedule">Schedule</string>
+    <string name="category_budget">Budget</string>
+    <string name="category_exercise">Exercise</string>
+    <string name="category_health">Health</string>
+    <string name="category_travel">Travel</string>
+    <string name="category_shopping">Shopping</string>
+
+    <!-- Memo -->
+    <string name="memo_title_label">Title</string>
+    <string name="memo_title_placeholder">Memo title</string>
+    <string name="memo_content_label">Content</string>
+    <string name="memo_content_placeholder">Memo content</string>
+    <string name="delete_confirm_title">Are you sure you want to delete?</string>
+    <string name="delete_confirm_message">Warning: This action cannot be undone</string>
+    <string name="yes">Yes</string>
+    <string name="no">No</string>
+    <string name="save">Save</string>
+    <string name="memo_done">Done</string>
+    <string name="add_memo">Add Memo</string>
+    <string name="edit_memo">Edit Memo</string>
+
+
+    <!-- Search / Sort / Count -->
+    <string name="search_placeholder">Search by title or content</string>
+    <string name="sort_newest">Newest</string>
+    <string name="sort_oldest">Oldest</string>
+    <string name="edit_mode">Edit</string>
+    <string name="memo_count">%d memos</string>
+    <string name="memo_updated_at">Edited:</string>
+    <string name="memo_copy">Copy</string>
+    <string name="memo_copied">Memo copied</string>
+    <string name="memo_shared">Memo shared</string>
+    <string name="char_count">%d chars</string>
+    <string name="empty_memo_hint">No memos yet\nAdd your first memo!</string>
+    <string name="empty_search_hint">No results found</string>
+
+    <!-- Donation -->
+    <string name="donation_button">Buy the Developer Rice 🍚</string>
+    <string name="donation_title">Buy the Developer Rice</string>
+    <string name="donation_subtitle">Your support helps us cook up better features!</string>
+    <string name="donation_tier_1_name">1 Instant Rice</string>
+    <string name="donation_tier_1_desc">A quick meal gift</string>
+    <string name="donation_tier_2_name">6-Pack Instant Rice</string>
+    <string name="donation_tier_2_desc">A week of meals</string>
+    <string name="donation_tier_3_name">18-Pack Instant Rice</string>
+    <string name="donation_tier_3_desc">A month of hearty meals</string>
+    <string name="donation_tier_4_name">10kg Rice Bag</string>
+    <string name="donation_tier_4_desc">A real bag of rice!</string>
+    <string name="donation_tier_5_name">20kg Rice Sack</string>
+    <string name="donation_tier_5_desc">The ultimate support! Thank you</string>
+    <string name="donation_thank_title">Thank You! 🙏</string>
+    <string name="donation_thank_message">Thank you for your warm support!\nWe\'ll keep making the app better.</string>
+    <string name="donation_error_title">Payment Error</string>
+    <string name="donation_error_message">Something went wrong during payment.\nPlease try again.</string>
+    <string name="donation_loading">Connecting…</string>
+
+    <!-- Export -->
+    <string name="memo_share">Share as text</string>
+    <string name="memo_export_md">Export as Markdown</string>
+
+    <!-- Backup -->
+    <string name="backup_export">Export Backup</string>
+    <string name="backup_restore">Restore Backup</string>
+    <string name="backup_restore_action">Restore</string>
+    <string name="backup_restore_confirm">All existing memos will be deleted and replaced with the backup.\nThis action cannot be undone.</string>
+    <string name="backup_success">%d memos processed</string>
+    <string name="backup_error">An error occurred during backup</string>
+
+    <!-- Trash -->
+    <string name="trash_title">Trash</string>
+    <string name="trash_empty">Trash is empty</string>
+    <string name="trash_empty_action">Empty</string>
+    <string name="trash_empty_confirm_title">Empty Trash</string>
+    <string name="trash_empty_confirm_message">All memos will be permanently deleted.\nThis action cannot be undone.</string>
+    <string name="trash_restore">Restore</string>
+    <string name="trash_permanent_delete_title">Delete Permanently</string>
+    <string name="trash_permanent_delete_action">Delete Permanently</string>
+    <string name="trash_permanent_delete_message">This memo will be permanently deleted.\nIt cannot be restored.</string>
+    <string name="trash_auto_delete_hint">Deleted memos are permanently removed after 30 days</string>
+
+    <!-- Summary Card -->
+    <string name="summary_card_web">Web Page</string>
+    <string name="summary_card_open">Open Original</string>
+    <string name="summary_card_view_summary">View Summary</string>
+    <string name="summary_card_summarize">AI Summary</string>
+
+    <!-- Filter -->
+    <string name="filter_all">All</string>
+    <string name="filter_memo">Memo</string>
+    <string name="filter_youtube">YouTube</string>
+    <string name="filter_recording">Recording</string>
+
+    <!-- Actions -->
+    <string name="pin">Pin</string>
+    <string name="unpin">Unpin</string>
+    <string name="delete_memo">Delete Memo</string>
+    <string name="add_tag">Add Tag</string>
+    <string name="tag_name">Tag Name</string>
+    <string name="add">Add</string>
+    <string name="confirm">OK</string>
+    <string name="previous">Previous</string>
+    <string name="next_step">Next</string>
+    <string name="summarize">Summarize</string>
+
+    <!-- Memo Actions -->
+    <string name="copy_link">Copy Link</string>
+    <string name="open_in_browser">Open in Browser</string>
+    <string name="open_in_youtube">Open in YouTube</string>
+    <string name="ai_summarize">AI Summarize</string>
+    <string name="link_label">Link</string>
+    <string name="quiz_label">Quiz</string>
+    <string name="notification_label">Notification</string>
+    <string name="web_link">Web Page Link</string>
+    <string name="paste_clipboard">Paste</string>
+
+    <!-- Status -->
+    <string name="recording_tap_to_stop">Recording… Tap to stop</string>
+    <string name="transcribing">Transcribing…</string>
+    <string name="web_summarizing">Summarizing web page…</string>
+    <string name="youtube_summarizing">Summarizing YouTube…</string>
+    <string name="recording_file">Recording File</string>
+    <string name="recording_start">Record</string>
+    <string name="recording_stop">Stop</string>
+    <string name="youtube_label">YouTube</string>
+    <string name="saved_to_downloads">Saved to Downloads</string>
+
+    <!-- Dialogs -->
+    <string name="web_summary_title">Web Page Summary</string>
+    <string name="web_summary_desc">Enter the URL to summarize</string>
+    <string name="youtube_summary_title">YouTube Video Summary</string>
+    <string name="youtube_summary_desc">Enter the YouTube URL to summarize</string>
+    <string name="time_select">Select Time</string>
+    <string name="cancel_reminder">Cancel Reminder</string>
+
+    <!-- Summary Mode -->
+    <string name="summary_collapse">Collapse Summary</string>
+    <string name="summary_expand">View Summary</string>
+    <string name="summary_mode_simple">Quick Summary</string>
+    <string name="summary_mode_detailed">Detailed Summary</string>
+    <string name="youtube_url_copied">YouTube URL copied</string>
+    <string name="youtube_open_to_copy">Copy URL from YouTube →</string>
+    <string name="summary_style_select">Summarize</string>
+    <string name="web_url_copied">Web URL copied</string>
+    <string name="summary_copy">Copy summary</string>
+    <string name="summary_delete_title">Delete Summary</string>
+    <string name="summary_delete_message">Are you sure you want to delete the summary?\nThis cannot be undone.</string>
+    <string name="summary_delete_action">Delete</string>
+    <string name="memo_copy_done">Copied</string>
+
+    <!-- Trash Extra -->
+    <string name="trash_days_left">Permanently deleted in %d days</string>
+    <string name="trash_soon_delete">Permanently deleted soon</string>
+
+    <!-- Multi-select -->
+    <string name="select">Select</string>
+    <string name="selected_count">%d selected</string>
+    <string name="delete_selected_title">Delete Selected Memos</string>
+    <string name="delete_selected_message">Delete %d selected memos?\nDeleted memos will be moved to trash.</string>
+    <string name="select_all">Select All</string>
+    <string name="deselect_all">Deselect All</string>
+    <string name="delete_action">Delete</string>
+
+    <!-- Quiz -->
+    <string name="quiz_title">Memo Quiz</string>
+    <string name="quiz_generating">Generating quiz…</string>
+    <string name="quiz_retry">Try Again</string>
+    <string name="quiz_next">Next</string>
+    <string name="quiz_show_result">Show Results</string>
+    <string name="quiz_explanation">Explanation</string>
+    <string name="quiz_back">Go Back</string>
+
+    <!-- Auth -->
+    <string name="section_account">Account</string>
+    <string name="sign_in_google">Sign in with Google Account</string>
+    <string name="sign_out">Sign Out</string>
+    <string name="sign_in_error">Sign in failed</string>
+    <string name="sign_out_confirm">Are you sure you want to sign out?</string>
+    <string name="sign_in_loading">Signing in…</string>
+    <string name="login_subtitle">Keep your memos safe with cloud backup</string>
+    <string name="login_skip">Start without account</string>
+
+    <!-- Cloud Backup -->
+    <string name="section_cloud_backup">Cloud Backup</string>
+    <string name="cloud_backup_now">Backup to Cloud</string>
+    <string name="cloud_backup_restore">Restore from Cloud</string>
+    <string name="cloud_backup_manage">Manage Backups</string>
+    <string name="cloud_backup_uploading">Uploading backup…</string>
+    <string name="cloud_backup_success">Backup completed (%d memos)</string>
+    <string name="cloud_backup_error">Backup failed</string>
+    <string name="cloud_backup_restore_confirm">Restoring this backup will replace all current data.\nThis action cannot be undone.</string>
+    <string name="cloud_backup_restore_success">Restored successfully (%d memos)</string>
+    <string name="cloud_backup_restore_error">Restore failed</string>
+    <string name="cloud_backup_delete_confirm">Delete this backup?</string>
+    <string name="cloud_backup_empty">No backups saved</string>
+    <string name="cloud_backup_login_required">Sign in to use cloud backup</string>
+    <string name="cloud_backup_restoring">Restoring…</string>
+    <string name="cloud_backup_count">%d backups saved</string>
+    <string name="cloud_backup_memo_count">%d memos</string>
+    <string name="cloud_backup_last_time">Last backup: %s</string>
+
+    <!-- Font Settings -->
+    <string name="font_settings">Font</string>
+    <string name="font_size">Font Size</string>
+    <string name="font_size_small">Small</string>
+    <string name="font_size_normal">Normal</string>
+    <string name="font_size_large">Large</string>
+    <string name="font_preview_title">Title Preview</string>
+    <string name="font_preview_body">This is a body text preview. This font will be applied to your memos.</string>
+    <string name="font_system">System Default</string>
+
+    <!-- AI Limit -->
+    <string name="ai_limit_title">Daily AI limit reached</string>
+    <string name="ai_limit_free_message">Free users can use AI features up to %d times per day.</string>
+    <string name="ai_limit_pro_message">Pro users can use AI features up to %d times per day.\nYou can use it again tomorrow.</string>
+    <string name="ai_limit_upgrade">Upgrade to Pro</string>
+    <string name="ai_limit_upgrade_desc">More AI summaries + all premium features</string>
+    <string name="ai_limit_watch_ad">Watch ad for +1 use</string>
+    <string name="ai_limit_ad_remaining">%d more views available today</string>
+    <string name="ai_limit_ad_exhausted">No more ad views available today</string>
+    <string name="ai_limit_ad_loading">Loading ad…</string>
+    <string name="ai_limit_close">Close</string>
+
+    <!-- Subscription -->
+    <string name="subscription_title">Memozy Pro</string>
+    <string name="subscription_desc">Use AI features more generously</string>
+    <string name="subscription_monthly">Monthly</string>
+    <string name="subscription_yearly">Yearly</string>
+    <string name="subscription_yearly_discount">30%% off</string>
+    <string name="subscription_feature_youtube">YouTube summary</string>
+    <string name="subscription_feature_web">Web page summary</string>
+    <string name="subscription_feature_ocr">Photo summary</string>
+    <string name="subscription_feature_more">More summaries available</string>
+    <string name="subscription_feature_no_ads">No ads</string>
+    <string name="subscription_current_plan">Current plan</string>
+    <string name="subscription_manage">Manage subscription</string>
+    <string name="subscription_restore">Restore purchases</string>
+
+    <!-- Memozy AI -->
+    <string name="memozy_ai">Memozy AI</string>
+    <string name="ai_action_explain">Explain in simple terms</string>
+    <string name="ai_action_organize">Organize neatly</string>
+    <string name="ai_action_summarize">Summarize key points</string>
+    <string name="ai_action_custom">Custom input</string>
+    <string name="ai_input_placeholder">Ask Memozy AI anything</string>
+    <string name="ai_insert_to_memo">Add to memo</string>
+    <string name="ai_loading">AI is responding…</string>
+</resources>

--- a/feature/core/resource/src/commonMain/composeResources/values-ja/strings.xml
+++ b/feature/core/resource/src/commonMain/composeResources/values-ja/strings.xml
@@ -1,0 +1,275 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Settings -->
+    <string name="settings">設定</string>
+    <string name="section_theme">テーマ</string>
+    <string name="section_data">データ</string>
+    <string name="section_other">その他</string>
+    <string name="language_settings">言語設定</string>
+    <string name="open_source_license">オープンソースライセンス</string>
+    <string name="reset_memos">メモをリセット</string>
+    <string name="reset_confirm">保存されたすべてのメモが削除されます。\n本当にリセットしますか？</string>
+    <string name="reset">リセット</string>
+    <string name="cancel">キャンセル</string>
+    <string name="close">閉じる</string>
+    <string name="theme_settings">テーマ設定</string>
+    <string name="theme_light">ライトモード</string>
+    <string name="theme_dark">ダークモード</string>
+    <string name="theme_system">システムデフォルト</string>
+    <string name="license_content">• Jetpack Compose - Apache 2.0\n• Room Database - Apache 2.0\n• Kotlin Coroutines - Apache 2.0\n• Navigation Compose - Apache 2.0</string>
+
+    <!-- Categories -->
+    <string name="category_all">すべて</string>
+    <string name="category_settings">カテゴリ設定</string>
+    <string name="category_general">一般</string>
+    <string name="category_work">仕事</string>
+    <string name="category_idea">アイデア</string>
+    <string name="category_todo">やること</string>
+    <string name="category_study">勉強</string>
+    <string name="category_schedule">予定</string>
+    <string name="category_budget">家計簿</string>
+    <string name="category_exercise">運動</string>
+    <string name="category_health">健康</string>
+    <string name="category_travel">旅行</string>
+    <string name="category_shopping">ショッピング</string>
+
+    <!-- Memo -->
+    <string name="memo_title_label">タイトル</string>
+    <string name="memo_title_placeholder">メモのタイトル</string>
+    <string name="memo_content_label">内容</string>
+    <string name="memo_content_placeholder">メモの内容</string>
+    <string name="delete_confirm_title">本当に削除しますか？</string>
+    <string name="delete_confirm_message">注意 : 削除後は復元できません</string>
+    <string name="yes">はい</string>
+    <string name="no">いいえ</string>
+    <string name="save">保存</string>
+    <string name="memo_done">完了</string>
+    <string name="add_memo">メモを追加</string>
+    <string name="edit_memo">メモを編集</string>
+
+
+    <!-- Search / Sort / Count -->
+    <string name="search_placeholder">タイトルまたは内容で検索</string>
+    <string name="sort_newest">新しい順</string>
+    <string name="sort_oldest">古い順</string>
+    <string name="edit_mode">編集</string>
+    <string name="memo_count">計 %d件</string>
+    <string name="memo_updated_at">編集:</string>
+    <string name="memo_copy">コピー</string>
+    <string name="memo_copied">メモをコピーしました</string>
+    <string name="memo_shared">メモを共有しました</string>
+    <string name="char_count">%d字</string>
+    <string name="empty_memo_hint">メモがまだありません\n新しいメモを追加してみてください</string>
+    <string name="empty_search_hint">検索結果がありません</string>
+
+    <!-- Donation -->
+    <string name="donation_button">開発者にお米を贈る 🍚</string>
+    <string name="donation_title">開発者にお米を贈る</string>
+    <string name="donation_subtitle">ご支援いただけると、もっと美味しい機能を作れます！</string>
+    <string name="donation_tier_1_name">ごはん 1個</string>
+    <string name="donation_tier_1_desc">ちょっとした一食のプレゼント</string>
+    <string name="donation_tier_2_name">ごはん 6個セット</string>
+    <string name="donation_tier_2_desc">一週間分のごはん</string>
+    <string name="donation_tier_3_name">ごはん 18個セット</string>
+    <string name="donation_tier_3_desc">一ヶ月の安心ごはん</string>
+    <string name="donation_tier_4_name">お米 10kg</string>
+    <string name="donation_tier_4_desc">本物のお米一袋！</string>
+    <string name="donation_tier_5_name">お米 1俵 (20kg)</string>
+    <string name="donation_tier_5_desc">最高のご支援！ありがとうございます</string>
+    <string name="donation_thank_title">ありがとうございます！ 🙏</string>
+    <string name="donation_thank_message">温かいご支援ありがとうございます！\nもっと良いアプリを作ります。</string>
+    <string name="donation_error_title">決済エラー</string>
+    <string name="donation_error_message">決済処理中に問題が発生しました。\nもう一度お試しください。</string>
+    <string name="donation_loading">接続中…</string>
+
+    <!-- Export -->
+    <string name="memo_share">テキストで共有</string>
+    <string name="memo_export_md">Markdownで書き出し</string>
+
+    <!-- Backup -->
+    <string name="backup_export">バックアップを書き出す</string>
+    <string name="backup_restore">バックアップを復元</string>
+    <string name="backup_restore_action">復元</string>
+    <string name="backup_restore_confirm">既存のメモをすべて削除し、バックアップファイルから復元します。\nこの操作は元に戻せません。</string>
+    <string name="backup_success">%d件のメモを処理しました</string>
+    <string name="backup_error">バックアップ処理中にエラーが発生しました</string>
+
+    <!-- Trash -->
+    <string name="trash_title">ゴミ箱</string>
+    <string name="trash_empty">ゴミ箱は空です</string>
+    <string name="trash_empty_action">空にする</string>
+    <string name="trash_empty_confirm_title">ゴミ箱を空にする</string>
+    <string name="trash_empty_confirm_message">すべてのメモが完全に削除されます。\nこの操作は元に戻せません。</string>
+    <string name="trash_restore">復元</string>
+    <string name="trash_permanent_delete_title">完全に削除</string>
+    <string name="trash_permanent_delete_action">完全に削除</string>
+    <string name="trash_permanent_delete_message">このメモを完全に削除します。\n復元できません。</string>
+    <string name="trash_auto_delete_hint">削除されたメモは30日後に自動的に完全削除されます</string>
+
+    <!-- Summary Card -->
+    <string name="summary_card_web">ウェブページ</string>
+    <string name="summary_card_open">元を見る</string>
+    <string name="summary_card_view_summary">要約を見る</string>
+    <string name="summary_card_summarize">AI要約</string>
+
+    <!-- Filter -->
+    <string name="filter_all">すべて</string>
+    <string name="filter_memo">メモ</string>
+    <string name="filter_youtube">YouTube</string>
+    <string name="filter_recording">録音</string>
+
+    <!-- Actions -->
+    <string name="pin">ピン留め</string>
+    <string name="unpin">ピン解除</string>
+    <string name="delete_memo">メモを削除</string>
+    <string name="add_tag">タグを追加</string>
+    <string name="tag_name">タグ名</string>
+    <string name="add">追加</string>
+    <string name="confirm">確認</string>
+    <string name="previous">前へ</string>
+    <string name="next_step">次へ</string>
+    <string name="summarize">要約する</string>
+
+    <!-- Memo Actions -->
+    <string name="copy_link">リンクをコピー</string>
+    <string name="open_in_browser">ブラウザで開く</string>
+    <string name="open_in_youtube">YouTubeで開く</string>
+    <string name="ai_summarize">AI要約する</string>
+    <string name="link_label">リンク</string>
+    <string name="quiz_label">クイズ</string>
+    <string name="notification_label">通知</string>
+    <string name="web_link">ウェブページリンク</string>
+    <string name="paste_clipboard">貼り付け</string>
+
+    <!-- Status -->
+    <string name="recording_tap_to_stop">録音中… タップで停止</string>
+    <string name="transcribing">音声変換中…</string>
+    <string name="web_summarizing">ウェブページ要約中…</string>
+    <string name="youtube_summarizing">YouTube要約中…</string>
+    <string name="recording_file">録音ファイル</string>
+    <string name="recording_start">録音</string>
+    <string name="recording_stop">停止</string>
+    <string name="youtube_label">YouTube</string>
+    <string name="saved_to_downloads">ダウンロードに保存しました</string>
+
+    <!-- Dialogs -->
+    <string name="web_summary_title">ウェブページ要約</string>
+    <string name="web_summary_desc">要約するURLを入力してください</string>
+    <string name="youtube_summary_title">YouTube動画要約</string>
+    <string name="youtube_summary_desc">要約するYouTube URLを入力してください</string>
+    <string name="time_select">時間選択</string>
+    <string name="cancel_reminder">リマインダー解除</string>
+
+    <!-- Summary Mode -->
+    <string name="summary_collapse">要約を閉じる</string>
+    <string name="summary_expand">要約を見る</string>
+    <string name="summary_mode_simple">簡単要約</string>
+    <string name="summary_mode_detailed">詳細要約</string>
+    <string name="youtube_url_copied">YouTube URLがコピーされました</string>
+    <string name="youtube_open_to_copy">YouTubeからURLをコピー →</string>
+    <string name="summary_style_select">要約する</string>
+    <string name="web_url_copied">Web URLがコピーされました</string>
+    <string name="summary_copy">要約をコピー</string>
+    <string name="summary_delete_title">要約を削除</string>
+    <string name="summary_delete_message">要約を削除しますか？\n削除すると元に戻せません。</string>
+    <string name="summary_delete_action">削除</string>
+    <string name="memo_copy_done">コピーしました</string>
+
+    <!-- Trash Extra -->
+    <string name="trash_days_left">%d日後に完全削除</string>
+    <string name="trash_soon_delete">まもなく完全削除</string>
+
+    <!-- Multi-select -->
+    <string name="select">選択</string>
+    <string name="selected_count">%d件選択</string>
+    <string name="delete_selected_title">選択したメモを削除</string>
+    <string name="delete_selected_message">選択した%d件のメモを削除しますか？\n削除されたメモはゴミ箱に移動します。</string>
+    <string name="select_all">全選択</string>
+    <string name="deselect_all">選択解除</string>
+    <string name="delete_action">削除</string>
+
+    <!-- Quiz -->
+    <string name="quiz_title">メモクイズ</string>
+    <string name="quiz_generating">クイズを作成中…</string>
+    <string name="quiz_retry">もう一度</string>
+    <string name="quiz_next">次へ</string>
+    <string name="quiz_show_result">結果を見る</string>
+    <string name="quiz_explanation">解説</string>
+    <string name="quiz_back">戻る</string>
+
+    <!-- Auth -->
+    <string name="section_account">アカウント</string>
+    <string name="sign_in_google">Googleアカウントでログイン</string>
+    <string name="sign_out">ログアウト</string>
+    <string name="sign_in_error">ログインに失敗しました</string>
+    <string name="sign_out_confirm">ログアウトしますか？</string>
+    <string name="sign_in_loading">ログイン中…</string>
+    <string name="login_subtitle">クラウドバックアップでメモを安全に保管</string>
+    <string name="login_skip">アカウントなしで始める</string>
+
+    <!-- Cloud Backup -->
+    <string name="section_cloud_backup">クラウドバックアップ</string>
+    <string name="cloud_backup_now">クラウドにバックアップ</string>
+    <string name="cloud_backup_restore">クラウドから復元</string>
+    <string name="cloud_backup_manage">バックアップ管理</string>
+    <string name="cloud_backup_uploading">バックアップ中…</string>
+    <string name="cloud_backup_success">バックアップ完了 (メモ %d件)</string>
+    <string name="cloud_backup_error">バックアップに失敗しました</string>
+    <string name="cloud_backup_restore_confirm">このバックアップで復元すると、現在のデータが置き換えられます。\nこの操作は元に戻せません。</string>
+    <string name="cloud_backup_restore_success">復元が完了しました (メモ %d件)</string>
+    <string name="cloud_backup_restore_error">復元に失敗しました</string>
+    <string name="cloud_backup_delete_confirm">このバックアップを削除しますか？</string>
+    <string name="cloud_backup_empty">保存されたバックアップはありません</string>
+    <string name="cloud_backup_login_required">ログインしてからご利用ください</string>
+    <string name="cloud_backup_restoring">復元中…</string>
+    <string name="cloud_backup_count">保存済みバックアップ %d件</string>
+    <string name="cloud_backup_memo_count">メモ %d件</string>
+    <string name="cloud_backup_last_time">最後のバックアップ: %s</string>
+
+    <!-- Font Settings -->
+    <string name="font_settings">フォント設定</string>
+    <string name="font_size">文字サイズ</string>
+    <string name="font_size_small">小</string>
+    <string name="font_size_normal">中</string>
+    <string name="font_size_large">大</string>
+    <string name="font_preview_title">タイトルプレビュー</string>
+    <string name="font_preview_body">本文プレビューテキストです。このフォントがメモに適用されます。</string>
+    <string name="font_system">システムデフォルト</string>
+
+    <!-- AI Limit -->
+    <string name="ai_limit_title">本日のAI使用回数に達しました</string>
+    <string name="ai_limit_free_message">無料ユーザーは1日%d回までAI機能を使用できます。</string>
+    <string name="ai_limit_pro_message">Proユーザーは1日%d回までAI機能を使用できます。\n明日また使用できます。</string>
+    <string name="ai_limit_upgrade">Proにアップグレード</string>
+    <string name="ai_limit_upgrade_desc">より多くのAI要約 + すべてのプレミアム機能</string>
+    <string name="ai_limit_watch_ad">広告を見て1回追加</string>
+    <string name="ai_limit_ad_remaining">今日あと%d回視聴可能</string>
+    <string name="ai_limit_ad_exhausted">今日の広告視聴回数を使い切りました</string>
+    <string name="ai_limit_ad_loading">広告を準備中…</string>
+    <string name="ai_limit_close">閉じる</string>
+
+    <!-- Subscription -->
+    <string name="subscription_title">Memozy Pro</string>
+    <string name="subscription_desc">AI機能をもっと使いましょう</string>
+    <string name="subscription_monthly">月額</string>
+    <string name="subscription_yearly">年額</string>
+    <string name="subscription_yearly_discount">30%%オフ</string>
+    <string name="subscription_feature_youtube">YouTube要約</string>
+    <string name="subscription_feature_web">Webページ要約</string>
+    <string name="subscription_feature_ocr">写真要約</string>
+    <string name="subscription_feature_more">より多くの要約が可能</string>
+    <string name="subscription_feature_no_ads">広告なし</string>
+    <string name="subscription_current_plan">現在のプラン</string>
+    <string name="subscription_manage">サブスクリプション管理</string>
+    <string name="subscription_restore">購入を復元</string>
+
+    <!-- Memozy AI -->
+    <string name="memozy_ai">Memozy AI</string>
+    <string name="ai_action_explain">分かりやすく説明して</string>
+    <string name="ai_action_organize">きれいに整理して</string>
+    <string name="ai_action_summarize">要点だけまとめて</string>
+    <string name="ai_action_custom">直接入力</string>
+    <string name="ai_input_placeholder">Memozy AIに何でも聞いてください</string>
+    <string name="ai_insert_to_memo">メモに追加</string>
+    <string name="ai_loading">AI応答中…</string>
+</resources>

--- a/feature/core/resource/src/commonMain/composeResources/values/strings.xml
+++ b/feature/core/resource/src/commonMain/composeResources/values/strings.xml
@@ -1,0 +1,279 @@
+<resources>
+    <!-- Settings -->
+    <string name="settings">설정</string>
+    <string name="section_theme">테마</string>
+    <string name="section_data">데이터</string>
+    <string name="section_other">기타</string>
+    <string name="language_settings">언어 설정</string>
+    <string name="open_source_license">오픈 소스 라이센스</string>
+    <string name="reset_memos">메모 초기화</string>
+    <string name="reset_confirm">저장된 모든 메모가 삭제됩니다.\n정말 초기화하시겠습니까?</string>
+    <string name="reset">초기화</string>
+    <string name="cancel">취소</string>
+    <string name="close">닫기</string>
+    <string name="theme_settings">테마 설정</string>
+    <string name="theme_light">라이트 모드</string>
+    <string name="theme_dark">다크 모드</string>
+    <string name="theme_system">시스템 기본값</string>
+    <string name="license_content">• Jetpack Compose - Apache 2.0\n• Room Database - Apache 2.0\n• Kotlin Coroutines - Apache 2.0\n• Navigation Compose - Apache 2.0</string>
+
+    <!-- Categories -->
+    <string name="category_all">전체</string>
+    <string name="category_settings">카테고리 설정</string>
+    <string name="category_general">일반</string>
+    <string name="category_work">업무</string>
+    <string name="category_idea">아이디어</string>
+    <string name="category_todo">할 일</string>
+    <string name="category_study">공부</string>
+    <string name="category_schedule">일정</string>
+    <string name="category_budget">가계부</string>
+    <string name="category_exercise">운동</string>
+    <string name="category_health">건강</string>
+    <string name="category_travel">여행</string>
+    <string name="category_shopping">쇼핑</string>
+
+    <!-- Memo -->
+    <string name="memo_title_label">제목</string>
+    <string name="memo_title_placeholder">메모 제목</string>
+    <string name="memo_content_label">내용</string>
+    <string name="memo_content_placeholder">메모 내용</string>
+    <string name="delete_confirm_title">정말 삭제하시겠습니까?</string>
+    <string name="delete_confirm_message">주의 : 삭제 시 복구가 불가능합니다</string>
+    <string name="yes">예</string>
+    <string name="no">아니오</string>
+    <string name="save">저장</string>
+    <string name="memo_done">완료</string>
+    <string name="add_memo">메모 추가</string>
+    <string name="edit_memo">메모 수정</string>
+
+
+    <!-- Search / Sort / Count -->
+    <string name="search_placeholder">제목 또는 내용으로 검색</string>
+    <string name="sort_newest">최신순</string>
+    <string name="sort_oldest">오래된순</string>
+    <string name="edit_mode">편집</string>
+    <string name="memo_count">총 %d개</string>
+    <string name="memo_updated_at">수정:</string>
+    <string name="memo_copy">복사</string>
+    <string name="memo_copied">메모가 복사되었습니다</string>
+    <string name="memo_shared">메모를 공유했습니다</string>
+    <string name="char_count">%d자</string>
+    <string name="empty_memo_hint">아직 메모가 없어요\n새 메모를 추가해 보세요</string>
+    <string name="empty_search_hint">검색 결과가 없어요</string>
+
+    <!-- Donation -->
+    <string name="donation_button">개발자에게 쌀 사주기 🍚</string>
+    <string name="donation_title">개발자에게 쌀 사주기</string>
+    <string name="donation_subtitle">후원해 주시면 더 맛있는 기능을 만들 수 있어요!</string>
+    <string name="donation_tier_1_name">햇반 1개</string>
+    <string name="donation_tier_1_desc">간단한 한 끼 선물</string>
+    <string name="donation_tier_2_name">햇반 6개 (1묶음)</string>
+    <string name="donation_tier_2_desc">일주일치 밥 선물</string>
+    <string name="donation_tier_3_name">햇반 18개 (1묶음)</string>
+    <string name="donation_tier_3_desc">한 달 든든한 선물</string>
+    <string name="donation_tier_4_name">쌀 10kg</string>
+    <string name="donation_tier_4_desc">진짜 쌀 한 포대!</string>
+    <string name="donation_tier_5_name">쌀 1포대 (20kg)</string>
+    <string name="donation_tier_5_desc">최고의 후원! 감사합니다</string>
+    <string name="donation_thank_title">감사합니다! 🙏</string>
+    <string name="donation_thank_message">따뜻한 후원 감사합니다!\n더 좋은 앱을 만들겠습니다.</string>
+    <string name="donation_error_title">결제 오류</string>
+    <string name="donation_error_message">결제 처리 중 문제가 발생했습니다.\n다시 시도해 주세요.</string>
+    <string name="donation_loading">연결 중…</string>
+
+    <!-- Export -->
+    <string name="memo_share">텍스트 공유</string>
+    <string name="memo_export_md">마크다운 내보내기</string>
+
+    <!-- Backup -->
+    <string name="backup_export">백업 내보내기</string>
+    <string name="backup_restore">백업 복원</string>
+    <string name="backup_restore_action">복원</string>
+    <string name="backup_restore_confirm">기존 메모를 모두 삭제하고 백업 파일로 복원합니다.\n이 작업은 되돌릴 수 없습니다.</string>
+    <string name="backup_success">%d개 메모가 처리되었습니다</string>
+    <string name="backup_error">백업 처리 중 오류가 발생했습니다</string>
+
+    <string name="trash_title">휴지통</string>
+    <string name="trash_empty">휴지통이 비어 있어요</string>
+    <string name="trash_empty_action">비우기</string>
+    <string name="trash_empty_confirm_title">휴지통 비우기</string>
+    <string name="trash_empty_confirm_message">모든 메모가 영구 삭제됩니다.\n이 작업은 되돌릴 수 없습니다.</string>
+    <string name="trash_restore">복원</string>
+    <string name="trash_permanent_delete_title">영구 삭제</string>
+    <string name="trash_permanent_delete_action">영구 삭제</string>
+    <string name="trash_permanent_delete_message">이 메모를 영구적으로 삭제합니다.\n복원할 수 없습니다.</string>
+    <string name="trash_auto_delete_hint">삭제된 메모는 30일 후 자동으로 영구 삭제됩니다</string>
+
+    <!-- Summary Card -->
+    <string name="summary_card_web">웹페이지</string>
+    <string name="summary_card_open">원본 보기</string>
+    <string name="summary_card_view_summary">요약 보기</string>
+    <string name="summary_card_summarize">AI 요약</string>
+
+    <!-- Filter -->
+    <string name="filter_all">전체</string>
+    <string name="filter_memo">메모</string>
+    <string name="filter_youtube">유튜브</string>
+    <string name="filter_recording">녹음</string>
+
+    <!-- Actions -->
+    <string name="pin">고정</string>
+    <string name="unpin">고정 해제</string>
+    <string name="delete_memo">메모 삭제</string>
+    <string name="add_tag">태그 추가</string>
+    <string name="tag_name">태그 이름</string>
+    <string name="add">추가</string>
+    <string name="confirm">확인</string>
+    <string name="previous">이전</string>
+    <string name="next_step">다음</string>
+    <string name="summarize">요약하기</string>
+
+    <!-- Memo Actions -->
+    <string name="copy_link">링크 복사</string>
+    <string name="open_in_browser">브라우저에서 열기</string>
+    <string name="open_in_youtube">YouTube에서 열기</string>
+    <string name="ai_summarize">AI 요약하기</string>
+    <string name="link_label">링크</string>
+    <string name="quiz_label">퀴즈</string>
+    <string name="notification_label">알림</string>
+    <string name="web_link">웹페이지 링크</string>
+    <string name="paste_clipboard">붙여넣기</string>
+
+    <!-- Status -->
+    <string name="recording_tap_to_stop">녹음 중… 탭하여 중지</string>
+    <string name="transcribing">음성 변환 중…</string>
+    <string name="web_summarizing">웹페이지 요약 중…</string>
+    <string name="youtube_summarizing">유튜브 요약 중…</string>
+    <string name="recording_file">녹음 파일</string>
+    <string name="recording_start">녹음</string>
+    <string name="recording_stop">중지</string>
+    <string name="youtube_label">유튜브</string>
+    <string name="saved_to_downloads">내 파일 > Download 에 저장됨</string>
+
+    <!-- Dialogs -->
+    <string name="web_summary_title">웹페이지 요약</string>
+    <string name="web_summary_desc">요약할 웹페이지 URL을 입력해주세요</string>
+    <string name="youtube_summary_title">유튜브 영상 요약</string>
+    <string name="youtube_summary_desc">요약할 YouTube URL을 입력해주세요</string>
+    <string name="time_select">시간 선택</string>
+    <string name="cancel_reminder">알림 해제</string>
+
+    <!-- Summary Mode -->
+    <string name="summary_collapse">요약 접기</string>
+    <string name="summary_expand">요약 보기</string>
+    <string name="summary_mode_simple">간단 요약</string>
+    <string name="summary_mode_detailed">상세 요약</string>
+    <string name="youtube_url_copied">유튜브 URL이 복사되었습니다</string>
+    <string name="youtube_open_to_copy">YouTube에서 URL 복사하기 →</string>
+    <string name="summary_style_select">요약 하기</string>
+    <string name="summary_style_simple">간단 요약</string>
+    <string name="summary_style_detailed">상세 요약</string>
+    <string name="web_url_copied">웹 URL이 복사되었습니다</string>
+    <string name="summary_copy">요약 복사</string>
+    <string name="summary_delete_title">요약 삭제</string>
+    <string name="summary_delete_message">요약 내용을 삭제하시겠습니까?\n삭제 시 복구할 수 없습니다.</string>
+    <string name="summary_delete_action">삭제</string>
+    <string name="memo_copy_done">복사되었습니다</string>
+
+    <!-- Trash Extra -->
+    <string name="trash_days_left">%d일 후 영구 삭제</string>
+    <string name="trash_soon_delete">곧 영구 삭제</string>
+
+    <!-- Multi-select -->
+    <string name="select">선택</string>
+    <string name="selected_count">%d개 선택</string>
+    <string name="delete_selected_title">선택한 메모 삭제</string>
+    <string name="delete_selected_message">선택한 %d개의 메모를 삭제하시겠습니까?\n삭제된 메모는 휴지통으로 이동합니다.</string>
+    <string name="select_all">전체선택</string>
+    <string name="deselect_all">선택해제</string>
+    <string name="delete_action">삭제</string>
+
+    <!-- Quiz -->
+    <string name="quiz_title">메모 퀴즈</string>
+    <string name="quiz_generating">퀴즈를 만들고 있어요…</string>
+    <string name="quiz_retry">다시 도전</string>
+    <string name="quiz_next">다음 문제</string>
+    <string name="quiz_show_result">결과 보기</string>
+    <string name="quiz_explanation">해설</string>
+    <string name="quiz_back">돌아가기</string>
+
+    <!-- Auth -->
+    <string name="section_account">계정</string>
+    <string name="sign_in_google">Google 계정 로그인</string>
+    <string name="sign_out">로그아웃</string>
+    <string name="sign_in_error">로그인에 실패했습니다</string>
+    <string name="sign_out_confirm">로그아웃하시겠습니까?</string>
+    <string name="sign_in_loading">로그인 중…</string>
+    <string name="login_subtitle">클라우드 백업으로 메모를 안전하게 보관하세요</string>
+    <string name="login_skip">연결 없이 시작</string>
+
+    <!-- Cloud Backup -->
+    <string name="section_cloud_backup">클라우드 백업</string>
+    <string name="cloud_backup_now">클라우드에 백업</string>
+    <string name="cloud_backup_restore">클라우드에서 복원</string>
+    <string name="cloud_backup_manage">백업 관리</string>
+    <string name="cloud_backup_uploading">백업 업로드 중…</string>
+    <string name="cloud_backup_success">백업이 완료되었습니다 (메모 %d개)</string>
+    <string name="cloud_backup_error">백업에 실패했습니다</string>
+    <string name="cloud_backup_restore_confirm">이 백업으로 복원하면 현재 데이터가 대체됩니다.\n이 작업은 되돌릴 수 없습니다.</string>
+    <string name="cloud_backup_restore_success">복원이 완료되었습니다 (메모 %d개)</string>
+    <string name="cloud_backup_restore_error">복원에 실패했습니다</string>
+    <string name="cloud_backup_delete_confirm">이 백업을 삭제하시겠습니까?</string>
+    <string name="cloud_backup_empty">저장된 백업이 없습니다</string>
+    <string name="cloud_backup_login_required">로그인 후 사용할 수 있습니다</string>
+    <string name="cloud_backup_restoring">복원 중…</string>
+    <string name="cloud_backup_count">저장된 백업 %d개</string>
+    <string name="cloud_backup_memo_count">메모 %d개</string>
+    <string name="cloud_backup_last_time">마지막 백업: %s</string>
+
+    <!-- Font Settings -->
+    <string name="font_settings">폰트 설정</string>
+    <string name="font_size">글자 크기</string>
+    <string name="font_size_small">작게</string>
+    <string name="font_size_normal">보통</string>
+    <string name="font_size_large">크게</string>
+    <string name="font_preview_title">제목 미리보기</string>
+    <string name="font_preview_body">본문 미리보기 텍스트입니다. 이 글꼴이 메모에 적용됩니다.</string>
+    <string name="font_system">시스템 기본</string>
+
+    <!-- AI Limit -->
+    <string name="ai_limit_title">오늘 AI 사용 한도에 도달했어요</string>
+    <string name="ai_limit_free_message">무료 사용자는 하루 %d회까지 AI 기능을 사용할 수 있어요.</string>
+    <string name="ai_limit_pro_message">Pro 사용자는 하루 %d회까지 AI 기능을 사용할 수 있어요.\n내일 다시 사용할 수 있어요.</string>
+    <string name="ai_limit_upgrade">Pro로 업그레이드</string>
+    <string name="ai_limit_upgrade_desc">더 많은 AI 요약 + 모든 프리미엄 기능</string>
+    <string name="ai_limit_watch_ad">광고 보고 1회 추가</string>
+    <string name="ai_limit_ad_remaining">오늘 %d회 더 시청 가능</string>
+    <string name="ai_limit_ad_exhausted">오늘 광고 시청 횟수를 모두 사용했어요</string>
+    <string name="ai_limit_ad_loading">광고 준비 중…</string>
+    <string name="ai_limit_close">닫기</string>
+
+    <!-- Subscription -->
+    <string name="subscription_title">Memozy Pro</string>
+    <string name="subscription_desc">AI 기능을 더 넉넉하게 사용하세요</string>
+    <string name="subscription_monthly">월간 구독</string>
+    <string name="subscription_yearly">연간 구독</string>
+    <string name="subscription_yearly_discount">30%% 할인</string>
+    <string name="subscription_feature_youtube">유튜브 요약</string>
+    <string name="subscription_feature_web">웹페이지 요약</string>
+    <string name="subscription_feature_ocr">사진 요약</string>
+    <string name="subscription_feature_more">더 많은 요약 가능</string>
+    <string name="subscription_feature_no_ads">광고 없음</string>
+    <string name="subscription_current_plan">현재 이용 중</string>
+    <string name="subscription_manage">구독 관리</string>
+    <string name="subscription_restore">구매 복원</string>
+
+    <!-- Login Prompt -->
+    <string name="login_prompt_title">로그인이 필요해요</string>
+    <string name="login_prompt_message">AI 요약 기능을 사용하려면 Google 계정으로 로그인해주세요.\n설정 > 계정에서 로그인할 수 있어요.</string>
+
+    <!-- Memozy AI -->
+    <string name="memozy_ai">Memozy AI</string>
+    <string name="ai_action_explain">이해하기 쉽게 설명해줘</string>
+    <string name="ai_action_organize">깔끔하게 정리해줘</string>
+    <string name="ai_action_summarize">핵심만 요약해줘</string>
+    <string name="ai_action_custom">직접 입력</string>
+    <string name="ai_input_placeholder">Memozy AI에게 물어보세요</string>
+    <string name="ai_insert_to_memo">메모에 추가</string>
+    <string name="ai_loading">AI 응답 중…</string>
+</resources>


### PR DESCRIPTION
## Summary
- `commonMain/composeResources/values*/strings.xml` 3개 (한/영/일) 복사본 추가
- `compose.resources { publicResClass, packageOfResClass }` 설정 추가
- `androidMain/res` 원본 유지 (원 프롬프트의 '원본 삭제' 지시는 Res.* ≠ R.* shim 이라는 잘못된 전제였음 — 삭제 시 CategoryConstants + 19 consumer + Glance Widget 에서 232건 R.string.* 가 즉시 깨짐)

## Why publicResClass + packageOfResClass
- default 는 `internal object Res` + root-project-name 기반 패키지(`memozy.feature.core.resource.generated.resources`) → consumer 모듈에서 접근 불가, A-1 블로커 해제 못 함
- 설정 2줄로 최소 보강 (프롬프트가 허용한 '최소로 보강' 범위)
- `packageOfResClass` 는 Android namespace 와 정합시켜 import 경로 예측 가능하게 조정

## Generated Res (A-1 import path)
```kotlin
import me.pecos.memozy.feature.core.resource.generated.resources.Res
import me.pecos.memozy.feature.core.resource.generated.resources.<string_name>

// 사용
stringResource(Res.string.<name>)
```
- Class: `public object Res` (consumer 접근 가능)
- String accessor: `public val Res.string.<name>: StringResource`
- 언어 qualifier (`values-en`, `values-ja`) 정상 반영됨

## Follow-up (explicit, 순서대로)
- A-1 home PR: `feature/home/impl` 소비자 파일별 `R.string.* → stringResource(Res.string.*)` incremental 교체 (commonMain 이전과 함께)
- A-1 memo-plain PR: `feature/memo-plain/impl` 동일
- 두 A-1 머지 후 cleanup PR: `feature/core/resource/src/androidMain/res/values*/strings.xml` 삭제 + `CategoryConstants` 의 Int 리스트 제거 (한 줄 수준)
- `MemoWidget`(Glance) 은 compose-resources 미적용 대상 → 영구 `R.*` 유지

## Test plan
- [x] `:feature:core:resource:compileAndroidMain` — `generateResourceAccessorsForCommonMain` + `generateComposeResClass` 실행 확인
- [x] `:feature:core:resource:compileKotlinIosX64 / IosArm64 / IosSimulatorArm64`
- [x] `:feature:home:impl:compileAndroidMain` — consumer 무영향 증거 (warning 전부 기존)
- [x] `:feature:memo-plain:impl:compileAndroidMain` — 동일
- [x] `:app:assembleDebug`
- [x] 생성된 `Res` 클래스 public 및 지정 패키지 확인 (`build/generated/compose/resourceGenerator/kotlin/commonResClass/me/pecos/memozy/feature/core/resource/generated/resources/Res.kt`)
- [ ] 런타임 회귀 — 원본 유지라 기존 동작 변화 없음 예상 (소비자 아직 Res.* 미사용)

## Refs
- #231 Wave 2 선행②
- #261 선행①(theme commonMain), #266 선행③(expect services) 과 합쳐 A-1 home/memo-plain 재개 블로커 전부 해제

🤖 Generated with [Claude Code](https://claude.com/claude-code)