### PR TITLE
Fix: #299 %d/%s 포맷 치환 — stringResourceFormatted 유틸 도입

### DIFF
--- a/feature/core/resource/src/commonMain/kotlin/me/pecos/memozy/presentation/util/StringFormat.kt
+++ b/feature/core/resource/src/commonMain/kotlin/me/pecos/memozy/presentation/util/StringFormat.kt
@@ -1,0 +1,28 @@
+package me.pecos.memozy.presentation.util
+
+import androidx.compose.runtime.Composable
+import org.jetbrains.compose.resources.StringResource
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * format args(%d, %s)를 지원하는 stringResource 래퍼.
+ *
+ * Compose Multiplatform Resources 1.10.3의 stringResource(resource, vararg args) 오버로드가
+ * 런타임에 format args를 치환하지 않고 리터럴로 노출하는 이슈가 있어 직접 Regex로 치환한다.
+ * 리소스에서 사용 중인 포맷은 단일 %d 또는 %s 뿐이라 positional/%% escape는 지원하지 않는다.
+ */
+@Composable
+fun stringResourceFormatted(resource: StringResource, vararg args: Any): String {
+    val template = stringResource(resource)
+    return applyFormatArgs(template, args)
+}
+
+private val FORMAT_PATTERN = Regex("""%[ds]""")
+
+private fun applyFormatArgs(template: String, args: Array<out Any>): String {
+    if (args.isEmpty()) return template
+    var index = 0
+    return FORMAT_PATTERN.replace(template) { match ->
+        if (index < args.size) args[index++].toString() else match.value
+    }
+}

--- a/feature/home/impl/src/commonMain/kotlin/me/pecos/memozy/presentation/screen/home/HomeScreen.kt
+++ b/feature/home/impl/src/commonMain/kotlin/me/pecos/memozy/presentation/screen/home/HomeScreen.kt
@@ -88,6 +88,7 @@ import me.pecos.memozy.feature.core.viewmodel.model.SortOrder
 import me.pecos.memozy.presentation.theme.LocalAppColors
 import me.pecos.memozy.presentation.theme.LocalFontSettings
 import org.jetbrains.compose.resources.painterResource
+import me.pecos.memozy.presentation.util.stringResourceFormatted
 import org.jetbrains.compose.resources.stringResource
 
 // ── 홈 화면 ────────────────────────────────────────────────────────────────────
