### PR TITLE
Fix: #298 위젯 HTML raw 노출 수정 + 메모 카드 간격 개선

### DIFF
--- a/app/src/main/java/me/pecos/memozy/widget/MemoWidget.kt
+++ b/app/src/main/java/me/pecos/memozy/widget/MemoWidget.kt
@@ -32,6 +32,7 @@ import me.pecos.memozy.MainActivity
 import me.pecos.memozy.R
 import me.pecos.memozy.data.datasource.local.entity.Memo
 import me.pecos.memozy.data.repository.MemoRepository
+import me.pecos.memozy.presentation.util.htmlToPlainText
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import java.text.SimpleDateFormat
@@ -133,7 +134,7 @@ class MemoWidget : GlanceAppWidget(), KoinComponent {
                                     val summaryPreview = memo.summaryContent?.let {
                                         me.pecos.memozy.presentation.screen.home.model.parseSummaryEntries(it).firstOrNull()?.content
                                     }
-                                    val widgetContent = memo.content.ifBlank { summaryPreview ?: "" }
+                                    val widgetContent = memo.content.htmlToPlainText().ifBlank { summaryPreview ?: "" }
                                     if (widgetContent.isNotBlank()) {
                                         Spacer(modifier = GlanceModifier.height(2.dp))
                                         Text(

--- a/app/src/main/java/me/pecos/memozy/widget/MemoWidget.kt
+++ b/app/src/main/java/me/pecos/memozy/widget/MemoWidget.kt
@@ -108,11 +108,13 @@ class MemoWidget : GlanceAppWidget(), KoinComponent {
                         }
                     } else {
                         Column(modifier = GlanceModifier.defaultWeight()) {
-                            for (memo in memos) {
+                            memos.forEachIndexed { index, memo ->
+                                if (index > 0) {
+                                    Spacer(modifier = GlanceModifier.height(8.dp))
+                                }
                                 Column(
                                     modifier = GlanceModifier
                                         .fillMaxWidth()
-                                        .padding(vertical = 4.dp)
                                         .cornerRadius(12.dp)
                                         .background(MemoWidgetColors.cardBackground)
                                         .padding(12.dp)


### PR DESCRIPTION
## Summary
- 위젯(MemoWidget)에 메모 본문이 HTML 태그/엔티티(`<p>`, `&lsqb;`, `<br>` 등)로 그대로 노출되던 치명 버그 수정
- 위젯 카드 간격이 좁아 답답했던 문제 개선

## Changes

### 1. BUG-1: 위젯 HTML raw 노출 수정 (`d2ab545`)
- `MemoWidget.kt`: `memo.content` → `memo.content.htmlToPlainText()` 적용
- 기존 `htmlToPlainText()` 유틸 재사용 (`MemoCard`, `TrashScreen`와 동일 패턴)
- `feature:core:resource` 의존성은 이미 존재 → 추가 의존성 없음

### 2. 위젯 메모 카드 간격 확대 (`366fd4e`)
- 카드 outer `padding(vertical = 4.dp)` 제거
- 카드 사이에 `Spacer(8.dp)` 명시적으로 추가
- `for` → `forEachIndexed` 전환 (첫 카드 상단 공백 제거)

## Test Plan
- [x] 실기기(Galaxy S20 FE, Android 13) 설치 후 위젯 확인
- [x] HTML 포함 메모가 `[네이버지도]`, 개행 등으로 정상 렌더링
- [x] 메모 카드 사이 간격 자연스러운지 육안 확인
- [ ] 다크 모드에서도 간격/렌더링 동일한지 확인 (선택)
- [ ] 특수문자/이모지가 섞인 메모 테스트 (선택)

## 관련 이슈
- Refs #298 (배포 전 QA — BUG-1 항목)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
