### PR TITLE
Fix: #185 AdMob 출시 인프라 + #192 언어 프롬프트 + AI 한도 계산 버그 fix

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -32,11 +32,16 @@ android {
         manifestPlaceholders["admobAppId"] = admobAppId
     }
     buildTypes {
+        // AdMob 광고 단위 ID — local.properties 미지정 시 AdMob 공식 테스트 ID 사용 (계정 정지 위험 제로).
+        // 출시 빌드 전 admob.reward.ad.unit.id 를 실제 단위 ID 로 설정 + admob.test.device.ids 에 단말 ID 등록 필수.
+        val testRewardAdUnitId = "ca-app-pub-3940256099942544/5224354917"
         debug {
             buildConfigField("String", "WORKER_URL", "\"${localProperties.getProperty("worker.url", "")}\"")
             buildConfigField("String", "APP_SECRET_KEY", "\"${localProperties.getProperty("app.secret.key", "")}\"")
             buildConfigField("String", "SUPABASE_URL", "\"${localProperties.getProperty("supabase.url", "")}\"")
             buildConfigField("String", "SUPABASE_ANON_KEY", "\"${localProperties.getProperty("supabase.anon.key", "")}\"")
+            buildConfigField("String", "ADMOB_REWARD_AD_UNIT_ID", "\"${localProperties.getProperty("admob.reward.ad.unit.id", testRewardAdUnitId)}\"")
+            buildConfigField("String", "ADMOB_TEST_DEVICE_IDS", "\"${localProperties.getProperty("admob.test.device.ids", "")}\"")
         }
         release {
             isMinifyEnabled = true
@@ -49,6 +54,8 @@ android {
             buildConfigField("String", "APP_SECRET_KEY", "\"${localProperties.getProperty("app.prod.secret.key", "")}\"")
             buildConfigField("String", "SUPABASE_URL", "\"${localProperties.getProperty("supabase.prod.url", "")}\"")
             buildConfigField("String", "SUPABASE_ANON_KEY", "\"${localProperties.getProperty("supabase.prod.anon.key", "")}\"")
+            buildConfigField("String", "ADMOB_REWARD_AD_UNIT_ID", "\"${localProperties.getProperty("admob.reward.ad.unit.id", testRewardAdUnitId)}\"")
+            buildConfigField("String", "ADMOB_TEST_DEVICE_IDS", "\"${localProperties.getProperty("admob.test.device.ids", "")}\"")
         }
     }
 }

--- a/app/src/main/java/me/pecos/memozy/di/AdsPlatformModule.kt
+++ b/app/src/main/java/me/pecos/memozy/di/AdsPlatformModule.kt
@@ -1,10 +1,21 @@
 package me.pecos.memozy.di
 
+import me.pecos.memozy.BuildConfig
 import me.pecos.memozy.platform.ads.AdsService
 import me.pecos.memozy.platform.ads.provideAdsService
 import org.koin.android.ext.koin.androidContext
 import org.koin.dsl.module
 
 val adsPlatformModule = module {
-    single<AdsService> { provideAdsService(androidContext()) }
+    single<AdsService> {
+        val testDeviceIds = BuildConfig.ADMOB_TEST_DEVICE_IDS
+            .split(",")
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+        provideAdsService(
+            context = androidContext(),
+            adUnitId = BuildConfig.ADMOB_REWARD_AD_UNIT_ID,
+            testDeviceIds = testDeviceIds,
+        )
+    }
 }

