### PR TITLE
Update: #231 Wave 2 후속 — feature/memo-plain/impl components Android 직접 호출을 platform/intent 서비스로 교체

### DIFF
--- a/feature/memo-plain/impl/build.gradle.kts
+++ b/feature/memo-plain/impl/build.gradle.kts
@@ -27,6 +27,7 @@ kotlin {
                 implementation(projects.data.repository.memo.api)
                 implementation(projects.datasource.remote.ai.api)
                 implementation(projects.platform.media.api)
+                implementation(projects.platform.intent.api)
                 implementation(libs.montage.android)
                 implementation(libs.androidx.compose.navigation)
                 implementation(libs.kotlinx.coroutines.android)

--- a/feature/memo-plain/impl/src/androidMain/kotlin/me/pecos/memozy/presentation/screen/memo/components/AiActionMenu.kt
+++ b/feature/memo-plain/impl/src/androidMain/kotlin/me/pecos/memozy/presentation/screen/memo/components/AiActionMenu.kt
@@ -1,6 +1,5 @@
 package me.pecos.memozy.presentation.screen.memo.components
 
-import android.view.HapticFeedbackConstants
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -16,12 +15,14 @@ import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import me.pecos.memozy.platform.intent.HapticKind
+import me.pecos.memozy.platform.intent.HapticService
 import me.pecos.memozy.presentation.theme.LocalAppColors
 import me.pecos.memozy.presentation.theme.LocalFontSettings
+import org.koin.compose.koinInject
 
 enum class AiPresetAction(
     val emoji: String,
@@ -41,7 +42,7 @@ fun AiActionMenu(
 ) {
     val colors = LocalAppColors.current
     val fontSettings = LocalFontSettings.current
-    val view = LocalView.current
+    val hapticService = koinInject<HapticService>()
 
     ModalBottomSheet(
         onDismissRequest = onDismiss,
@@ -67,7 +68,7 @@ fun AiActionMenu(
                     modifier = Modifier
                         .fillMaxWidth()
                         .clickable {
-                            view.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP)
+                            hapticService.perform(HapticKind.KeyboardTap)
                             onPresetSelected(action)
                         }
                         .padding(horizontal = 20.dp, vertical = 14.dp),

--- a/feature/memo-plain/impl/src/androidMain/kotlin/me/pecos/memozy/presentation/screen/memo/components/MemoDialogs.kt
+++ b/feature/memo-plain/impl/src/androidMain/kotlin/me/pecos/memozy/presentation/screen/memo/components/MemoDialogs.kt
@@ -1,9 +1,6 @@
 package me.pecos.memozy.presentation.screen.memo.components
 
-import android.content.ClipboardManager as AndroidClipboardManager
 import android.content.Context
-import android.content.Intent
-import android.net.Uri
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
@@ -35,7 +32,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.ClipboardManager
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontWeight
@@ -43,12 +39,15 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import me.pecos.memozy.feature.core.resource.R
+import me.pecos.memozy.platform.intent.ClipboardService
+import me.pecos.memozy.platform.intent.UrlLauncher
 import me.pecos.memozy.presentation.components.AppPopup
 import me.pecos.memozy.presentation.components.PopupActionArea
 import me.pecos.memozy.presentation.components.PopupNavigation
 import me.pecos.memozy.presentation.components.PopupSize
 import me.pecos.memozy.presentation.theme.AppColors
 import me.pecos.memozy.presentation.theme.LocalFontSettings
+import org.koin.compose.koinInject
 
 private val YOUTUBE_URL_REGEX = Regex(
     """(?:https?://)?(?:www\.)?(?:youtube\.com/watch\?v=|youtu\.be/|youtube\.com/shorts/)[\w\-]+(?:[&?][\w\-=]*)*"""
@@ -57,11 +56,6 @@ private val YOUTUBE_URL_REGEX = Regex(
 private val WEB_URL_REGEX = Regex(
     """https?://\S+"""
 )
-
-private fun getSystemClipboardText(context: Context): String {
-    val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as? AndroidClipboardManager
-    return clipboard?.primaryClip?.getItemAt(0)?.text?.toString() ?: ""
-}
 
 @Composable
 fun YouTubeUrlDialog(
@@ -72,9 +66,11 @@ fun YouTubeUrlDialog(
     onUrlAdded: (String) -> Unit
 ) {
     val fontSettings = LocalFontSettings.current
+    val clipboardService = koinInject<ClipboardService>()
+    val urlLauncher = koinInject<UrlLauncher>()
     var urlInput by remember { mutableStateOf("") }
     // 다이얼로그가 열릴 때마다 최신 클립보드를 읽도록 key 없이 매번 실행
-    val clipText = getSystemClipboardText(context)
+    val clipText = clipboardService.readPrimaryText() ?: ""
     val isValid = YOUTUBE_URL_REGEX.containsMatchIn(urlInput)
 
     AppPopup(
@@ -126,12 +122,10 @@ fun YouTubeUrlDialog(
             modifier = Modifier
                 .clip(RoundedCornerShape(8.dp))
                 .clickable {
-                    val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://www.youtube.com")).apply {
-                        setPackage("com.google.android.youtube")
-                    }
-                    try { context.startActivity(intent) } catch (_: Exception) {
-                        context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse("https://www.youtube.com")))
-                    }
+                    urlLauncher.openPreferringPackage(
+                        "https://www.youtube.com",
+                        "com.google.android.youtube"
+                    )
                 }
                 .padding(horizontal = 10.dp, vertical = 6.dp),
             verticalAlignment = Alignment.CenterVertically
@@ -156,10 +150,10 @@ fun WebUrlDialog(
     onDismiss: () -> Unit,
     onUrlConfirmed: (String) -> Unit
 ) {
-    val context = LocalContext.current
     val fontSettings = LocalFontSettings.current
+    val clipboardService = koinInject<ClipboardService>()
     var webUrlInput by remember { mutableStateOf("") }
-    val clipText = getSystemClipboardText(context)
+    val clipText = clipboardService.readPrimaryText() ?: ""
     val colors = me.pecos.memozy.presentation.theme.LocalAppColors.current
     val isValid = webUrlInput.startsWith("http")
 
@@ -221,6 +215,7 @@ fun WebLinkBottomSheet(
 ) {
     val colors = me.pecos.memozy.presentation.theme.LocalAppColors.current
     val fontSettings = LocalFontSettings.current
+    val urlLauncher = koinInject<UrlLauncher>()
     ModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = rememberModalBottomSheetState(),
@@ -248,7 +243,7 @@ fun WebLinkBottomSheet(
                 modifier = Modifier.fillMaxWidth().clip(RoundedCornerShape(12.dp))
                     .clickable {
                         val fullUrl = if (url.startsWith("http")) url else "https://$url"
-                        context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(fullUrl)))
+                        urlLauncher.open(fullUrl)
                         onDismiss()
                     }
                     .padding(vertical = 14.dp, horizontal = 4.dp),

--- a/feature/memo-plain/impl/src/androidMain/kotlin/me/pecos/memozy/presentation/screen/memo/components/SummaryCard.kt
+++ b/feature/memo-plain/impl/src/androidMain/kotlin/me/pecos/memozy/presentation/screen/memo/components/SummaryCard.kt
@@ -1,11 +1,5 @@
 package me.pecos.memozy.presentation.screen.memo.components
 
-import android.content.ClipData
-import android.content.ClipboardManager
-import android.content.Context
-import android.content.Intent
-import android.net.Uri
-import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -33,7 +27,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -41,9 +34,13 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
 import me.pecos.memozy.feature.core.resource.R
+import me.pecos.memozy.platform.intent.ClipboardService
+import me.pecos.memozy.platform.intent.ToastPresenter
+import me.pecos.memozy.platform.intent.UrlLauncher
 import me.pecos.memozy.presentation.screen.memo.SummaryMode
 import me.pecos.memozy.presentation.theme.LocalAppColors
 import me.pecos.memozy.presentation.theme.LocalFontSettings
+import org.koin.compose.koinInject
 
 enum class SummarySourceType { YOUTUBE, WEB, TWITTER }
 
@@ -60,8 +57,13 @@ fun SummaryCard(
     onDismiss: () -> Unit
 ) {
     val colors = LocalAppColors.current
-    val context = LocalContext.current
     val fontSettings = LocalFontSettings.current
+    val urlLauncher = koinInject<UrlLauncher>()
+    val clipboardService = koinInject<ClipboardService>()
+    val toastPresenter = koinInject<ToastPresenter>()
+    val youtubeUrlCopiedMsg = stringResource(R.string.youtube_url_copied)
+    val webUrlCopiedMsg = stringResource(R.string.web_url_copied)
+    val memoCopiedMsg = stringResource(R.string.memo_copied)
 
     Box {
         Column(
@@ -137,18 +139,10 @@ fun SummaryCard(
                             .clip(RoundedCornerShape(8.dp))
                             .background(colors.chipBackground)
                             .clickable {
-                                val intent = when (sourceType) {
-                                    SummarySourceType.YOUTUBE -> {
-                                        Intent(Intent.ACTION_VIEW, Uri.parse(url)).apply {
-                                            setPackage("com.google.android.youtube")
-                                        }
-                                    }
-                                    else -> Intent(Intent.ACTION_VIEW, Uri.parse(url))
-                                }
-                                try {
-                                    context.startActivity(intent)
-                                } catch (_: Exception) {
-                                    context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
+                                when (sourceType) {
+                                    SummarySourceType.YOUTUBE ->
+                                        urlLauncher.openPreferringPackage(url, "com.google.android.youtube")
+                                    else -> urlLauncher.open(url)
                                 }
                             }
                             .padding(horizontal = 10.dp, vertical = 6.dp),
@@ -165,14 +159,13 @@ fun SummaryCard(
                             .clip(RoundedCornerShape(8.dp))
                             .background(colors.chipBackground)
                             .clickable {
-                                val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
-                                clipboard.setPrimaryClip(ClipData.newPlainText("url", url))
+                                clipboardService.copyPlainText("url", url)
                                 val toastMsg = when (sourceType) {
-                                    SummarySourceType.YOUTUBE -> context.getString(R.string.youtube_url_copied)
-                                    SummarySourceType.WEB -> context.getString(R.string.web_url_copied)
-                                    else -> context.getString(R.string.memo_copied)
+                                    SummarySourceType.YOUTUBE -> youtubeUrlCopiedMsg
+                                    SummarySourceType.WEB -> webUrlCopiedMsg
+                                    else -> memoCopiedMsg
                                 }
-                                Toast.makeText(context, toastMsg, Toast.LENGTH_SHORT).show()
+                                toastPresenter.show(toastMsg)
                             }
                             .padding(horizontal = 10.dp, vertical = 6.dp),
                         verticalAlignment = Alignment.CenterVertically

--- a/feature/memo-plain/impl/src/androidMain/kotlin/me/pecos/memozy/presentation/screen/memo/components/WebSummaryInlineCard.kt
+++ b/feature/memo-plain/impl/src/androidMain/kotlin/me/pecos/memozy/presentation/screen/memo/components/WebSummaryInlineCard.kt
@@ -1,9 +1,6 @@
 package me.pecos.memozy.presentation.screen.memo.components
 
 import android.content.Context
-import android.content.Intent
-import android.net.Uri
-import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -39,9 +36,12 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import me.pecos.memozy.feature.core.resource.R
+import me.pecos.memozy.platform.intent.ToastPresenter
+import me.pecos.memozy.platform.intent.UrlLauncher
 import me.pecos.memozy.presentation.screen.memo.SummaryMode
 import me.pecos.memozy.presentation.theme.AppColors
 import me.pecos.memozy.presentation.theme.LocalFontSettings
+import org.koin.compose.koinInject
 
 @Composable
 fun WebSummaryInlineCard(
@@ -62,6 +62,10 @@ fun WebSummaryInlineCard(
     clipboardManager: ClipboardManager
 ) {
     val fontSettings = LocalFontSettings.current
+    val urlLauncher = koinInject<UrlLauncher>()
+    val toastPresenter = koinInject<ToastPresenter>()
+    val webUrlCopiedMsg = stringResource(R.string.web_url_copied)
+    val copyDoneMsg = stringResource(R.string.memo_copy_done)
 
     // 접힌 상태
     if (!isExpanded) {
@@ -115,7 +119,7 @@ fun WebSummaryInlineCard(
             Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(6.dp)) {
                 Row(
                     modifier = Modifier.weight(1f).clip(RoundedCornerShape(6.dp)).background(colors.chipBackground)
-                        .clickable { context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(webUrl))) }
+                        .clickable { urlLauncher.open(webUrl) }
                         .padding(vertical = 5.dp),
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.Center
@@ -127,7 +131,7 @@ fun WebSummaryInlineCard(
                     modifier = Modifier.weight(1f).clip(RoundedCornerShape(6.dp)).background(colors.chipBackground)
                         .clickable {
                             clipboardManager.setText(AnnotatedString(webUrl))
-                            Toast.makeText(context, context.getString(R.string.web_url_copied), Toast.LENGTH_SHORT).show()
+                            toastPresenter.show(webUrlCopiedMsg)
                         }
                         .padding(vertical = 5.dp),
                     verticalAlignment = Alignment.CenterVertically,
@@ -186,7 +190,7 @@ fun WebSummaryInlineCard(
                             .background(colors.chipBackground)
                             .clickable {
                                 clipboardManager.setText(AnnotatedString(summaryText))
-                                Toast.makeText(context, context.getString(R.string.memo_copy_done), Toast.LENGTH_SHORT).show()
+                                toastPresenter.show(copyDoneMsg)
                             }
                             .padding(vertical = 6.dp),
                         verticalAlignment = Alignment.CenterVertically,

--- a/feature/memo-plain/impl/src/androidMain/kotlin/me/pecos/memozy/presentation/screen/memo/components/YouTubeLinkBottomSheet.kt
+++ b/feature/memo-plain/impl/src/androidMain/kotlin/me/pecos/memozy/presentation/screen/memo/components/YouTubeLinkBottomSheet.kt
@@ -1,8 +1,6 @@
 package me.pecos.memozy.presentation.screen.memo.components
 
 import android.content.Context
-import android.content.Intent
-import android.net.Uri
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -27,9 +25,11 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import me.pecos.memozy.feature.core.resource.R
+import me.pecos.memozy.platform.intent.UrlLauncher
 import me.pecos.memozy.presentation.screen.memo.SummaryMode
 import me.pecos.memozy.presentation.theme.AppColors
 import me.pecos.memozy.presentation.theme.LocalFontSettings
+import org.koin.compose.koinInject
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -45,6 +45,7 @@ fun YouTubeLinkBottomSheet(
     onDismiss: () -> Unit,
     onSummarizeAndDismiss: (String, SummaryMode) -> Unit
 ) {
+    val urlLauncher = koinInject<UrlLauncher>()
     ModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = rememberModalBottomSheetState(),
@@ -77,7 +78,7 @@ fun YouTubeLinkBottomSheet(
                 modifier = Modifier.fillMaxWidth().clip(RoundedCornerShape(12.dp))
                     .clickable {
                         val fullUrl = if (url.startsWith("http")) url else "https://$url"
-                        context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(fullUrl)))
+                        urlLauncher.open(fullUrl)
                         onDismiss()
                     }
                     .padding(vertical = 14.dp, horizontal = 4.dp),
@@ -92,12 +93,7 @@ fun YouTubeLinkBottomSheet(
                 modifier = Modifier.fillMaxWidth().clip(RoundedCornerShape(12.dp))
                     .clickable {
                         val fullUrl = if (url.startsWith("http")) url else "https://$url"
-                        val ytIntent = Intent(Intent.ACTION_VIEW, Uri.parse(fullUrl)).apply {
-                            setPackage("com.google.android.youtube")
-                        }
-                        try { context.startActivity(ytIntent) } catch (_: Exception) {
-                            context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(fullUrl)))
-                        }
+                        urlLauncher.openPreferringPackage(fullUrl, "com.google.android.youtube")
                         onDismiss()
                     }
                     .padding(vertical = 14.dp, horizontal = 4.dp),

--- a/feature/memo-plain/impl/src/androidMain/kotlin/me/pecos/memozy/presentation/screen/memo/components/YouTubeSummaryInlineCard.kt
+++ b/feature/memo-plain/impl/src/androidMain/kotlin/me/pecos/memozy/presentation/screen/memo/components/YouTubeSummaryInlineCard.kt
@@ -1,9 +1,6 @@
 package me.pecos.memozy.presentation.screen.memo.components
 
 import android.content.Context
-import android.content.Intent
-import android.net.Uri
-import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -41,10 +38,13 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import me.pecos.memozy.feature.core.resource.R
+import me.pecos.memozy.platform.intent.ToastPresenter
+import me.pecos.memozy.platform.intent.UrlLauncher
 import me.pecos.memozy.presentation.screen.home.model.SummaryEntry
 import me.pecos.memozy.presentation.screen.memo.SummaryMode
 import me.pecos.memozy.presentation.theme.AppColors
 import me.pecos.memozy.presentation.theme.LocalFontSettings
+import org.koin.compose.koinInject
 
 @Composable
 fun YouTubeSummaryInlineCard(
@@ -70,6 +70,10 @@ fun YouTubeSummaryInlineCard(
     onStyleSelect: (() -> Unit)? = null
 ) {
     val fontSettings = LocalFontSettings.current
+    val urlLauncher = koinInject<UrlLauncher>()
+    val toastPresenter = koinInject<ToastPresenter>()
+    val urlCopiedMsg = stringResource(R.string.youtube_url_copied)
+    val copyDoneMsg = stringResource(R.string.memo_copy_done)
     val hasSummary = summaryEntries.isNotEmpty()
 
     // 접힌 상태
@@ -138,10 +142,7 @@ fun YouTubeSummaryInlineCard(
                     Row(
                         modifier = Modifier.weight(1f).clip(RoundedCornerShape(6.dp)).background(colors.chipBackground)
                             .clickable {
-                                val intent = Intent(Intent.ACTION_VIEW, Uri.parse(youtubeUrl)).apply { setPackage("com.google.android.youtube") }
-                                try { context.startActivity(intent) } catch (_: Exception) {
-                                    context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(youtubeUrl)))
-                                }
+                                urlLauncher.openPreferringPackage(youtubeUrl, "com.google.android.youtube")
                             }
                             .padding(vertical = 5.dp),
                         verticalAlignment = Alignment.CenterVertically,
@@ -154,7 +155,7 @@ fun YouTubeSummaryInlineCard(
                         modifier = Modifier.weight(1f).clip(RoundedCornerShape(6.dp)).background(colors.chipBackground)
                             .clickable {
                                 clipboardManager.setText(AnnotatedString(youtubeUrl))
-                                Toast.makeText(context, context.getString(R.string.youtube_url_copied), Toast.LENGTH_SHORT).show()
+                                toastPresenter.show(urlCopiedMsg)
                             }
                             .padding(vertical = 5.dp),
                         verticalAlignment = Alignment.CenterVertically,
@@ -245,7 +246,7 @@ fun YouTubeSummaryInlineCard(
                                 .background(colors.chipBackground)
                                 .clickable {
                                     clipboardManager.setText(AnnotatedString(entry.content))
-                                    Toast.makeText(context, context.getString(R.string.memo_copy_done), Toast.LENGTH_SHORT).show()
+                                    toastPresenter.show(copyDoneMsg)
                                 }
                                 .padding(vertical = 6.dp),
                             verticalAlignment = Alignment.CenterVertically,


### PR DESCRIPTION
## Summary
- components/ 6개 파일의 Android 직접 호출 → expect 서비스 교체
- build.gradle.kts 에 platform.intent.api 의존 추가

## Replaced call sites (파일별)

### AiActionMenu.kt
- `view.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP)` → `HapticService.perform(HapticKind.KeyboardTap)`
- `LocalView` / `HapticFeedbackConstants` import 제거

### MemoDialogs.kt
- `context.getSystemService(CLIPBOARD_SERVICE) as AndroidClipboardManager` 기반 `getSystemClipboardText(context)` 헬퍼 → `ClipboardService.readPrimaryText() ?: ""`
- YouTube 패키지 선호 Intent (`Intent.ACTION_VIEW` + `setPackage` + try/catch 폴백) → `UrlLauncher.openPreferringPackage("https://www.youtube.com", "com.google.android.youtube")`
- WebLinkBottomSheet 브라우저 Intent → `UrlLauncher.open(fullUrl)`

### SummaryCard.kt
- YouTube/일반 분기 Intent + try/catch 폴백 → `UrlLauncher.openPreferringPackage(url, "com.google.android.youtube")` / `UrlLauncher.open(url)`
- `ClipData.newPlainText + setPrimaryClip` → `ClipboardService.copyPlainText("url", url)`
- `Toast.makeText(...).show()` → `ToastPresenter.show(toastMsg)` (스트링은 `stringResource`로 composable 최상단에서 캡처)

### WebSummaryInlineCard.kt
- 브라우저 Intent (`context.startActivity(Intent.ACTION_VIEW ...)`) → `UrlLauncher.open(webUrl)`
- URL 복사 Toast + 요약 복사 Toast 2곳 → `ToastPresenter.show(webUrlCopiedMsg/copyDoneMsg)`

### YouTubeLinkBottomSheet.kt
- 브라우저 Intent → `UrlLauncher.open(fullUrl)`
- YouTube 패키지 선호 Intent + try/catch 폴백 → `UrlLauncher.openPreferringPackage(fullUrl, "com.google.android.youtube")`

### YouTubeSummaryInlineCard.kt
- YouTube 패키지 선호 Intent + try/catch 폴백 → `UrlLauncher.openPreferringPackage(youtubeUrl, "com.google.android.youtube")`
- URL 복사 Toast + 요약 복사 Toast 2곳 → `ToastPresenter.show(urlCopiedMsg/copyDoneMsg)`

서비스 주입은 모두 `org.koin.compose.koinInject<T>()` 사용 (이미 이 모듈에서 `AudioPlayerBar` / `MemoPlainNavigationImpl` 가 쓰는 패턴과 일치).

## Scope boundary
- `MemoScreen.kt` / `AudioPlayerBar.kt` / `MemoPlainNavigationImpl.kt` 는 ⓓ 담당 — 손대지 않음
- `FormattingToolbar.kt` 는 ⓔ 담당 — 손대지 않음
- `feature/home/**` 는 ⓑ 담당 — 손대지 않음
- 각 composable 함수 시그니처의 `context: Context` / `clipboardManager: ClipboardManager` 파라미터는 **유지** — 호출부인 `MemoScreen.kt`(⓭) 가 여전히 전달 중이며 이번 PR 범위에서 건드릴 수 없기 때문. ⓓ에서 MemoScreen도 서비스 전환 완료 후 파라미터 제거 예정 (현재 일부 미사용 경고 발생하나 빌드 통과).
- 컴포즈 `androidx.compose.ui.platform.ClipboardManager.setText(AnnotatedString)` 호출은 **유지** — 이미 멀티플랫폼 API라 "Android 직접 호출"에 해당하지 않음 (스코프 외).

## Rebase note
- ⓓ 트랙도 같은 `feature/memo-plain/impl/build.gradle.kts` 에 `projects.platform.intent.api` 를 추가 중. 먼저 머지되는 쪽이 winner, 나머지는 rebase 시 해당 1줄이 develop 에 이미 있어 auto-drop.
- ⓔ(parseColor) 와는 다른 파일들이라 충돌 없음.

## Test plan
- [x] `./gradlew :feature:memo-plain:impl:compileAndroidMain` BUILD SUCCESSFUL
- [x] `./gradlew :feature:memo-plain:impl:compileKotlinIosX64 :compileKotlinIosArm64 :compileKotlinIosSimulatorArm64` BUILD SUCCESSFUL
- [x] `./gradlew :app:assembleDebug` BUILD SUCCESSFUL
- [ ] 수동 회귀 — 메모 상세: YouTube/Web 링크 바텀시트에서 복사/토스트/브라우저/유튜브 앱 열기 동작, SummaryCard URL 복사 토스트, AI 액션 메뉴 선택 시 햅틱

## Refs
- #231 Wave 2 후속 ⓒ (memo-plain components)
- #266 expect services consumer 트랙

🤖 Generated with [Claude Code](https://claude.com/claude-code)