### PR TITLE
Fix: #298 위젯 + 버튼 라우팅 + 메모 DB 변경 시 위젯 자동 갱신

### DIFF
--- a/app/src/main/java/me/pecos/memozy/MemozyApplication.kt
+++ b/app/src/main/java/me/pecos/memozy/MemozyApplication.kt
@@ -1,10 +1,16 @@
 package me.pecos.memozy
 
 import android.app.Application
+import android.appwidget.AppWidgetManager
+import android.content.ComponentName
+import android.content.Intent
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
+import me.pecos.memozy.data.repository.MemoRepository
+import me.pecos.memozy.widget.MemoWidgetReceiver
 import me.pecos.memozy.di.adsPlatformModule
 import me.pecos.memozy.di.aiNetworkModule
 import me.pecos.memozy.di.authModule
@@ -56,6 +62,30 @@ class MemozyApplication : Application() {
         val adsService: AdsService by inject()
         appScope.launch {
             adsService.initialize()
+        }
+
+        // 메모 DB 변경 시 홈 위젯 갱신 — system broadcast 단일 경로 사용
+        // distinctUntilChanged로 동일 상태 연속 emit 차단 (저장 중 Room이 여러 번 emit 하는 케이스 방어)
+        val memoRepository: MemoRepository by inject()
+        appScope.launch {
+            memoRepository.getMemos()
+                .distinctUntilChanged { old, new ->
+                    old.size == new.size &&
+                        old.zip(new).all { (a, b) -> a.id == b.id && a.updatedAt == b.updatedAt }
+                }
+                .collect {
+                    val appWidgetManager = AppWidgetManager.getInstance(this@MemozyApplication)
+                    val ids = appWidgetManager.getAppWidgetIds(
+                        ComponentName(this@MemozyApplication, MemoWidgetReceiver::class.java)
+                    )
+                    if (ids.isNotEmpty()) {
+                        val intent = Intent(this@MemozyApplication, MemoWidgetReceiver::class.java).apply {
+                            action = AppWidgetManager.ACTION_APPWIDGET_UPDATE
+                            putExtra(AppWidgetManager.EXTRA_APPWIDGET_IDS, ids)
+                        }
+                        sendBroadcast(intent)
+                    }
+                }
         }
     }
 }

--- a/feature/home/impl/src/androidMain/kotlin/me/pecos/memozy/MainActivity.kt
+++ b/feature/home/impl/src/androidMain/kotlin/me/pecos/memozy/MainActivity.kt
@@ -254,8 +254,8 @@ class MainActivity : ComponentActivity() {
                             }
                         }
 
-                        // 위젯 액션 처리
-                        val widgetRoute = remember { getWidgetMemoRoute(intent) }
+                        // 위젯 액션 처리 — activeIntent를 key로 걸어 onNewIntent로 들어오는 새 intent도 반영
+                        val widgetRoute = remember(activeIntent) { getWidgetMemoRoute(activeIntent) }
                         LaunchedEffect(widgetRoute) {
                             if (widgetRoute != null) {
                                 navController.navigate(widgetRoute)


### PR DESCRIPTION
## Summary
위젯 관련 버그 2건 수정.
- 위젯 `+` 버튼으로 메모 추가 UI 진입 불가 → 수정
- 메모 저장 후 위젯이 자동 갱신되지 않음 → 기본 동작 추가

## Changes

### 1. BUG-7: 위젯 `+` 버튼 라우팅 (`bd222bf`)
**파일:** `feature/home/impl/src/androidMain/kotlin/me/pecos/memozy/MainActivity.kt`

```diff
-val widgetRoute = remember { getWidgetMemoRoute(intent) }
+val widgetRoute = remember(activeIntent) { getWidgetMemoRoute(activeIntent) }
```

`remember {}` 에 key가 없어 최초 1회만 평가 + `intent`(원본) 사용 → `onNewIntent`로 들어오는 새 intent가 반영 안 됨. 앱이 떠있는 상태에서 위젯 `+` 터치 시 메인 화면만 보이는 원인.

### 2. BUG-6: 위젯 자동 갱신 (`433c53b`)
**파일:** `app/src/main/java/me/pecos/memozy/MemozyApplication.kt`

- `MemoRepository.getMemos()` Flow 구독
- 변경 감지 시 `AppWidgetManager.ACTION_APPWIDGET_UPDATE` broadcast → `MemoWidgetReceiver` 재트리거
- `distinctUntilChanged(size + id + updatedAt)` 로 Room 과잉 emit 방어
- Glance `updateAll()` 대신 broadcast 단일 경로 채택 (병행 시 시스템 중복 dedupe로 간헐 실패 발생)

## Test Plan
- [x] 실기기(Galaxy S20 FE, Android 13) 위젯 `+` 버튼 → 메모추가 UI 이동 확인
- [x] 앱에서 메모 추가 → 위젯 반영 기본 동작 확인
- [ ] ⚠️ 간헐 실패 잔여 가능성 — **#BUG-8 (메모 저장 간헐 실패)** 해결 후 재검증 필요

## Refs
- Refs #298 (BUG-7, BUG-6 항목)
- ⚠️ **BUG-8 (메모 저장 간헐 실패)는 별도 이슈/PR로 분리 예정** — 원인은 `MemoPlainNavigationImpl.kt:597-610`의 `GlobalScope.launch` + `savedMemoId` race condition. 해당 문제가 수정되기 전까지는 위젯 자동 갱신도 완벽하지 않을 수 있음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
