### PR TITLE
Add: #281 iOS 언어 변경 재시작 안내 — AppRestarter 정책 공식화

### DIFF
--- a/feature/core/resource/src/commonMain/composeResources/values-en/strings.xml
+++ b/feature/core/resource/src/commonMain/composeResources/values-en/strings.xml
@@ -6,6 +6,7 @@
     <string name="section_data">Data</string>
     <string name="section_other">Other</string>
     <string name="language_settings">Language</string>
+    <string name="ios_restart_required">Changes will apply after restarting the app</string>
     <string name="open_source_license">Open Source Licenses</string>
     <string name="reset_memos">Reset Memos</string>
     <string name="reset_confirm">All saved memos will be deleted.\nAre you sure you want to reset?</string>

--- a/feature/core/resource/src/commonMain/composeResources/values-ja/strings.xml
+++ b/feature/core/resource/src/commonMain/composeResources/values-ja/strings.xml
@@ -6,6 +6,7 @@
     <string name="section_data">データ</string>
     <string name="section_other">その他</string>
     <string name="language_settings">言語設定</string>
+    <string name="ios_restart_required">アプリを再起動すると反映されます</string>
     <string name="open_source_license">オープンソースライセンス</string>
     <string name="reset_memos">メモをリセット</string>
     <string name="reset_confirm">保存されたすべてのメモが削除されます。\n本当にリセットしますか？</string>

--- a/feature/core/resource/src/commonMain/composeResources/values/strings.xml
+++ b/feature/core/resource/src/commonMain/composeResources/values/strings.xml
@@ -5,6 +5,7 @@
     <string name="section_data">데이터</string>
     <string name="section_other">기타</string>
     <string name="language_settings">언어 설정</string>
+    <string name="ios_restart_required">앱 재시작 후 반영됩니다</string>
     <string name="open_source_license">오픈 소스 라이센스</string>
     <string name="reset_memos">메모 초기화</string>
     <string name="reset_confirm">저장된 모든 메모가 삭제됩니다.\n정말 초기화하시겠습니까?</string>

--- a/feature/home/impl/src/commonMain/kotlin/me/pecos/memozy/presentation/screen/settings/SettingsScreen.kt
+++ b/feature/home/impl/src/commonMain/kotlin/me/pecos/memozy/presentation/screen/settings/SettingsScreen.kt
@@ -75,6 +75,7 @@ import me.pecos.memozy.feature.core.resource.generated.resources.font_size_large
 import me.pecos.memozy.feature.core.resource.generated.resources.font_size_normal
 import me.pecos.memozy.feature.core.resource.generated.resources.font_size_small
 import me.pecos.memozy.feature.core.resource.generated.resources.ic_google
+import me.pecos.memozy.feature.core.resource.generated.resources.ios_restart_required
 import me.pecos.memozy.feature.core.resource.generated.resources.language_settings
 import me.pecos.memozy.feature.core.resource.generated.resources.open_source_license
 import me.pecos.memozy.feature.core.resource.generated.resources.reset
