### PR TITLE
Add: #280 iOS AdsService no-op — 리워드 광고 iOS 미지원 공식화

### DIFF
--- a/feature/core/resource/src/commonMain/composeResources/values-en/strings.xml
+++ b/feature/core/resource/src/commonMain/composeResources/values-en/strings.xml
@@ -246,6 +246,7 @@
     <string name="ai_limit_ad_remaining">%d more views available today</string>
     <string name="ai_limit_ad_exhausted">No more ad views available today</string>
     <string name="ai_limit_ad_loading">Loading ad…</string>
+    <string name="ai_limit_ios_unsupported">Reward ads are not supported on iOS</string>
     <string name="ai_limit_close">Close</string>
 
     <!-- Subscription -->

--- a/feature/core/resource/src/commonMain/composeResources/values-ja/strings.xml
+++ b/feature/core/resource/src/commonMain/composeResources/values-ja/strings.xml
@@ -246,6 +246,7 @@
     <string name="ai_limit_ad_remaining">今日あと%d回視聴可能</string>
     <string name="ai_limit_ad_exhausted">今日の広告視聴回数を使い切りました</string>
     <string name="ai_limit_ad_loading">広告を準備中…</string>
+    <string name="ai_limit_ios_unsupported">リワード広告機能はiOSではご利用いただけません</string>
     <string name="ai_limit_close">閉じる</string>
 
     <!-- Subscription -->

--- a/feature/core/resource/src/commonMain/composeResources/values/strings.xml
+++ b/feature/core/resource/src/commonMain/composeResources/values/strings.xml
@@ -246,6 +246,7 @@
     <string name="ai_limit_ad_remaining">오늘 %d회 더 시청 가능</string>
     <string name="ai_limit_ad_exhausted">오늘 광고 시청 횟수를 모두 사용했어요</string>
     <string name="ai_limit_ad_loading">광고 준비 중…</string>
+    <string name="ai_limit_ios_unsupported">리워드 광고 기능은 iOS에서 지원하지 않아요</string>
     <string name="ai_limit_close">닫기</string>
 
     <!-- Subscription -->

--- a/feature/memo-plain/impl/src/commonMain/kotlin/me/pecos/memozy/feature/memoplain/impl/MemoPlainNavigationImpl.kt
+++ b/feature/memo-plain/impl/src/commonMain/kotlin/me/pecos/memozy/feature/memoplain/impl/MemoPlainNavigationImpl.kt
@@ -978,9 +978,10 @@ class MemoPlainNavigationImpl(
             }
 
             if (showLimitBottomSheet) {
+                val isAdPlatformSupported = rewardAdProvider?.isPlatformSupported != false
                 AiLimitBottomSheet(
                     subscriptionTier = subscriptionTier,
-                    canWatchAd = canWatchAd,
+                    canWatchAd = canWatchAd && isAdPlatformSupported,
                     remainingAdViews = remainingAdViews,
                     isAdLoading = rewardAdProvider?.isAdLoading == true,
                     onWatchAd = {
@@ -994,7 +995,8 @@ class MemoPlainNavigationImpl(
                         }
                     },
                     onUpgrade = { showLimitBottomSheet = false },
-                    onDismiss = { showLimitBottomSheet = false }
+                    onDismiss = { showLimitBottomSheet = false },
+                    isPlatformSupported = isAdPlatformSupported,
                 )
             }
         }

--- a/feature/memo-plain/impl/src/commonMain/kotlin/me/pecos/memozy/presentation/screen/memo/components/AiLimitBottomSheet.kt
+++ b/feature/memo-plain/impl/src/commonMain/kotlin/me/pecos/memozy/presentation/screen/memo/components/AiLimitBottomSheet.kt
@@ -26,6 +26,7 @@ import me.pecos.memozy.feature.core.resource.generated.resources.ai_limit_ad_exh
 import me.pecos.memozy.feature.core.resource.generated.resources.ai_limit_ad_remaining
 import me.pecos.memozy.feature.core.resource.generated.resources.ai_limit_close
 import me.pecos.memozy.feature.core.resource.generated.resources.ai_limit_free_message
+import me.pecos.memozy.feature.core.resource.generated.resources.ai_limit_ios_unsupported
 import me.pecos.memozy.feature.core.resource.generated.resources.ai_limit_pro_message
 import me.pecos.memozy.feature.core.resource.generated.resources.ai_limit_title
 import me.pecos.memozy.feature.core.resource.generated.resources.ai_limit_upgrade