@@ -138,7 +139,7 @@ fun HomeScreen(
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     Text(
-                        text = if (isSelectionMode) stringResource(Res.string.selected_count, selectedIds.size) else "Memozy",
+                        text = if (isSelectionMode) stringResourceFormatted(Res.string.selected_count, selectedIds.size) else "Memozy",
                         fontSize = fontSettings.scaled(22),
                         fontWeight = FontWeight.Bold,
                         color = colors.topbarTitle,
@@ -146,7 +147,7 @@ fun HomeScreen(
                     )
                     if (!isSelectionMode) {
                         Text(
-                            text = stringResource(Res.string.memo_count, filteredList.size),
+                            text = stringResourceFormatted(Res.string.memo_count, filteredList.size),
                             fontSize = fontSettings.scaled(12),
                             color = colors.textSecondary
                         )
@@ -387,7 +388,7 @@ fun HomeScreen(
             onSecondaryClick = { showDeleteConfirm = false }
         ) {
             Text(
-                stringResource(Res.string.delete_selected_message, selectedIds.size),
+                stringResourceFormatted(Res.string.delete_selected_message, selectedIds.size),
                 color = LocalAppColors.current.textBody
             )
         }

--- a/feature/home/impl/src/commonMain/kotlin/me/pecos/memozy/presentation/screen/settings/SettingsScreen.kt
+++ b/feature/home/impl/src/commonMain/kotlin/me/pecos/memozy/presentation/screen/settings/SettingsScreen.kt
@@ -129,6 +129,7 @@ import me.pecos.memozy.presentation.components.rememberOpenDocumentLauncher
 import me.pecos.memozy.presentation.theme.LocalActivity
 import org.jetbrains.compose.resources.getString
 import org.jetbrains.compose.resources.painterResource
+import me.pecos.memozy.presentation.util.stringResourceFormatted
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.koinInject
 import me.pecos.memozy.presentation.theme.LocalAppColors
@@ -691,7 +692,7 @@ fun SettingsScreen(
                         // 마지막 백업 시간 표시 (이메일 아래)
                         lastBackupTime?.let { time ->
                             Text(
-                                text = stringResource(Res.string.cloud_backup_last_time, time.take(16).replace("T", " ")),
+                                text = stringResourceFormatted(Res.string.cloud_backup_last_time, time.take(16).replace("T", " ")),
                                 fontSize = fontSettings.scaled(11),
                                 color = colors.textSecondary,
                                 modifier = Modifier.padding(start = 20.dp, bottom = 4.dp)

--- a/feature/home/impl/src/commonMain/kotlin/me/pecos/memozy/presentation/screen/trash/TrashScreen.kt
+++ b/feature/home/impl/src/commonMain/kotlin/me/pecos/memozy/presentation/screen/trash/TrashScreen.kt
@@ -1,6 +1,7 @@
 package me.pecos.memozy.presentation.screen.trash
 
 import me.pecos.memozy.presentation.util.htmlToPlainText
+import me.pecos.memozy.presentation.util.stringResourceFormatted
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -286,7 +287,7 @@ private fun formatDeletedTime(deletedAt: Long?): String {
     val msPerDay = 24L * 60L * 60L * 1000L
     val daysLeft = 30 - (now - deletedAt) / msPerDay
     return if (daysLeft > 0) {
-        stringResource(Res.string.trash_days_left, daysLeft.toInt())
+        stringResourceFormatted(Res.string.trash_days_left, daysLeft.toInt())
     } else {
         stringResource(Res.string.trash_soon_delete)
     }

--- a/feature/memo-plain/impl/src/commonMain/kotlin/me/pecos/memozy/presentation/screen/memo/components/AiLimitBottomSheet.kt
+++ b/feature/memo-plain/impl/src/commonMain/kotlin/me/pecos/memozy/presentation/screen/memo/components/AiLimitBottomSheet.kt
@@ -35,6 +35,7 @@ import me.pecos.memozy.feature.core.resource.generated.resources.ai_limit_watch_
 import me.pecos.memozy.presentation.theme.LocalAppColors
 import me.pecos.memozy.presentation.theme.LocalFontSettings
 import me.pecos.memozy.presentation.theme.SubscriptionTier
+import me.pecos.memozy.presentation.util.stringResourceFormatted
 import org.jetbrains.compose.resources.stringResource
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -75,9 +76,9 @@ fun AiLimitBottomSheet(
             Spacer(modifier = Modifier.height(12.dp))
 
             val message = if (subscriptionTier.isPro) {
-                stringResource(Res.string.ai_limit_pro_message, subscriptionTier.dailyAiLimit)
+                stringResourceFormatted(Res.string.ai_limit_pro_message, subscriptionTier.dailyAiLimit)
             } else {
-                stringResource(Res.string.ai_limit_free_message, subscriptionTier.dailyAiLimit)
+                stringResourceFormatted(Res.string.ai_limit_free_message, subscriptionTier.dailyAiLimit)
             }
 
             Text(
@@ -127,7 +128,7 @@ fun AiLimitBottomSheet(
                     Spacer(modifier = Modifier.height(4.dp))
 
                     Text(
-                        text = stringResource(Res.string.ai_limit_ad_remaining, remainingAdViews),
+                        text = stringResourceFormatted(Res.string.ai_limit_ad_remaining, remainingAdViews),
                         fontSize = fontSettings.scaled(12),
                         color = colors.textBody.copy(alpha = 0.6f),
                         textAlign = TextAlign.Center


### PR DESCRIPTION
## Summary
Closes #299.
Compose Multiplatform Resources 1.10.3의 `stringResource(resource, vararg args)` 오버로드가 런타임에 format args를 치환하지 않고 `%d memos` 같은 리터럴을 그대로 노출하던 이슈 수정.

## Changes

### 새 유틸 (`feature/core/resource/.../util/StringFormat.kt`)
Regex로 `%d` / `%s`를 args 순서대로 치환하는 `stringResourceFormatted` 유틸 추가. positional(`%1$d`) 및 `%%` escape는 현재 리소스에서 미사용이라 미지원.

```kotlin
@Composable
fun stringResourceFormatted(resource: StringResource, vararg args: Any): String {
    val template = stringResource(resource)
    return applyFormatArgs(template, args)
}
```

### 호출부 치환 (8곳)
| 파일 | 리소스 |
|---|---|
| `AiLimitBottomSheet.kt` | `ai_limit_pro_message`, `ai_limit_free_message`, `ai_limit_ad_remaining` |
| `TrashScreen.kt` | `trash_days_left` |
| `SettingsScreen.kt` | `cloud_backup_last_time` |
| `HomeScreen.kt` | `memo_count`, `selected_count`, `delete_selected_message` |

## Test Plan
- [x] 실기기(Galaxy S20 FE, Android 13) 한국어 로케일 확인 — "총 3개", "N일 후 영구 삭제" 등 정상 표시
- [ ] 영어 로케일 — `N memos` 형태 확인 (선택)
- [ ] 일본어 로케일 — `計 N件` 형태 확인 (선택)

## Refs
- Closes #299
- Refs #298 BUG-2 항목

🤖 Generated with [Claude Code](https://claude.com/claude-code)
