### PR TITLE
Add: #280 + #281 iOS 광고/재시작 정책 공식화

### DIFF
--- a/feature/core/resource/src/commonMain/composeResources/values-en/strings.xml
+++ b/feature/core/resource/src/commonMain/composeResources/values-en/strings.xml
@@ -246,6 +246,7 @@
     <string name="ai_limit_ad_remaining">%d more views available today</string>
     <string name="ai_limit_ad_exhausted">No more ad views available today</string>
     <string name="ai_limit_ad_loading">Loading ad…</string>
+    <string name="ai_limit_ios_unsupported">Reward ads are not supported on iOS</string>
     <string name="ai_limit_close">Close</string>
 
     <!-- Subscription -->

--- a/feature/core/resource/src/commonMain/composeResources/values-en/strings.xml
+++ b/feature/core/resource/src/commonMain/composeResources/values-en/strings.xml
@@ -6,6 +6,7 @@
     <string name="section_data">Data</string>
     <string name="section_other">Other</string>
     <string name="language_settings">Language</string>
+    <string name="ios_restart_required">Changes will apply after restarting the app</string>
     <string name="open_source_license">Open Source Licenses</string>
     <string name="reset_memos">Reset Memos</string>
     <string name="reset_confirm">All saved memos will be deleted.\nAre you sure you want to reset?</string>

--- a/feature/core/resource/src/commonMain/composeResources/values-ja/strings.xml
+++ b/feature/core/resource/src/commonMain/composeResources/values-ja/strings.xml
@@ -6,6 +6,7 @@
     <string name="section_data">データ</string>
     <string name="section_other">その他</string>
     <string name="language_settings">言語設定</string>
+    <string name="ios_restart_required">アプリを再起動すると反映されます</string>
     <string name="open_source_license">オープンソースライセンス</string>
     <string name="reset_memos">メモをリセット</string>
     <string name="reset_confirm">保存されたすべてのメモが削除されます。\n本当にリセットしますか？</string>

--- a/feature/core/resource/src/commonMain/composeResources/values-ja/strings.xml
+++ b/feature/core/resource/src/commonMain/composeResources/values-ja/strings.xml
@@ -246,6 +246,7 @@
     <string name="ai_limit_ad_remaining">今日あと%d回視聴可能</string>
     <string name="ai_limit_ad_exhausted">今日の広告視聴回数を使い切りました</string>
     <string name="ai_limit_ad_loading">広告を準備中…</string>
+    <string name="ai_limit_ios_unsupported">リワード広告機能はiOSではご利用いただけません</string>
     <string name="ai_limit_close">閉じる</string>
 
     <!-- Subscription -->

--- a/feature/core/resource/src/commonMain/composeResources/values/strings.xml
+++ b/feature/core/resource/src/commonMain/composeResources/values/strings.xml
@@ -5,6 +5,7 @@
     <string name="section_data">데이터</string>
     <string name="section_other">기타</string>
     <string name="language_settings">언어 설정</string>
+    <string name="ios_restart_required">앱 재시작 후 반영됩니다</string>
     <string name="open_source_license">오픈 소스 라이센스</string>
     <string name="reset_memos">메모 초기화</string>
     <string name="reset_confirm">저장된 모든 메모가 삭제됩니다.\n정말 초기화하시겠습니까?</string>

--- a/feature/core/resource/src/commonMain/composeResources/values/strings.xml
+++ b/feature/core/resource/src/commonMain/composeResources/values/strings.xml
@@ -246,6 +246,7 @@
     <string name="ai_limit_ad_remaining">오늘 %d회 더 시청 가능</string>
     <string name="ai_limit_ad_exhausted">오늘 광고 시청 횟수를 모두 사용했어요</string>
     <string name="ai_limit_ad_loading">광고 준비 중…</string>
+    <string name="ai_limit_ios_unsupported">리워드 광고 기능은 iOS에서 지원하지 않아요</string>
     <string name="ai_limit_close">닫기</string>
 
     <!-- Subscription -->

--- a/feature/home/impl/src/commonMain/kotlin/me/pecos/memozy/presentation/screen/settings/SettingsScreen.kt
+++ b/feature/home/impl/src/commonMain/kotlin/me/pecos/memozy/presentation/screen/settings/SettingsScreen.kt
@@ -75,6 +75,7 @@ import me.pecos.memozy.feature.core.resource.generated.resources.font_size_large
 import me.pecos.memozy.feature.core.resource.generated.resources.font_size_normal
 import me.pecos.memozy.feature.core.resource.generated.resources.font_size_small
 import me.pecos.memozy.feature.core.resource.generated.resources.ic_google
