### PR TITLE
Fix: #195 AiActionMenu 팝업 출력 문제 — 반접힘 + 키보드 충돌 해결

### DIFF
--- a/feature/memo-plain/impl/build.gradle.kts
+++ b/feature/memo-plain/impl/build.gradle.kts
@@ -16,6 +16,7 @@ kotlin {
         commonMain.dependencies {
             implementation(libs.kotlinx.serialization.json)
             implementation(libs.richeditor.compose)
+            implementation(libs.compose.ui.backhandler)
             implementation(projects.feature.memoPlain.api)
             implementation(projects.feature.core.resource)
             implementation(projects.feature.core.viewmodel)

--- a/feature/memo-plain/impl/src/commonMain/kotlin/me/pecos/memozy/feature/memoplain/impl/MemoPlainNavigationImpl.kt
+++ b/feature/memo-plain/impl/src/commonMain/kotlin/me/pecos/memozy/feature/memoplain/impl/MemoPlainNavigationImpl.kt
@@ -1,6 +1,6 @@
 package me.pecos.memozy.feature.memoplain.impl
 
-import androidx.activity.compose.BackHandler
+import androidx.compose.ui.backhandler.BackHandler
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.AlertDialog
@@ -286,6 +286,7 @@ class MemoPlainNavigationImpl(
         }
     }
 
+    @OptIn(androidx.compose.ui.ExperimentalComposeUiApi::class)
     override fun registerGraph(
         navGraphBuilder: NavGraphBuilder,
         onNavigateToHome: () -> Unit,

--- a/feature/memo-plain/impl/src/commonMain/kotlin/me/pecos/memozy/presentation/screen/memo/MemoScreen.kt
+++ b/feature/memo-plain/impl/src/commonMain/kotlin/me/pecos/memozy/presentation/screen/memo/MemoScreen.kt
@@ -467,6 +467,9 @@ fun MemoScreen(
 
     var showAiActionMenu by remember { mutableStateOf(false) }
     var showAiCustomInput by remember { mutableStateOf(false) }
+    // AI 액션 메뉴 / 기타 바텀시트 띄울 때 키보드 먼저 내리기 — IME 와 ModalBottomSheet 가 충돌해서
+    // 시트가 가려지거나 위치가 어긋나 보이는 문제 방지.
+    val focusManager = androidx.compose.ui.platform.LocalFocusManager.current
 
     // containerColor 명시 → MaterialTheme.colorScheme.surface 무시
     Scaffold(
@@ -1042,7 +1045,10 @@ fun MemoScreen(
                                     onWebSummarize = onWebSummarize,
                                     onWebDialogOpen = { showWebDialog = true },
                                     onAiAssistClick = if (onAiPresetAction != null) {
-                                        { showAiActionMenu = true }
+                                        {
+                                            focusManager.clearFocus()
+                                            showAiActionMenu = true
+                                        }
                                     } else null
                                 )
                                 Spacer(modifier = Modifier.weight(1f))

--- a/feature/memo-plain/impl/src/commonMain/kotlin/me/pecos/memozy/presentation/screen/memo/components/AiActionMenu.kt
+++ b/feature/memo-plain/impl/src/commonMain/kotlin/me/pecos/memozy/presentation/screen/memo/components/AiActionMenu.kt
@@ -51,9 +51,11 @@ fun AiActionMenu(
     val fontSettings = LocalFontSettings.current
     val hapticService = koinInject<HapticService>()
 
+    // skipPartiallyExpanded = true: 콘텐츠가 짧아서 반접힌 상태로 떠 첫 항목만 보이는 문제 방지.
+    // 한 번에 전체 펼쳐진 상태로 노출.
     ModalBottomSheet(
         onDismissRequest = onDismiss,
-        sheetState = rememberModalBottomSheetState(),
+        sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
         containerColor = colors.cardBackground
     ) {
         Column(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -77,6 +77,7 @@ kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "kotlinxCoroutines" }
 montage-android = { module = "com.github.wanteddev:montage-android", version.ref = "montageAndroid" }
 richeditor-compose = { module = "com.mohamedrejeb.richeditor:richeditor-compose", version.ref = "richeditor" }
+compose-ui-backhandler = { group = "org.jetbrains.compose.ui", name = "ui-backhandler", version.ref = "composeMultiplatform" }
 coil-compose = { group = "io.coil-kt", name = "coil-compose", version.ref = "coil" }
 glance-appwidget = { group = "androidx.glance", name = "glance-appwidget", version.ref = "glance" }
 glance-material3 = { group = "androidx.glance", name = "glance-material3", version.ref = "glance" }


### PR DESCRIPTION
Closes #195

## Summary
메모 편집 화면 🪄 AI 버튼 탭 시 ModalBottomSheet 출력 위치/표시 문제 해결.

## 원인
1. `rememberModalBottomSheetState()` 기본값 `skipPartiallyExpanded = false` → 4개 짧은 항목 콘텐츠에서 시트가 반접힌 상태로 떠 첫 항목만 보였음. 사용자가 수동으로 위로 스와이프해야 전체 노출.
2. 본문 편집 중 (키보드 올라온 상태) 에서 AI 버튼 탭 시 IME 와 ModalBottomSheet 가 충돌하면서 시트 위치가 어긋나 보였음.

## 변경
- `AiActionMenu.kt`: `rememberModalBottomSheetState(skipPartiallyExpanded = true)` 로 항상 전체 펼쳐진 상태로 표시.
- `MemoScreen.kt`: AI 버튼 탭 핸들러에 `focusManager.clearFocus()` 추가 → 키보드 먼저 내리고 시트 오픈.
- `libs.versions.toml` + `feature/memo-plain/impl/build.gradle.kts`: `org.jetbrains.compose.ui:ui-backhandler` 의존성 명시. (IDE 가 BackHandler 임포트를 CMP 멀티플랫폼 변형으로 자동 변환했는데 의존성이 빠져있어 빌드가 깨지던 것 정리.)

## Test plan
- [x] 메모 편집 → 본문 입력 (키보드 올라온 상태) → 🪄 AI 버튼 탭 → 키보드 내려가면서 시트가 4개 항목 전체 펼쳐진 상태로 표시
- [x] 시트의 4개 항목 (설명/정리/요약/직접 입력) 클릭 정상 동작
- [x] 시트 외부 탭 시 dismiss 정상

🤖 Generated with [Claude Code](https://claude.com/claude-code)