@@ -398,7 +399,14 @@ fun SettingsScreen(
                     val onSelectLanguage = {
                         settingsViewModel.selectLanguage(language)
                         showLanguageDialog = false
-                        appRestarter.restart()
+                        if (appRestarter.isRestartSupported) {
+                            appRestarter.restart()
+                        } else {
+                            // iOS: 프로세스 재시작 수단이 없으므로 사용자에게 수동 재시작 안내
+                            scope.launch {
+                                toastPresenter.show(getString(Res.string.ios_restart_required))
+                            }
+                        }
                     }
                     Row(
                         modifier = Modifier

--- a/platform/intent/api/src/commonMain/kotlin/me/pecos/memozy/platform/intent/AppRestarter.kt
+++ b/platform/intent/api/src/commonMain/kotlin/me/pecos/memozy/platform/intent/AppRestarter.kt
@@ -2,8 +2,15 @@ package me.pecos.memozy.platform.intent
 
 /**
  * 언어 전환 후처럼 루트 UI 를 새로 만들어야 할 때 사용.
- * Android 는 Activity.recreate, iOS 는 SceneDelegate 기반 재로딩(후속 구현).
+ * Android 는 Activity.recreate, iOS 는 프로세스 재시작 수단이 없어 no-op.
  */
 interface AppRestarter {
+    /**
+     * 이 플랫폼에서 [restart] 가 실제로 UI 를 재구성하는지 여부.
+     * false 인 플랫폼에서는 호출 측이 사용자에게 "앱 재시작 후 반영됩니다"
+     * 안내를 노출해야 한다.
+     */
+    val isRestartSupported: Boolean get() = true
+
     fun restart()
 }

--- a/platform/intent/impl/src/iosMain/kotlin/me/pecos/memozy/platform/intent/IosAppRestarter.kt
+++ b/platform/intent/impl/src/iosMain/kotlin/me/pecos/memozy/platform/intent/IosAppRestarter.kt
@@ -1,11 +1,21 @@
 package me.pecos.memozy.platform.intent
 
 /**
- * iOS 에서는 현재 ComposeUIViewController 를 교체하는 훅이 없어 동작 안 함.
- * 언어 변경은 앱 재시작까지 반영되지 않음 (후속 과제).
+ * iOS no-op 정책 (공식).
+ *
+ * WHY: iOS 는 앱 프로세스 스스로 자신을 재시작할 공식 수단이 없다.
+ * UIApplication 수준에서 Activity.recreate 같은 훅이 제공되지 않으며,
+ * exit(0) 같은 강제 종료는 App Store 리젝 사유가 된다.
+ * 따라서 언어 변경 등 루트 UI 를 새로 구성해야 하는 상황은 "사용자가 직접
+ * 앱을 종료 → 재실행" 하는 방식으로만 반영된다.
+ *
+ * restart() 는 호출돼도 아무 것도 하지 않고, 호출 측이 [isRestartSupported]
+ * 를 체크해 안내 문구(예: ios_restart_required)를 노출해야 한다.
  */
 class IosAppRestarter : AppRestarter {
+    override val isRestartSupported: Boolean = false
+
     override fun restart() {
-        // no-op
+        // no-op (정책: 위 주석 참조)
     }
 }


### PR DESCRIPTION
## Summary
- `AppRestarter.isRestartSupported` 플래그 도입으로 commonMain UI 분기
- `IosAppRestarter` 는 `false` — iOS 는 프로세스 재시작 수단 없음 공식화
- `SettingsScreen` 언어 변경 시 iOS 는 Toast "앱 재시작 후 반영됩니다" 노출

## Context
Android 는 `recreate()` 로 언어 즉시 반영, iOS 는 `UIApplication` 재시작 훅 없음 + `exit(0)` 는 App Store 리젝 사유 → 사용자 수동 재시작만 유효. 옵션 3(정책 공식화) 채택.

## Changes
- `platform/intent/api/.../AppRestarter.kt` — `isRestartSupported` 플래그 (default `true`)
- `platform/intent/impl/.../iosMain/IosAppRestarter.kt` — `isRestartSupported=false` + WHY 주석 확장
- `feature/home/impl/.../SettingsScreen.kt` — 언어 변경 분기: 지원 시 `restart()`, 미지원 시 Toast
- `feature/core/resource/.../values*/strings.xml` — `ios_restart_required` (ko/en/ja)

## Behavior
- Android: 언어 선택 → 즉시 반영 (변경 없음)
- iOS: 언어 선택 → 값 저장 → 다이얼로그 닫힘 → Toast "앱 재시작 후 반영됩니다"

## Test plan
- [ ] Android 회귀: 언어 변경 즉시 반영
- [ ] iOS 시뮬: 언어 변경 후 Toast 노출 + 재시작 후 새 언어 반영

Closes #281

🤖 Generated with [Claude Code](https://claude.com/claude-code)