+import me.pecos.memozy.feature.core.resource.generated.resources.ios_restart_required
 import me.pecos.memozy.feature.core.resource.generated.resources.language_settings
 import me.pecos.memozy.feature.core.resource.generated.resources.open_source_license
 import me.pecos.memozy.feature.core.resource.generated.resources.reset
@@ -398,7 +399,14 @@ fun SettingsScreen(
                     val onSelectLanguage = {
                         settingsViewModel.selectLanguage(language)
                         showLanguageDialog = false
-                        appRestarter.restart()
+                        if (appRestarter.isRestartSupported) {
+                            appRestarter.restart()
+                        } else {
+                            // iOS: 프로세스 재시작 수단이 없으므로 사용자에게 수동 재시작 안내
+                            scope.launch {
+                                toastPresenter.show(getString(Res.string.ios_restart_required))
+                            }
+                        }
                     }
                     Row(
                         modifier = Modifier

--- a/feature/memo-plain/impl/src/commonMain/kotlin/me/pecos/memozy/feature/memoplain/impl/MemoPlainNavigationImpl.kt
+++ b/feature/memo-plain/impl/src/commonMain/kotlin/me/pecos/memozy/feature/memoplain/impl/MemoPlainNavigationImpl.kt
@@ -978,9 +978,10 @@ class MemoPlainNavigationImpl(
             }
 
             if (showLimitBottomSheet) {
+                val isAdPlatformSupported = rewardAdProvider?.isPlatformSupported != false
                 AiLimitBottomSheet(
                     subscriptionTier = subscriptionTier,
-                    canWatchAd = canWatchAd,
+                    canWatchAd = canWatchAd && isAdPlatformSupported,
                     remainingAdViews = remainingAdViews,
                     isAdLoading = rewardAdProvider?.isAdLoading == true,
                     onWatchAd = {
@@ -994,7 +995,8 @@ class MemoPlainNavigationImpl(
                         }
                     },
                     onUpgrade = { showLimitBottomSheet = false },
-                    onDismiss = { showLimitBottomSheet = false }
+                    onDismiss = { showLimitBottomSheet = false },
+                    isPlatformSupported = isAdPlatformSupported,
                 )
             }
         }

--- a/feature/memo-plain/impl/src/commonMain/kotlin/me/pecos/memozy/presentation/screen/memo/components/AiLimitBottomSheet.kt
+++ b/feature/memo-plain/impl/src/commonMain/kotlin/me/pecos/memozy/presentation/screen/memo/components/AiLimitBottomSheet.kt
@@ -26,6 +26,7 @@ import me.pecos.memozy.feature.core.resource.generated.resources.ai_limit_ad_exh
 import me.pecos.memozy.feature.core.resource.generated.resources.ai_limit_ad_remaining
 import me.pecos.memozy.feature.core.resource.generated.resources.ai_limit_close
 import me.pecos.memozy.feature.core.resource.generated.resources.ai_limit_free_message
+import me.pecos.memozy.feature.core.resource.generated.resources.ai_limit_ios_unsupported
 import me.pecos.memozy.feature.core.resource.generated.resources.ai_limit_pro_message
 import me.pecos.memozy.feature.core.resource.generated.resources.ai_limit_title
 import me.pecos.memozy.feature.core.resource.generated.resources.ai_limit_upgrade
@@ -45,7 +46,8 @@ fun AiLimitBottomSheet(
     isAdLoading: Boolean,
     onWatchAd: () -> Unit,
     onUpgrade: () -> Unit,
-    onDismiss: () -> Unit
+    onDismiss: () -> Unit,
+    isPlatformSupported: Boolean = true,
 ) {
     val colors = LocalAppColors.current
     val fontSettings = LocalFontSettings.current
@@ -88,8 +90,16 @@ fun AiLimitBottomSheet(
             Spacer(modifier = Modifier.height(20.dp))
 
             if (!subscriptionTier.isPro) {
-                // 광고 시청 버튼 (Free 유저만)
-                if (canWatchAd) {
+                // 광고 시청 버튼 (Free 유저만) — iOS는 현재 리워드 광고 SDK 미연동
+                if (!isPlatformSupported) {
+                    Text(
+                        text = stringResource(Res.string.ai_limit_ios_unsupported),
+                        fontSize = fontSettings.scaled(13),
+                        color = colors.textSecondary,
+                        textAlign = TextAlign.Center
+                    )
+                    Spacer(modifier = Modifier.height(12.dp))
+                } else if (canWatchAd) {
                     Button(
                         onClick = onWatchAd,
                         enabled = !isAdLoading,

--- a/platform/ads/api/src/commonMain/kotlin/me/pecos/memozy/platform/ads/AdsService.kt
+++ b/platform/ads/api/src/commonMain/kotlin/me/pecos/memozy/platform/ads/AdsService.kt
@@ -4,6 +4,9 @@ interface AdsService {
     val isAdReady: Boolean
     val isAdLoading: Boolean
 
+    /** 현재 플랫폼에서 광고 기능을 실제로 지원하는지. iOS no-op 구현은 false. */
+    val isPlatformSupported: Boolean get() = true
+
     fun initialize()
     fun loadAd()
     fun showAd(onRewarded: () -> Unit)

--- a/platform/ads/impl/src/iosMain/kotlin/me/pecos/memozy/platform/ads/IosAdsService.kt
+++ b/platform/ads/impl/src/iosMain/kotlin/me/pecos/memozy/platform/ads/IosAdsService.kt
@@ -1,0 +1,20 @@
+package me.pecos.memozy.platform.ads
+
+/**
+ * iOS no-op 구현 (이슈 #280 옵션 A).
+ * 리워드 광고 SDK 연동 전까지 모든 메서드는 아무 동작도 하지 않고,
+ * 상위 UI는 [isPlatformSupported] 로 iOS 미지원 안내를 분기한다.
+ */
+class IosAdsService : AdsService {
+
+    override val isAdReady: Boolean = false
+    override val isAdLoading: Boolean = false
+    override val isPlatformSupported: Boolean = false
+
+    override fun initialize() { /* no-op */ }
+    override fun loadAd() { /* no-op */ }
+    override fun showAd(onRewarded: () -> Unit) { /* no-op — 호출되지 않아야 함 */ }
+
+    override fun bindActivity(activity: Any?) { /* no-op */ }
+    override fun unbindActivity() { /* no-op */ }
+}

--- a/platform/intent/api/src/commonMain/kotlin/me/pecos/memozy/platform/intent/AppRestarter.kt
+++ b/platform/intent/api/src/commonMain/kotlin/me/pecos/memozy/platform/intent/AppRestarter.kt
@@ -2,8 +2,15 @@ package me.pecos.memozy.platform.intent
 
 /**
  * 언어 전환 후처럼 루트 UI 를 새로 만들어야 할 때 사용.
- * Android 는 Activity.recreate, iOS 는 SceneDelegate 기반 재로딩(후속 구현).
+ * Android 는 Activity.recreate, iOS 는 프로세스 재시작 수단이 없어 no-op.
  */
 interface AppRestarter {
+    /**
+     * 이 플랫폼에서 [restart] 가 실제로 UI 를 재구성하는지 여부.
+     * false 인 플랫폼에서는 호출 측이 사용자에게 "앱 재시작 후 반영됩니다"
+     * 안내를 노출해야 한다.
+     */
+    val isRestartSupported: Boolean get() = true
+
     fun restart()
 }

--- a/platform/intent/impl/src/iosMain/kotlin/me/pecos/memozy/platform/intent/IosAppRestarter.kt
+++ b/platform/intent/impl/src/iosMain/kotlin/me/pecos/memozy/platform/intent/IosAppRestarter.kt
@@ -1,11 +1,21 @@
 package me.pecos.memozy.platform.intent
 
 /**
- * iOS 에서는 현재 ComposeUIViewController 를 교체하는 훅이 없어 동작 안 함.
- * 언어 변경은 앱 재시작까지 반영되지 않음 (후속 과제).
+ * iOS no-op 정책 (공식).
+ *
+ * WHY: iOS 는 앱 프로세스 스스로 자신을 재시작할 공식 수단이 없다.
+ * UIApplication 수준에서 Activity.recreate 같은 훅이 제공되지 않으며,
+ * exit(0) 같은 강제 종료는 App Store 리젝 사유가 된다.
+ * 따라서 언어 변경 등 루트 UI 를 새로 구성해야 하는 상황은 "사용자가 직접
+ * 앱을 종료 → 재실행" 하는 방식으로만 반영된다.
+ *
+ * restart() 는 호출돼도 아무 것도 하지 않고, 호출 측이 [isRestartSupported]
+ * 를 체크해 안내 문구(예: ios_restart_required)를 노출해야 한다.
  */
 class IosAppRestarter : AppRestarter {
+    override val isRestartSupported: Boolean = false
+
     override fun restart() {
-        // no-op
+        // no-op (정책: 위 주석 참조)
     }
 }

--- a/shared/umbrella/build.gradle.kts
+++ b/shared/umbrella/build.gradle.kts
@@ -53,6 +53,8 @@ kotlin {
             implementation(projects.platform.intent.impl)
             implementation(projects.platform.credential.api)
             implementation(projects.platform.credential.impl)
+            implementation(projects.platform.ads.api)
+            implementation(projects.platform.ads.impl)
         }
     }
 }

--- a/shared/umbrella/src/iosMain/kotlin/me/pecos/memozy/shared/umbrella/SharedKoin.kt
+++ b/shared/umbrella/src/iosMain/kotlin/me/pecos/memozy/shared/umbrella/SharedKoin.kt
@@ -15,6 +15,8 @@ import me.pecos.memozy.feature.core.viewmodel.settings.FileUriBridge
 import me.pecos.memozy.feature.core.viewmodel.settings.IosFileUriBridge
 import me.pecos.memozy.feature.core.viewmodel.settings.NSUserDefaultsPreferencesProvider
 import me.pecos.memozy.feature.core.viewmodel.settings.PreferencesProvider
+import me.pecos.memozy.platform.ads.AdsService
+import me.pecos.memozy.platform.ads.IosAdsService
 import me.pecos.memozy.platform.credential.CredentialService
 import me.pecos.memozy.platform.credential.IosCredentialService
 import me.pecos.memozy.platform.intent.AppInfo
@@ -68,6 +70,9 @@ val sharedModule: Module = module {
 
     // Credential
     single<CredentialService> { IosCredentialService() }
+
+    // Ads (iOS no-op — 이슈 #280 옵션 A)
+    single<AdsService> { IosAdsService() }
 
     // Stubs (Supabase 연결 완료 전까지 임시)
     single<AuthService> { IosStubAuthService() }


### PR DESCRIPTION
## Summary
iOS 플랫폼 전용 기능 두 개를 "정책으로 공식화 + commonMain UI 분기" 방식으로 묶어 처리.

- **#280**: iOS AdMob 미연동 공식화 — `IosAdsService` no-op + `AdsService.isPlatformSupported` 플래그 + `AiLimitBottomSheet` 광고 버튼 숨김
- **#281**: iOS AppRestarter 미지원 공식화 — `IosAppRestarter.isRestartSupported=false` + `SettingsScreen` 언어 변경 시 "앱 재시작 후 반영" Toast

두 작업 모두 인터페이스에 플랫폼 기능 플래그(`isPlatformSupported` / `isRestartSupported`) 하나를 추가해 commonMain UI 가 플랫폼 이름을 몰라도 분기하는 동일 패턴.

## Changes

### #280 — iOS 광고 no-op
- `platform/ads/api/.../AdsService.kt` — `isPlatformSupported` (default `true`)
- `platform/ads/impl/.../iosMain/IosAdsService.kt` — no-op actual (신규)
- `shared/umbrella/build.gradle.kts` — iosMain 에 `platform:ads` api/impl 추가
- `shared/umbrella/.../SharedKoin.kt` — `AdsService` iOS 바인딩
- `feature/memo-plain/impl/.../AiLimitBottomSheet.kt` — iOS 분기 UI
- `feature/memo-plain/impl/.../MemoPlainNavigationImpl.kt` — `canWatchAd` 게이트
- `feature/core/resource/.../values*/strings.xml` — `ai_limit_ios_unsupported` (ko/en/ja)

### #281 — iOS 재시작 정책
- `platform/intent/api/.../AppRestarter.kt` — `isRestartSupported` (default `true`)
- `platform/intent/impl/.../iosMain/IosAppRestarter.kt` — `false` + WHY 주석 확장
- `feature/home/impl/.../SettingsScreen.kt` — 언어 변경 분기 (restart 또는 Toast)
- `feature/core/resource/.../values*/strings.xml` — `ios_restart_required` (ko/en/ja)

## Behavior
- **Android**: 기존 동작 유지 (광고 정상 / 언어 즉시 반영)
- **iOS**:
  - 리워드 광고 버튼 자리에 "리워드 광고 기능은 iOS에서 지원하지 않아요"
  - 언어 변경 → 값 저장 → Toast "앱 재시작 후 반영됩니다"

## Build verification
- ✅ `:platform:ads:*:compileKotlinIosSimulatorArm64`
- ✅ `:platform:ads:impl:assemble` (Android AAR + iOS klib)
- ⚠️ `:shared:umbrella:compileKotlinIosSimulatorArm64` 는 `feature/core/resource` .gitkeep 에러로 블록 — develop 에서도 동일 재현 (선행 환경 이슈, 이번 작업 무관)

## Test plan
- [ ] Android 회귀: 리워드 광고 정상 로드/노출 + 언어 변경 즉시 반영
- [ ] iOS 시뮬:
  - [ ] `AiLimitBottomSheet` 에서 광고 버튼 미노출 + 안내 문구
  - [ ] 언어 변경 후 Toast 노출 + 재실행 후 새 언어 반영

Closes #280
Closes #281

🤖 Generated with [Claude Code](https://claude.com/claude-code)