--- a/feature/core/resource/src/commonMain/kotlin/me/pecos/memozy/presentation/theme/SubscriptionTier.kt
+++ b/feature/core/resource/src/commonMain/kotlin/me/pecos/memozy/presentation/theme/SubscriptionTier.kt
@@ -5,8 +5,8 @@ enum class SubscriptionTier {
 
     val dailyAiLimit: Int
         get() = when (this) {
-            FREE -> 100
-            PRO -> 15
+            FREE -> 15
+            PRO -> 100
         }
 
     val isPro: Boolean get() = this == PRO

--- a/feature/memo-plain/impl/src/commonMain/kotlin/me/pecos/memozy/feature/memoplain/impl/MemoPlainNavigationImpl.kt
+++ b/feature/memo-plain/impl/src/commonMain/kotlin/me/pecos/memozy/feature/memoplain/impl/MemoPlainNavigationImpl.kt
@@ -207,31 +207,42 @@ class MemoPlainNavigationImpl(
                     |절대 #, ##, **, *** 같은 마크다운 서식을 사용하지 마. 이모지와 일반 텍스트만 써.
                     |인사말이나 부가 설명 없이 바로 아래 형식대로만 출력해:
                     |
+                    |【번역 원칙 — 매우 중요】
+                    |- 자막은 음성을 전사한 것일 뿐이라 직역하면 어색하다. 자막의 단어를 그대로 옮기지 말고,
+                    |  화자가 진짜 전달하려는 의미를 ${userLang} 사용자에게 자연스럽게 전달해라.
+                    |- 관용 표현·구어·줄임말은 ${userLang}의 자연스러운 대응 표현으로 의역해라.
+                    |- 문맥상 생략된 주어·목적어가 있으면 ${userLang} 번역에서 보완해 자연스럽게 만들어라.
+                    |- 원어가 짧다고 번역도 짧을 필요 없다. 의미가 잘 전달되는 길이가 우선.
+                    |- 직역 같은 부자연스러운 표현(예: "그것을 하다", "이것을 봐주세요" 같은 기계 번역체) 금지.
+                    |
                     |📋 핵심 표현 (10~15개)
                     |
-                    |영상에서 나온 외국어 표현을 원문 그대로 적고, 바로 다음 줄에 ${userLang} 뜻을 적어.
+                    |영상에서 나온 외국어 표현을 원문 그대로 적고, 바로 다음 줄에 ${userLang} 뜻을 자연스럽게 적어.
+                    |단어 단위 직역이 아니라 ${userLang} 화자가 같은 상황에서 실제로 쓸 표현으로.
                     |표현과 표현 사이에는 빈 줄을 넣어.
                     |
                     |외국어 원문
-                    |${userLang} 뜻
+                    |${userLang} 뜻 (자연스러운 의역)
                     |
                     |외국어 원문
-                    |${userLang} 뜻
+                    |${userLang} 뜻 (자연스러운 의역)
                     |
                     |📖 주요 문장 (5~10개)
                     |
                     |영상에서 나온 핵심 문장을 원문 그대로 적고, 다음 줄에 ${userLang} 해석을 적어.
+                    |해석은 자막 직역이 아니라, 그 문장이 영상 흐름에서 어떤 의미인지 반영한 자연스러운 번역으로.
                     |각 문장 앞에 * 를 붙여. 문장과 문장 사이에는 빈 줄을 넣어.
                     |
                     |* 외국어 원문 문장
-                    |${userLang} 해석
+                    |${userLang} 해석 (자연스러운 번역)
                     |
                     |* 외국어 원문 문장
-                    |${userLang} 해석
+                    |${userLang} 해석 (자연스러운 번역)
                     |
                     |💡 학습 포인트
                     |
-                    |문법, 뉘앙스, 발음, 사용법 등 학습에 도움되는 내용을 ${userLang}로 2~4줄 정리.
+                    |문법, 뉘앙스, 직역과 의역의 차이, 발음, 사용 상황 등 학습에 도움되는 내용을 ${userLang}로 2~4줄 정리.
+                    |특히 위에서 의역한 표현 중 직역과 큰 차이가 있는 것이 있다면 왜 그렇게 번역했는지 설명해.
                 """.trimMargin()
                 }
             }
@@ -359,8 +370,13 @@ class MemoPlainNavigationImpl(
             var dailyAdViewCount by remember { mutableStateOf(0) }
             var adBonusCount by remember { mutableStateOf(0) }
             LaunchedEffect(Unit) {
-                dailyUsageCount = aiUsageDao.getTotalCountSince(startOfToday())
+                val total = aiUsageDao.getTotalCountSince(startOfToday())
                 dailyAdViewCount = aiUsageDao.getCountSince(FEATURE_REWARD_AD, startOfToday())
+                // ai_usage 에 광고 시청 기록도 들어가므로 실제 AI 사용량은 total - 광고시청 횟수.
+                dailyUsageCount = total - dailyAdViewCount
+                // adBonusCount 는 in-memory 라 화면 재진입 시 사라지지만 광고 시청은 DB 에 남으므로
+                // 광고 본 횟수만큼 보너스를 복원해서 일관성 유지.
+                adBonusCount = dailyAdViewCount
             }
             val dailyLimit = subscriptionTier.dailyAiLimit + adBonusCount
             val canUseAiQuota = dailyUsageCount < dailyLimit

--- a/platform/ads/impl/src/androidMain/kotlin/me/pecos/memozy/platform/ads/AndroidAdsService.kt
+++ b/platform/ads/impl/src/androidMain/kotlin/me/pecos/memozy/platform/ads/AndroidAdsService.kt
@@ -21,15 +21,26 @@ sealed class RewardAdState {
     data class Error(val message: String) : RewardAdState()
 }
 
-fun provideAdsService(context: Context): AdsService = AndroidAdsService(context)
+/**
+ * @param adUnitId 리워드 광고 단위 ID. 미지정 시 AdMob 공식 테스트 ID 사용.
+ *   출시 빌드는 local.properties 의 admob.reward.ad.unit.id 를 통해 실제 ID 주입.
+ * @param testDeviceIds 실제 광고 ID 사용 시 개발 단말 ID 목록. 등록 안 하고 실광고 클릭 시 계정 정지 위험.
+ */
+fun provideAdsService(
+    context: Context,
+    adUnitId: String = AndroidAdsService.TEST_REWARD_AD_UNIT_ID,
+    testDeviceIds: List<String> = emptyList(),
+): AdsService = AndroidAdsService(context, adUnitId, testDeviceIds)
 
 internal class AndroidAdsService(
     context: Context,
+    private val adUnitId: String = TEST_REWARD_AD_UNIT_ID,
+    private val testDeviceIds: List<String> = emptyList(),
 ) : AdsService {
 
-    private companion object {
-        // 테스트 광고 단위 ID — 출시 시 실제 ID로 교체
-        const val AD_UNIT_ID = "ca-app-pub-3940256099942544/5224354917"
+    internal companion object {
+        // AdMob 공식 테스트 리워드 광고 단위 ID — debug/내부 테스트 용도
+        const val TEST_REWARD_AD_UNIT_ID = "ca-app-pub-3940256099942544/5224354917"
     }
 
     private val appContext = context.applicationContext
@@ -44,6 +55,13 @@ internal class AndroidAdsService(
     override val isAdLoading: Boolean get() = _state.value is RewardAdState.Loading
 
     override fun initialize() {
+        if (testDeviceIds.isNotEmpty()) {
+            MobileAds.setRequestConfiguration(
+                com.google.android.gms.ads.RequestConfiguration.Builder()
+                    .setTestDeviceIds(testDeviceIds)
+                    .build()
+            )
+        }
         MobileAds.initialize(appContext)
     }
 
@@ -61,7 +79,7 @@ internal class AndroidAdsService(
         _state.value = RewardAdState.Loading
 
         val adRequest = AdRequest.Builder().build()
-        RewardedAd.load(appContext, AD_UNIT_ID, adRequest, object : RewardedAdLoadCallback() {
+        RewardedAd.load(appContext, adUnitId, adRequest, object : RewardedAdLoadCallback() {
             override fun onAdLoaded(ad: RewardedAd) {
                 rewardedAd = ad
                 _state.value = RewardAdState.Ready


### PR DESCRIPTION
Closes #185 #192

## Summary
출시 전 점검 라운드에서 AdMob 광고 단위 ID 분리 + 언어 요약 프롬프트 자연 번역 강화 + AI 한도 계산 관련 버그 3종 한꺼번에 수정.

## #185 — AdMob 출시 인프라
실제 광고 ID 교체는 사용자가 AdMob 콘솔 작업 후 \`local.properties\` 두 줄만 추가하면 되도록 정리.

- \`AndroidAdsService\`: \`AD_UNIT_ID\` 하드코딩 → 생성자 파라미터 (\`adUnitId\`, \`testDeviceIds\`)
- \`MobileAds.setRequestConfiguration(...setTestDeviceIds(...))\` 추가 — 실제 광고 ID + 등록 안 된 단말 클릭 시 계정 정지 위험 방지
- \`BuildConfig.ADMOB_REWARD_AD_UNIT_ID\` + \`ADMOB_TEST_DEVICE_IDS\` 필드 추가
- \`local.properties\` 키: \`admob.reward.ad.unit.id\`, \`admob.test.device.ids\` (콤마 구분). 미지정 시 AdMob 공식 테스트 ID 폴백 → debug 빌드는 변경 없이 그대로 동작
- \`AdsPlatformModule\`: BuildConfig 값을 Koin 주입

**출시 시 사용자 작업** (코드 변경 없음):
\`\`\`properties
admob.reward.ad.unit.id=ca-app-pub-XXXX/YYYY
admob.test.device.ids=DEVICE_ID_1,DEVICE_ID_2
\`\`\`

## #192 — 언어 학습 프롬프트 강화
- LANGUAGE 프롬프트 상단에 **"번역 원칙"** 블록 신설:
  - 자막 직역 금지 → 화자 의도 중심 의역
  - 관용 표현 / 구어 / 줄임말은 모국어 자연 대응 표현으로
  - 문맥상 생략된 주어·목적어 보완
  - 기계 번역체 ("그것을 하다", "이것을 봐주세요" 등) 명시 차단
- 핵심 표현 / 주요 문장 섹션에 "자연스러운 의역" 강조
- 학습 포인트에 "직역과 의역 차이가 큰 표현 설명" 항목 추가

## AI 한도 계산 버그 fix (테스트 중 발견)

### Bug 1 — 광고 시청이 사용 한도에 포함됨
\`AiUsageDao.getTotalCountSince\` 가 \`ai_usage\` 테이블 모든 row 를 셈 (FEATURE_REWARD_AD 포함). 광고를 볼수록 한도가 더 빨리 차오르는 역효과.
\`\`\`kotlin
val total = aiUsageDao.getTotalCountSince(startOfToday())
dailyAdViewCount = aiUsageDao.getCountSince(FEATURE_REWARD_AD, startOfToday())
dailyUsageCount = total - dailyAdViewCount  // 광고분 제외
\`\`\`

### Bug 2 — \`adBonusCount\` in-memory 휘발
화면 재진입 시 \`adBonusCount = 0\` 으로 리셋되는데 광고 시청 기록은 DB 에 남아있음. 광고로 늘려놓은 보너스가 사라지면서 손해.
\`\`\`kotlin
adBonusCount = dailyAdViewCount  // DB 에서 복원
\`\`\`

### Bug 3 — \`SubscriptionTier\` 값 swap
PR #294 에서 의도된 \`FREE=15, PRO=100\` 이 어느 시점에 \`FREE=100, PRO=15\` 로 뒤집혀있었음. PRO 가 FREE 보다 적은 명백한 오류. 원복.

## Test plan
- [x] AI 사용 → \`dailyUsageCount\` 만 증가, 광고 시청 → \`dailyAdViewCount\` 만 증가, 한도 = 15 + 광고 시청 횟수
- [x] 광고 시청 후 화면 나갔다 들어와도 보너스 유지
- [x] LANGUAGE 요약 — 자막 직역체 안 나오는지 영상 1~2개로 검증
- [x] AdMob 광고 정상 동작 (debug 빌드, 테스트 ID)
- [ ] 출시 빌드 ID 교체 후 실기기 검증 — **별건** (외부 작업)

🤖 Generated with [Claude Code](https://claude.com/claude-code)