@@ -45,7 +46,8 @@ fun AiLimitBottomSheet(
     isAdLoading: Boolean,
     onWatchAd: () -> Unit,
     onUpgrade: () -> Unit,
-    onDismiss: () -> Unit
+    onDismiss: () -> Unit,
+    isPlatformSupported: Boolean = true,
 ) {
     val colors = LocalAppColors.current
     val fontSettings = LocalFontSettings.current
@@ -88,8 +90,16 @@ fun AiLimitBottomSheet(
             Spacer(modifier = Modifier.height(20.dp))
 
             if (!subscriptionTier.isPro) {
-                // 광고 시청 버튼 (Free 유저만)
-                if (canWatchAd) {
+                // 광고 시청 버튼 (Free 유저만) — iOS는 현재 리워드 광고 SDK 미연동
+                if (!isPlatformSupported) {
+                    Text(
+                        text = stringResource(Res.string.ai_limit_ios_unsupported),
+                        fontSize = fontSettings.scaled(13),
+                        color = colors.textSecondary,
+                        textAlign = TextAlign.Center
+                    )
+                    Spacer(modifier = Modifier.height(12.dp))
+                } else if (canWatchAd) {
                     Button(
                         onClick = onWatchAd,
                         enabled = !isAdLoading,

--- a/platform/ads/api/src/commonMain/kotlin/me/pecos/memozy/platform/ads/AdsService.kt
+++ b/platform/ads/api/src/commonMain/kotlin/me/pecos/memozy/platform/ads/AdsService.kt
@@ -4,6 +4,9 @@ interface AdsService {
     val isAdReady: Boolean
     val isAdLoading: Boolean
 
+    /** 현재 플랫폼에서 광고 기능을 실제로 지원하는지. iOS no-op 구현은 false. */
+    val isPlatformSupported: Boolean get() = true
+
     fun initialize()
     fun loadAd()
     fun showAd(onRewarded: () -> Unit)

--- a/platform/ads/impl/src/iosMain/kotlin/me/pecos/memozy/platform/ads/IosAdsService.kt
+++ b/platform/ads/impl/src/iosMain/kotlin/me/pecos/memozy/platform/ads/IosAdsService.kt
@@ -1,0 +1,20 @@
+package me.pecos.memozy.platform.ads
+
+/**
+ * iOS no-op 구현 (이슈 #280 옵션 A).
+ * 리워드 광고 SDK 연동 전까지 모든 메서드는 아무 동작도 하지 않고,
+ * 상위 UI는 [isPlatformSupported] 로 iOS 미지원 안내를 분기한다.
+ */
+class IosAdsService : AdsService {
+
+    override val isAdReady: Boolean = false
+    override val isAdLoading: Boolean = false
+    override val isPlatformSupported: Boolean = false
+
+    override fun initialize() { /* no-op */ }
+    override fun loadAd() { /* no-op */ }
+    override fun showAd(onRewarded: () -> Unit) { /* no-op — 호출되지 않아야 함 */ }
+
+    override fun bindActivity(activity: Any?) { /* no-op */ }
+    override fun unbindActivity() { /* no-op */ }
+}

--- a/shared/umbrella/build.gradle.kts
+++ b/shared/umbrella/build.gradle.kts
@@ -53,6 +53,8 @@ kotlin {
             implementation(projects.platform.intent.impl)
             implementation(projects.platform.credential.api)
             implementation(projects.platform.credential.impl)
+            implementation(projects.platform.ads.api)
+            implementation(projects.platform.ads.impl)
         }
     }
 }

--- a/shared/umbrella/src/iosMain/kotlin/me/pecos/memozy/shared/umbrella/SharedKoin.kt
+++ b/shared/umbrella/src/iosMain/kotlin/me/pecos/memozy/shared/umbrella/SharedKoin.kt
@@ -15,6 +15,8 @@ import me.pecos.memozy.feature.core.viewmodel.settings.FileUriBridge
 import me.pecos.memozy.feature.core.viewmodel.settings.IosFileUriBridge
 import me.pecos.memozy.feature.core.viewmodel.settings.NSUserDefaultsPreferencesProvider
 import me.pecos.memozy.feature.core.viewmodel.settings.PreferencesProvider
+import me.pecos.memozy.platform.ads.AdsService
+import me.pecos.memozy.platform.ads.IosAdsService
 import me.pecos.memozy.platform.credential.CredentialService
 import me.pecos.memozy.platform.credential.IosCredentialService
 import me.pecos.memozy.platform.intent.AppInfo
@@ -68,6 +70,9 @@ val sharedModule: Module = module {
 
     // Credential
     single<CredentialService> { IosCredentialService() }
+
+    // Ads (iOS no-op — 이슈 #280 옵션 A)
+    single<AdsService> { IosAdsService() }
 
     // Stubs (Supabase 연결 완료 전까지 임시)
     single<AuthService> { IosStubAuthService() }


### PR DESCRIPTION
## Summary
- `platform/ads/impl/iosMain` 에 `IosAdsService` no-op actual 추가 (AdMob 미연동 정책)
- `AdsService.isPlatformSupported` 플래그 도입으로 commonMain UI 가 플랫폼 이름을 몰라도 분기
- `AiLimitBottomSheet` iOS 에서 광고 버튼 숨김 + 안내 문구 노출

## Context
iOS 용 광고 경로 부재. 옵션 A(범위 최소) 로 결정 — iOS 리워드 광고 미지원 공식화.

## Changes
- `platform/ads/api/.../AdsService.kt` — `isPlatformSupported` 플래그 (default `true`)
- `platform/ads/impl/.../iosMain/IosAdsService.kt` — no-op actual (신규)
- `shared/umbrella/build.gradle.kts` — iosMain 에 platform:ads api/impl 의존성 추가
- `shared/umbrella/.../SharedKoin.kt` — `AdsService` iOS 바인딩
- `feature/memo-plain/impl/.../AiLimitBottomSheet.kt` — iOS 분기 UI
- `feature/memo-plain/impl/.../MemoPlainNavigationImpl.kt` — `canWatchAd` 게이트
- `feature/core/resource/.../values*/strings.xml` — `ai_limit_ios_unsupported` (ko/en/ja)

## Build verification
- ✅ `:platform:ads:api:compileKotlinIosSimulatorArm64`
- ✅ `:platform:ads:impl:compileKotlinIosSimulatorArm64`
- ✅ `:platform:ads:impl:assemble` (Android AAR + iOS klib)
- ⚠️ `:shared:umbrella:compileKotlinIosSimulatorArm64` 는 `feature/core/resource` .gitkeep 에러로 블록 — develop 에서도 동일 재현. 이번 작업 무관.

## Test plan
- [ ] Android 회귀: 리워드 광고 정상 로드/노출
- [ ] iOS 시뮬: `AiLimitBottomSheet` 에서 광고 버튼 미노출 + "리워드 광고 기능은 iOS에서 지원하지 않아요" 문구 노출

Closes #280

🤖 Generated with [Claude Code](https://claude.com/claude-code)