### PR TITLE
Add: iOS 네이티브 Google/Apple 사인인 + 출시 준비 UI/UX

### DIFF
--- a/datasource/remote/auth/impl/src/commonMain/kotlin/me/pecos/memozy/data/datasource/remote/auth/AuthServiceImpl.kt
+++ b/datasource/remote/auth/impl/src/commonMain/kotlin/me/pecos/memozy/data/datasource/remote/auth/AuthServiceImpl.kt
@@ -45,37 +45,18 @@ class AuthServiceImpl(
         }
 
     override suspend fun signInWithGoogle(idToken: String): Result<AuthUser> = runCatching {
-        println("[AuthService] Google signIn START — idToken length=${idToken.length}")
-        try {
-            supabaseClient.auth.signInWith(IDToken) {
-                this.idToken = idToken
-                provider = Google
-            }
-            println("[AuthService] Google signIn SUCCESS — currentUser=${currentUser?.email}")
-        } catch (e: io.github.jan.supabase.exceptions.RestException) {
-            val errBody = try { e.error } catch (_: Throwable) { "(no error)" }
-            val description = try { e.description } catch (_: Throwable) { "(no desc)" }
-            println("[AuthService] Google signIn RestException — error=$errBody, description=$description, statusCode=${e.statusCode}")
-            throw e
-        } catch (e: Throwable) {
-            println("[AuthService] Google signIn THROW: ${e::class.simpleName} - ${e.message}")
-            throw e
+        supabaseClient.auth.signInWith(IDToken) {
+            this.idToken = idToken
+            provider = Google
         }
         currentUser ?: throw IllegalStateException("User not found after sign in")
     }
 
     override suspend fun signInWithApple(idToken: String, rawNonce: String): Result<AuthUser> = runCatching {
-        println("[AuthService] Apple signIn START — idToken length=${idToken.length}")
-        try {
-            supabaseClient.auth.signInWith(IDToken) {
-                this.idToken = idToken
-                this.nonce = rawNonce
-                provider = Apple
-            }
-            println("[AuthService] Apple signIn SUCCESS — currentUser=${currentUser?.email}")
-        } catch (e: Throwable) {
-            println("[AuthService] Apple signIn THROW: ${e::class.simpleName} - ${e.message}")
-            throw e
+        supabaseClient.auth.signInWith(IDToken) {
+            this.idToken = idToken
+            this.nonce = rawNonce
+            provider = Apple
         }
         currentUser ?: throw IllegalStateException("User not found after sign in")
     }

--- a/datasource/remote/auth/impl/src/commonMain/kotlin/me/pecos/memozy/data/datasource/remote/auth/AuthServiceImpl.kt
+++ b/datasource/remote/auth/impl/src/commonMain/kotlin/me/pecos/memozy/data/datasource/remote/auth/AuthServiceImpl.kt
@@ -45,18 +45,37 @@ class AuthServiceImpl(
         }
 
     override suspend fun signInWithGoogle(idToken: String): Result<AuthUser> = runCatching {
-        supabaseClient.auth.signInWith(IDToken) {
-            this.idToken = idToken
-            provider = Google
+        println("[AuthService] Google signIn START — idToken length=${idToken.length}")
+        try {
+            supabaseClient.auth.signInWith(IDToken) {
+                this.idToken = idToken
+                provider = Google
+            }
+            println("[AuthService] Google signIn SUCCESS — currentUser=${currentUser?.email}")
+        } catch (e: io.github.jan.supabase.exceptions.RestException) {
+            val errBody = try { e.error } catch (_: Throwable) { "(no error)" }
+            val description = try { e.description } catch (_: Throwable) { "(no desc)" }
+            println("[AuthService] Google signIn RestException — error=$errBody, description=$description, statusCode=${e.statusCode}")
+            throw e
+        } catch (e: Throwable) {
+            println("[AuthService] Google signIn THROW: ${e::class.simpleName} - ${e.message}")
+            throw e
         }
         currentUser ?: throw IllegalStateException("User not found after sign in")
     }
 
     override suspend fun signInWithApple(idToken: String, rawNonce: String): Result<AuthUser> = runCatching {
-        supabaseClient.auth.signInWith(IDToken) {
-            this.idToken = idToken
-            this.nonce = rawNonce
-            provider = Apple
+        println("[AuthService] Apple signIn START — idToken length=${idToken.length}")
+        try {
+            supabaseClient.auth.signInWith(IDToken) {
+                this.idToken = idToken
+                this.nonce = rawNonce
+                provider = Apple
+            }
+            println("[AuthService] Apple signIn SUCCESS — currentUser=${currentUser?.email}")
+        } catch (e: Throwable) {
+            println("[AuthService] Apple signIn THROW: ${e::class.simpleName} - ${e.message}")
+            throw e
         }
         currentUser ?: throw IllegalStateException("User not found after sign in")
     }

--- a/feature/core/resource/src/commonMain/composeResources/values-en/strings.xml
+++ b/feature/core/resource/src/commonMain/composeResources/values-en/strings.xml
@@ -200,7 +200,8 @@
 
     <!-- Auth -->
     <string name="section_account">Account</string>
-    <string name="sign_in_google">Sign in with Google Account</string>
+    <string name="sign_in_google">Continue with Google</string>
+    <string name="sign_in_apple">Continue with Apple</string>
     <string name="sign_out">Sign Out</string>
     <string name="sign_in_error">Sign in failed</string>
     <string name="sign_out_confirm">Are you sure you want to sign out?</string>

--- a/feature/core/resource/src/commonMain/composeResources/values-ja/strings.xml
+++ b/feature/core/resource/src/commonMain/composeResources/values-ja/strings.xml
@@ -200,7 +200,8 @@
 
     <!-- Auth -->
     <string name="section_account">アカウント</string>
-    <string name="sign_in_google">Googleアカウントでログイン</string>
+    <string name="sign_in_google">Googleで続ける</string>
+    <string name="sign_in_apple">Appleで続ける</string>
     <string name="sign_out">ログアウト</string>
     <string name="sign_in_error">ログインに失敗しました</string>
     <string name="sign_out_confirm">ログアウトしますか？</string>

--- a/feature/core/resource/src/commonMain/composeResources/values/strings.xml
+++ b/feature/core/resource/src/commonMain/composeResources/values/strings.xml
@@ -200,7 +200,8 @@
 
     <!-- Auth -->
     <string name="section_account">계정</string>
-    <string name="sign_in_google">Google 계정 로그인</string>
+    <string name="sign_in_google">Google 로 계속하기</string>
+    <string name="sign_in_apple">Apple 로 계속하기</string>
     <string name="sign_out">로그아웃</string>
     <string name="sign_in_error">로그인에 실패했습니다</string>
     <string name="sign_out_confirm">로그아웃하시겠습니까?</string>

--- a/feature/core/resource/src/commonMain/composeResources/values/strings.xml
+++ b/feature/core/resource/src/commonMain/composeResources/values/strings.xml
@@ -200,8 +200,8 @@
 
     <!-- Auth -->
     <string name="section_account">계정</string>
-    <string name="sign_in_google">Google 로 계속하기</string>
-    <string name="sign_in_apple">Apple 로 계속하기</string>
+    <string name="sign_in_google">Google로 계속하기</string>
+    <string name="sign_in_apple">Apple로 계속하기</string>
     <string name="sign_out">로그아웃</string>
     <string name="sign_in_error">로그인에 실패했습니다</string>
     <string name="sign_out_confirm">로그아웃하시겠습니까?</string>

--- a/feature/core/viewmodel/src/commonMain/kotlin/me/pecos/memozy/feature/core/viewmodel/SettingsViewModel.kt
+++ b/feature/core/viewmodel/src/commonMain/kotlin/me/pecos/memozy/feature/core/viewmodel/SettingsViewModel.kt
@@ -114,21 +114,13 @@ class SettingsViewModel(
 
     fun signInWithGoogle(idToken: String) {
         viewModelScope.launch {
-            val result = authRepository.signInWithGoogle(idToken)
-            result.onFailure { e ->
-                println("SettingsViewModel: Google Supabase sign-in failed: ${e.message}")
-                e.printStackTrace()
-            }
+            authRepository.signInWithGoogle(idToken)
         }
     }
 
     fun signInWithApple(idToken: String, rawNonce: String) {
         viewModelScope.launch {
-            val result = authRepository.signInWithApple(idToken, rawNonce)
-            result.onFailure { e ->
-                println("SettingsViewModel: Apple Supabase sign-in failed: ${e.message}")
-                e.printStackTrace()
-            }
+            authRepository.signInWithApple(idToken, rawNonce)
         }
     }
 

--- a/feature/core/viewmodel/src/commonMain/kotlin/me/pecos/memozy/feature/core/viewmodel/SettingsViewModel.kt
+++ b/feature/core/viewmodel/src/commonMain/kotlin/me/pecos/memozy/feature/core/viewmodel/SettingsViewModel.kt
@@ -114,13 +114,21 @@ class SettingsViewModel(
 
     fun signInWithGoogle(idToken: String) {
         viewModelScope.launch {
-            authRepository.signInWithGoogle(idToken)
+            val result = authRepository.signInWithGoogle(idToken)
+            result.onFailure { e ->
+                println("SettingsViewModel: Google Supabase sign-in failed: ${e.message}")
+                e.printStackTrace()
+            }
         }
     }
 
     fun signInWithApple(idToken: String, rawNonce: String) {
         viewModelScope.launch {
-            authRepository.signInWithApple(idToken, rawNonce)
+            val result = authRepository.signInWithApple(idToken, rawNonce)
+            result.onFailure { e ->
+                println("SettingsViewModel: Apple Supabase sign-in failed: ${e.message}")
+                e.printStackTrace()
+            }
         }
     }
 

--- a/feature/home/impl/src/androidMain/kotlin/me/pecos/memozy/feature/home/impl/AuthConfig.android.kt
+++ b/feature/home/impl/src/androidMain/kotlin/me/pecos/memozy/feature/home/impl/AuthConfig.android.kt
@@ -1,3 +1,4 @@
 package me.pecos.memozy.feature.home.impl
 
 internal actual val GOOGLE_WEB_CLIENT_ID: String = BuildConstants.GOOGLE_WEB_CLIENT_ID
+internal actual val IsGoogleSignInAvailable: Boolean = true

--- a/feature/home/impl/src/commonMain/kotlin/me/pecos/memozy/feature/home/impl/AuthConfig.kt
+++ b/feature/home/impl/src/commonMain/kotlin/me/pecos/memozy/feature/home/impl/AuthConfig.kt
@@ -1,3 +1,4 @@
 package me.pecos.memozy.feature.home.impl
 
 internal expect val GOOGLE_WEB_CLIENT_ID: String
+internal expect val IsGoogleSignInAvailable: Boolean

--- a/feature/home/impl/src/commonMain/kotlin/me/pecos/memozy/presentation/screen/login/LoginScreen.kt
+++ b/feature/home/impl/src/commonMain/kotlin/me/pecos/memozy/presentation/screen/login/LoginScreen.kt
@@ -29,8 +29,10 @@ import me.pecos.memozy.feature.core.resource.generated.resources.ic_google
 import me.pecos.memozy.feature.core.resource.generated.resources.login_skip
 import me.pecos.memozy.feature.core.resource.generated.resources.login_subtitle
 import me.pecos.memozy.feature.core.resource.generated.resources.sign_in_error
+import me.pecos.memozy.feature.core.resource.generated.resources.sign_in_apple
 import me.pecos.memozy.feature.core.resource.generated.resources.sign_in_google
 import me.pecos.memozy.feature.home.impl.GOOGLE_WEB_CLIENT_ID
+import me.pecos.memozy.feature.home.impl.IsGoogleSignInAvailable
 import me.pecos.memozy.platform.credential.AppleSignInResult
 import me.pecos.memozy.platform.credential.CredentialService
 import me.pecos.memozy.platform.credential.GoogleSignInResult
@@ -85,34 +87,36 @@ fun LoginScreen(
 
             Spacer(modifier = Modifier.height(48.dp))
 
-            OutlinedButton(
-                onClick = {
-                    scope.launch {
-                        val result = credentialService.signInWithGoogle(
-                            activity = activity,
-                            serverClientId = GOOGLE_WEB_CLIENT_ID,
-                        )
-                        when (result) {
-                            is GoogleSignInResult.Success -> onSignIn(result.idToken)
-                            is GoogleSignInResult.Cancelled -> Unit
-                            is GoogleSignInResult.Error -> {
-                                println("LoginScreen: Sign-in failed: ${result.message}")
-                                toastPresenter.show(getString(Res.string.sign_in_error))
+            if (IsGoogleSignInAvailable) {
+                OutlinedButton(
+                    onClick = {
+                        scope.launch {
+                            val result = credentialService.signInWithGoogle(
+                                activity = activity,
+                                serverClientId = GOOGLE_WEB_CLIENT_ID,
+                            )
+                            when (result) {
+                                is GoogleSignInResult.Success -> onSignIn(result.idToken)
+                                is GoogleSignInResult.Cancelled -> Unit
+                                is GoogleSignInResult.Error -> {
+                                    println("LoginScreen: Sign-in failed: ${result.message}")
+                                    toastPresenter.show(getString(Res.string.sign_in_error))
+                                }
                             }
                         }
-                    }
-                },
-                modifier = Modifier.fillMaxWidth(),
-                border = BorderStroke(1.dp, colors.cardBorder),
-                shape = RoundedCornerShape(12.dp),
-                colors = ButtonDefaults.outlinedButtonColors(contentColor = colors.textTitle),
-            ) {
-                Icon(painter = painterResource(Res.drawable.ic_google), contentDescription = null, modifier = Modifier.size(18.dp))
-                Spacer(modifier = Modifier.width(8.dp))
-                Text(stringResource(Res.string.sign_in_google), fontSize = fontSettings.scaled(14))
-            }
+                    },
+                    modifier = Modifier.fillMaxWidth(),
+                    border = BorderStroke(1.dp, colors.cardBorder),
+                    shape = RoundedCornerShape(12.dp),
+                    colors = ButtonDefaults.outlinedButtonColors(contentColor = colors.textTitle),
+                ) {
+                    Icon(painter = painterResource(Res.drawable.ic_google), contentDescription = null, modifier = Modifier.size(18.dp))
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(stringResource(Res.string.sign_in_google), fontSize = fontSettings.scaled(14))
+                }
 
-            Spacer(modifier = Modifier.height(12.dp))
+                Spacer(modifier = Modifier.height(12.dp))
+            }
 
             // Apple 로 계속하기 — Apple HIG: 검정 배경 + 사과 로고. iOS 에서만 실제 동작 (Android 는 미구현 안내).
             OutlinedButton(
@@ -136,7 +140,7 @@ fun LoginScreen(
             ) {
                 Text("\uF8FF", fontSize = fontSettings.scaled(16))
                 Spacer(modifier = Modifier.width(8.dp))
-                Text("Apple 로 계속하기", fontSize = fontSettings.scaled(14))
+                Text(stringResource(Res.string.sign_in_apple), fontSize = fontSettings.scaled(14))
             }
 
             Spacer(modifier = Modifier.height(16.dp))

--- a/feature/home/impl/src/commonMain/kotlin/me/pecos/memozy/presentation/screen/settings/SettingsScreen.kt
+++ b/feature/home/impl/src/commonMain/kotlin/me/pecos/memozy/presentation/screen/settings/SettingsScreen.kt
@@ -87,11 +87,13 @@ import me.pecos.memozy.feature.core.resource.generated.resources.section_other
 import me.pecos.memozy.feature.core.resource.generated.resources.section_theme
 import me.pecos.memozy.feature.core.resource.generated.resources.settings
 import me.pecos.memozy.feature.core.resource.generated.resources.sign_in_error
+import me.pecos.memozy.feature.core.resource.generated.resources.sign_in_apple
 import me.pecos.memozy.feature.core.resource.generated.resources.sign_in_google
 import me.pecos.memozy.feature.core.resource.generated.resources.sign_in_loading
 import me.pecos.memozy.feature.core.resource.generated.resources.sign_out
 import me.pecos.memozy.feature.core.resource.generated.resources.sign_out_confirm
 import me.pecos.memozy.feature.core.resource.generated.resources.subscription_current_plan
+import me.pecos.memozy.feature.core.resource.generated.resources.subscription_title
 import me.pecos.memozy.feature.core.resource.generated.resources.theme_dark
 import me.pecos.memozy.feature.core.resource.generated.resources.theme_light
 import me.pecos.memozy.feature.core.resource.generated.resources.theme_settings
@@ -119,6 +121,7 @@ import me.pecos.memozy.feature.core.viewmodel.settings.CloudBackupState
 import me.pecos.memozy.feature.core.viewmodel.settings.FontSizeLevel
 import me.pecos.memozy.feature.core.viewmodel.settings.LANGUAGES
 import me.pecos.memozy.feature.core.viewmodel.settings.ThemeMode
+import me.pecos.memozy.platform.credential.AppleSignInResult
 import me.pecos.memozy.platform.credential.CredentialService
 import me.pecos.memozy.platform.credential.GoogleSignInResult
 import me.pecos.memozy.platform.intent.AppInfo
@@ -638,34 +641,65 @@ fun SettingsScreen(
                         }
                     }
                     is AuthState.Unauthenticated -> {
-                        OutlinedButton(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(horizontal = 16.dp),
-                            border = BorderStroke(1.dp, colors.cardBorder),
-                            shape = RoundedCornerShape(12.dp),
-                            colors = ButtonDefaults.outlinedButtonColors(contentColor = colors.textTitle),
-                            onClick = {
-                                scope.launch {
-                                    val result = credentialService.signInWithGoogle(
-                                        activity = activity,
-                                        serverClientId = GOOGLE_WEB_CLIENT_ID,
-                                    )
-                                    when (result) {
-                                        is GoogleSignInResult.Success ->
-                                            settingsViewModel.signInWithGoogle(result.idToken)
-                                        is GoogleSignInResult.Cancelled -> Unit
-                                        is GoogleSignInResult.Error -> {
-                                            println("SettingsAuth: Sign-in failed: ${result.message}")
-                                            toastPresenter.show(getString(Res.string.sign_in_error))
+                        Column {
+                            OutlinedButton(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(horizontal = 16.dp),
+                                border = BorderStroke(1.dp, colors.cardBorder),
+                                shape = RoundedCornerShape(12.dp),
+                                colors = ButtonDefaults.outlinedButtonColors(contentColor = colors.textTitle),
+                                onClick = {
+                                    scope.launch {
+                                        val result = credentialService.signInWithGoogle(
+                                            activity = activity,
+                                            serverClientId = GOOGLE_WEB_CLIENT_ID,
+                                        )
+                                        when (result) {
+                                            is GoogleSignInResult.Success ->
+                                                settingsViewModel.signInWithGoogle(result.idToken)
+                                            is GoogleSignInResult.Cancelled -> Unit
+                                            is GoogleSignInResult.Error -> {
+                                                println("SettingsAuth: Sign-in failed: ${result.message}")
+                                                toastPresenter.show(getString(Res.string.sign_in_error))
+                                            }
                                         }
                                     }
                                 }
+                            ) {
+                                Icon(painter = painterResource(Res.drawable.ic_google), contentDescription = null, modifier = Modifier.size(18.dp))
+                                Spacer(modifier = Modifier.width(8.dp))
+                                Text(stringResource(Res.string.sign_in_google), fontSize = fontSettings.scaled(14))
                             }
-                        ) {
-                            Icon(painter = painterResource(Res.drawable.ic_google), contentDescription = null, modifier = Modifier.size(18.dp))
-                            Spacer(modifier = Modifier.width(8.dp))
-                            Text(stringResource(Res.string.sign_in_google), fontSize = fontSettings.scaled(14))
+
+                            Spacer(modifier = Modifier.height(6.dp))
+
+                            OutlinedButton(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(horizontal = 16.dp),
+                                border = BorderStroke(1.dp, colors.cardBorder),
+                                shape = RoundedCornerShape(12.dp),
+                                colors = ButtonDefaults.outlinedButtonColors(contentColor = colors.textTitle),
+                                onClick = {
+                                    scope.launch {
+                                        val result = credentialService.signInWithApple(activity = activity)
+                                        when (result) {
+                                            is AppleSignInResult.Success ->
+                                                settingsViewModel.signInWithApple(result.idToken, result.rawNonce)
+                                            is AppleSignInResult.Cancelled -> Unit
+                                            is AppleSignInResult.Error -> {
+                                                println("SettingsAuth: Apple sign-in failed: ${result.message}")
+                                                toastPresenter.show(getString(Res.string.sign_in_error))
+                                            }
+                                        }
+                                    }
+                                }
+                            ) {
+                                Text("\uF8FF", fontSize = fontSettings.scaled(16))
+                                Spacer(modifier = Modifier.width(8.dp))
+                                Text(stringResource(Res.string.sign_in_apple), fontSize = fontSettings.scaled(14))
+                            }
                         }
                     }
                     is AuthState.Authenticated -> {
@@ -702,7 +736,7 @@ fun SettingsScreen(
                     }
                 }
 
-                Spacer(modifier = Modifier.height(12.dp))
+                Spacer(modifier = Modifier.height(6.dp))
 
                 // ── Memozy Pro ──
                 val currentTier = LocalSubscriptionTier.current
@@ -715,7 +749,7 @@ fun SettingsScreen(
                     shape = RoundedCornerShape(12.dp),
                     colors = ButtonDefaults.outlinedButtonColors(contentColor = colors.textTitle),
                 ) {
-                    Text("Memozy Pro", fontSize = fontSettings.scaled(14), fontWeight = FontWeight.SemiBold)
+                    Text(stringResource(Res.string.subscription_title), fontSize = fontSettings.scaled(14), fontWeight = FontWeight.SemiBold)
                     if (currentTier.isPro) {
                         Spacer(modifier = Modifier.width(6.dp))
                         Text(

--- a/feature/home/impl/src/commonMain/kotlin/me/pecos/memozy/presentation/screen/subscription/SubscriptionScreen.kt
+++ b/feature/home/impl/src/commonMain/kotlin/me/pecos/memozy/presentation/screen/subscription/SubscriptionScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -32,7 +33,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -55,6 +55,7 @@ import me.pecos.memozy.feature.core.resource.generated.resources.subscription_re
 import me.pecos.memozy.feature.core.resource.generated.resources.subscription_title
 import me.pecos.memozy.feature.core.resource.generated.resources.subscription_yearly
 import me.pecos.memozy.feature.core.resource.generated.resources.subscription_yearly_discount
+import me.pecos.memozy.platform.ads.AdsService
 import me.pecos.memozy.platform.billing.BillingService
 import me.pecos.memozy.platform.billing.PurchaseState
 import me.pecos.memozy.platform.intent.UrlLauncher
@@ -67,16 +68,19 @@ import me.pecos.memozy.presentation.components.PopupSize
 import me.pecos.memozy.presentation.theme.LocalActivity
 import me.pecos.memozy.presentation.theme.LocalAppColors
 import me.pecos.memozy.presentation.theme.LocalFontSettings
+import me.pecos.memozy.presentation.theme.LocalIsLoggedIn
 import me.pecos.memozy.presentation.theme.LocalSubscriptionTier
 
 @Composable
 fun SubscriptionScreen(
     onBack: () -> Unit = {},
     billingService: BillingService = koinInject(),
+    adsService: AdsService = koinInject(),
 ) {
     val subscriptionProducts by billingService.subscriptionProducts.collectAsState()
     val purchaseState by billingService.purchaseState.collectAsState()
     val currentTier = LocalSubscriptionTier.current
+    val isLoggedIn = LocalIsLoggedIn.current
     val colors = LocalAppColors.current
     val fontSettings = LocalFontSettings.current
     val activity = LocalActivity.current
@@ -123,26 +127,23 @@ fun SubscriptionScreen(
                 .verticalScroll(rememberScrollState())
         ) {
             // ── 히어로 영역 ──
-            val heroGradient = if (isSystemDark) {
-                Brush.verticalGradient(listOf(Color(0xFF1A3A5C), Color(0xFF2A1A4E), colors.screenBackground))
-            } else {
-                Brush.verticalGradient(listOf(Color(0xFF4A90D9), Color(0xFF7B5EA7), colors.screenBackground))
-            }
-
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .background(heroGradient)
+                    .background(colors.screenBackground)
                     .padding(horizontal = 24.dp)
                     .padding(top = 24.dp, bottom = 32.dp)
             ) {
                 Column {
-                    // 뒤로가기
-                    IconButton(onClick = onBack) {
+                    // 뒤로가기 — IconButton 기본 12dp 내부 패딩 보정해서 M과 좌측 정렬
+                    IconButton(
+                        onClick = onBack,
+                        modifier = Modifier.offset(x = (-12).dp)
+                    ) {
                         Icon(
                             imageVector = Icons.AutoMirrored.Filled.ArrowBack,
                             contentDescription = stringResource(Res.string.close),
-                            tint = Color.White
+                            tint = colors.textTitle
                         )
                     }
 
@@ -152,7 +153,7 @@ fun SubscriptionScreen(
                         text = "Memozy Pro",
                         fontSize = fontSettings.scaled(28),
                         fontWeight = FontWeight.Bold,
-                        color = Color.White
+                        color = colors.textTitle
                     )
 
                     Spacer(modifier = Modifier.height(8.dp))
@@ -160,7 +161,7 @@ fun SubscriptionScreen(
                     Text(
                         text = stringResource(Res.string.subscription_desc),
                         fontSize = fontSettings.scaled(15),
-                        color = Color.White.copy(alpha = 0.85f)
+                        color = colors.textSecondary
                     )
 
                     if (currentTier.isPro) {
@@ -169,10 +170,10 @@ fun SubscriptionScreen(
                             text = stringResource(Res.string.subscription_current_plan),
                             fontSize = fontSettings.scaled(13),
                             fontWeight = FontWeight.Bold,
-                            color = Color.White,
+                            color = colors.chipText,
                             modifier = Modifier
                                 .clip(RoundedCornerShape(6.dp))
-                                .background(Color.White.copy(alpha = 0.2f))
+                                .background(colors.chipText.copy(alpha = 0.1f))
                                 .padding(horizontal = 10.dp, vertical = 4.dp)
                         )
                     }
@@ -185,21 +186,31 @@ fun SubscriptionScreen(
                     .fillMaxWidth()
                     .padding(horizontal = 20.dp)
                     .clip(RoundedCornerShape(16.dp))
-                    .background(colors.cardBackground)
+                    .background(colors.screenBackground)
                     .border(1.dp, colors.cardBorder, RoundedCornerShape(16.dp))
                     .padding(20.dp)
             ) {
                 // 헤더
                 Row(modifier = Modifier.fillMaxWidth()) {
                     Spacer(modifier = Modifier.weight(1.4f))
-                    Text(
-                        text = "Free",
-                        fontSize = fontSettings.scaled(13),
-                        fontWeight = FontWeight.Bold,
-                        color = colors.textSecondary,
-                        textAlign = TextAlign.Center,
-                        modifier = Modifier.weight(1f)
-                    )
+                    Column(
+                        modifier = Modifier.weight(1f),
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        Text(
+                            text = "Free",
+                            fontSize = fontSettings.scaled(13),
+                            fontWeight = FontWeight.Bold,
+                            color = colors.textSecondary,
+                            textAlign = TextAlign.Center,
+                        )
+                        Text(
+                            text = "광고 시청 후 이용",
+                            fontSize = fontSettings.scaled(10),
+                            color = colors.textSecondary,
+                            textAlign = TextAlign.Center,
+                        )
+                    }
                     Text(
                         text = "Pro",
                         fontSize = fontSettings.scaled(13),
@@ -217,9 +228,7 @@ fun SubscriptionScreen(
                 // 비교 항목
                 val comparisons = listOf(
                     Triple(stringResource(Res.string.subscription_feature_youtube), true, true),
-                    Triple(stringResource(Res.string.subscription_feature_web), false, true),
-                    Triple(stringResource(Res.string.subscription_feature_ocr), false, true),
-                    Triple(stringResource(Res.string.subscription_feature_more), false, true),
+                    Triple(stringResource(Res.string.subscription_feature_web), true, true),
                     Triple(stringResource(Res.string.subscription_feature_no_ads), false, true),
                 )
 
@@ -255,6 +264,22 @@ fun SubscriptionScreen(
             }
 
             Spacer(modifier = Modifier.height(24.dp))
+
+            if (!isLoggedIn) {
+                Text(
+                    text = "로그인 없이는 구독이 어렵습니다",
+                    fontSize = fontSettings.scaled(13),
+                    color = colors.textSecondary,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 20.dp)
+                        .clip(RoundedCornerShape(8.dp))
+                        .background(colors.cardBorder.copy(alpha = 0.15f))
+                        .padding(horizontal = 16.dp, vertical = 10.dp)
+                )
+                Spacer(modifier = Modifier.height(12.dp))
+            }
 
             // ── 구독 상품 카드 ──
             val monthly = subscriptionProducts.find { it.productId == BillingService.SUB_PRO_MONTHLY }
@@ -349,26 +374,16 @@ private fun SubscriptionCard(
 ) {
     val colors = LocalAppColors.current
     val fontSettings = LocalFontSettings.current
-    val isSystemDark = colors.screenBackground == Color(0xFF1C1C1E)
-
-    val cardGradient = if (isRecommended && !isCurrentPlan) {
-        if (isSystemDark) {
-            Brush.linearGradient(listOf(Color(0xFF1A3A5C), Color(0xFF2A1A4E)))
-        } else {
-            Brush.linearGradient(listOf(Color(0xFF4A90D9), Color(0xFF7B5EA7)))
-        }
-    } else null
-
     Box(
         modifier = Modifier
             .fillMaxWidth()
             .padding(horizontal = 20.dp)
             .clip(RoundedCornerShape(16.dp))
-            .then(
-                if (cardGradient != null) Modifier.background(cardGradient)
-                else Modifier
-                    .background(colors.cardBackground)
-                    .border(1.dp, colors.cardBorder, RoundedCornerShape(16.dp))
+            .background(colors.screenBackground)
+            .border(
+                width = if (isRecommended && !isCurrentPlan) 2.dp else 1.dp,
+                color = if (isRecommended && !isCurrentPlan) colors.chipText else colors.cardBorder,
+                shape = RoundedCornerShape(16.dp)
             )
             .clickable(enabled = !isCurrentPlan) { onClick() }
             .padding(20.dp)
@@ -384,7 +399,7 @@ private fun SubscriptionCard(
                         text = label,
                         fontSize = fontSettings.scaled(16),
                         fontWeight = FontWeight.Bold,
-                        color = if (cardGradient != null) Color.White else colors.textTitle
+                        color = colors.textTitle
                     )
                     if (badge != null) {
                         Spacer(modifier = Modifier.width(8.dp))
@@ -392,13 +407,10 @@ private fun SubscriptionCard(
                             text = badge,
                             fontSize = fontSettings.scaled(11),
                             fontWeight = FontWeight.Bold,
-                            color = if (cardGradient != null) Color.White else colors.chipText,
+                            color = colors.chipText,
                             modifier = Modifier
                                 .clip(RoundedCornerShape(4.dp))
-                                .background(
-                                    if (cardGradient != null) Color.White.copy(alpha = 0.2f)
-                                    else colors.chipText.copy(alpha = 0.1f)
-                                )
+                                .background(colors.chipText.copy(alpha = 0.1f))
                                 .padding(horizontal = 6.dp, vertical = 2.dp)
                         )
                     }
@@ -409,11 +421,7 @@ private fun SubscriptionCard(
                 text = price,
                 fontSize = fontSettings.scaled(18),
                 fontWeight = FontWeight.Bold,
-                color = when {
-                    isCurrentPlan -> colors.textSecondary
-                    cardGradient != null -> Color.White
-                    else -> colors.chipText
-                },
+                color = if (isCurrentPlan) colors.textSecondary else colors.chipText,
                 textAlign = TextAlign.End
             )
         }

--- a/feature/home/impl/src/iosMain/kotlin/me/pecos/memozy/feature/home/impl/AuthConfig.ios.kt
+++ b/feature/home/impl/src/iosMain/kotlin/me/pecos/memozy/feature/home/impl/AuthConfig.ios.kt
@@ -2,3 +2,4 @@ package me.pecos.memozy.feature.home.impl
 
 // iOS Google Sign-In 연동 시 Info.plist 또는 별도 설정에서 공급.
 internal actual val GOOGLE_WEB_CLIENT_ID: String = ""
+internal actual val IsGoogleSignInAvailable: Boolean = true

--- a/feature/memo-plain/impl/src/commonMain/kotlin/me/pecos/memozy/feature/memoplain/impl/MemoPlainNavigationImpl.kt
+++ b/feature/memo-plain/impl/src/commonMain/kotlin/me/pecos/memozy/feature/memoplain/impl/MemoPlainNavigationImpl.kt
@@ -258,9 +258,17 @@ class MemoPlainNavigationImpl(
         }
 
         private fun buildWebPrompt(mode: SummaryMode, lang: String): String {
+            val style = when (mode) {
+                SummaryMode.SIMPLE -> SummaryStyle.SIMPLE
+                SummaryMode.DETAILED -> SummaryStyle.DETAILED
+            }
+            return buildWebPrompt(style, lang)
+        }
+
+        private fun buildWebPrompt(style: SummaryStyle, lang: String): String {
             val l = langInstruction(lang)
-            return when (mode) {
-                SummaryMode.SIMPLE -> """
+            return when (style) {
+                SummaryStyle.SIMPLE -> """
                     |이 웹페이지 내용을 ${l} 간결하게 요약해줘. 인사말이나 부가 설명 없이 아래 형식만 정확히 출력해:
                     |
                     |[한줄 요약]
@@ -272,7 +280,7 @@ class MemoPlainNavigationImpl(
                     |[핵심 내용]
                     |- 가장 중요한 내용 3~5개를 각 1줄로 정리
                 """.trimMargin()
-                SummaryMode.DETAILED -> """
+                SummaryStyle.DETAILED -> """
                     |이 웹페이지 내용을 ${l} 상세하게 요약해줘. 인사말이나 부가 설명 없이 아래 형식만 정확히 출력해:
                     |
                     |[한줄 요약]
@@ -293,6 +301,47 @@ class MemoPlainNavigationImpl(
                     |[핵심 인사이트]
                     |- 이 글에서 얻을 수 있는 주요 인사이트를 정리
                 """.trimMargin()
+                SummaryStyle.NOTE -> """
+                    |다음 웹페이지 내용을 ${l} 학습 노트 형태로 정리해줘. 인사말이나 부가 설명 없이 바로 시작해:
+                    |
+                    |주제별로 묶어서 개조식(- 기호)으로 간결하게 작성해.
+                    |굵게(**) 표시는 꼭 필요한 핵심 용어에만 최소한으로 사용해.
+                    |한 항목당 1줄, 복습할 때 빠르게 훑을 수 있는 형태로.
+                """.trimMargin()
+                SummaryStyle.LANGUAGE -> {
+                    val userLang = when (lang) {
+                        "en" -> "English"
+                        "ja" -> "日本語"
+                        else -> "한국어"
+                    }
+                    """
+                    |다음 웹페이지 내용을 언어 학습용으로 정리해줘.
+                    |사용자의 모국어는 ${userLang}이고, 페이지에 나오는 외국어를 학습하려는 목적이야.
+                    |절대 #, ##, **, *** 같은 마크다운 서식을 사용하지 마. 이모지와 일반 텍스트만 써.
+                    |인사말이나 부가 설명 없이 바로 아래 형식대로만 출력해:
+                    |
+                    |[핵심 표현 (10~15개)]
+                    |
+                    |페이지에서 나온 외국어 표현을 원문 그대로 적고, 바로 다음 줄에 ${userLang} 뜻을 자연스럽게 적어.
+                    |단어 단위 직역이 아니라 ${userLang} 화자가 같은 상황에서 실제로 쓸 표현으로.
+                    |표현과 표현 사이에는 빈 줄을 넣어.
+                    |
+                    |외국어 원문
+                    |${userLang} 뜻 (자연스러운 의역)
+                    |
+                    |[주요 문장 (5~10개)]
+                    |
+                    |페이지에서 나온 핵심 문장을 원문 그대로 적고, 다음 줄에 ${userLang} 해석을 적어.
+                    |각 문장 앞에 * 를 붙여. 문장과 문장 사이에는 빈 줄을 넣어.
+                    |
+                    |* 외국어 원문 문장
+                    |${userLang} 해석 (자연스러운 번역)
+                    |
+                    |[학습 포인트]
+                    |
+                    |문법, 뉘앙스, 직역과 의역의 차이, 사용 상황 등 학습에 도움되는 내용을 ${userLang}로 2~4줄 정리.
+                """.trimMargin()
+                }
             }
         }
     }
@@ -380,7 +429,8 @@ class MemoPlainNavigationImpl(
             }
             val dailyLimit = subscriptionTier.dailyAiLimit + adBonusCount
             val canUseAiQuota = dailyUsageCount < dailyLimit
-            val canUseAi = isLoggedIn && canUseAiQuota
+            // TEST: AI 한도 일시 해제 — 출시 전 원복 필요
+            val canUseAi = true // isLoggedIn && canUseAiQuota
             val canWatchAd = !subscriptionTier.isPro && dailyAdViewCount < MAX_DAILY_AD_VIEWS
             val remainingAdViews = MAX_DAILY_AD_VIEWS - dailyAdViewCount
             var showLimitBottomSheet by remember { mutableStateOf(false) }
@@ -714,6 +764,43 @@ class MemoPlainNavigationImpl(
                 webSummaryResult = webSummaryResult,
                 webSummaryError = webSummaryError,
                 webPageTitle = webPageTitle,
+                onWebSummaryStyleSelected = { style, url ->
+                    if (!canUseAi) {
+                        notifyAiBlocked()
+                        return@MemoScreen
+                    }
+                    currentSummarizeJob?.cancel()
+                    currentSummarizeJob = scope.launch {
+                        isWebSummarizing = true
+                        webSummaryError = null
+                        try {
+                            val content = webScrapeService.scrapeWebPage(url)
+                            if (content == null) {
+                                webSummaryError = "웹페이지를 불러올 수 없어요."
+                            } else {
+                                webPageTitle = content.title
+                                val webPrompt = buildWebPrompt(style, languageCode)
+                                val summary = retryOn503 {
+                                    aiApiService.generateContent(
+                                        "$webPrompt\n\n아래는 웹페이지 내용입니다:\n\n${content.text}"
+                                    )
+                                }
+                                webSummaryResult = summary
+                                aiUsageDao.insert(AiUsage(feature = FEATURE_WEB_SUMMARY))
+                            }
+                        } catch (e: Exception) {
+                            webSummaryError = when {
+                                e.message?.contains("503") == true || e.message?.contains("UNAVAILABLE") == true ->
+                                    "AI 서버가 일시적으로 바빠요. 잠시 후 다시 시도해주세요."
+                                e.message?.contains("timeout") == true || e.message?.contains("Timeout") == true ->
+                                    "응답 시간이 초과됐어요. 더 짧은 페이지를 시도해주세요."
+                                else -> "DEBUG: ${e::class.simpleName}: ${e.message}"
+                            }
+                        } finally {
+                            isWebSummarizing = false
+                        }
+                    }
+                },
                 onSummaryStyleSelected = { style, url ->
                     activeSummaryStyle = style
                     // 바텀시트에서 양식 선택 시 즉시 요약 실행

--- a/feature/memo-plain/impl/src/commonMain/kotlin/me/pecos/memozy/presentation/screen/memo/MemoScreen.kt
+++ b/feature/memo-plain/impl/src/commonMain/kotlin/me/pecos/memozy/presentation/screen/memo/MemoScreen.kt
@@ -249,6 +249,7 @@ fun MemoScreen(
     webSummaryError: String? = null,
     webPageTitle: String? = null,
     onSummaryStyleSelected: ((SummaryStyle, String) -> Unit)? = null,
+    onWebSummaryStyleSelected: ((SummaryStyle, String) -> Unit)? = null,
     // Memozy AI — (actionName, currentTitle, currentBody)
     onAiPresetAction: ((String, String, String) -> Unit)? = null,
     onAiCustomSend: ((String, String, String) -> Unit)? = null,
@@ -307,6 +308,7 @@ fun MemoScreen(
     // 요약 결과 표시 상태
     var showSummary by remember { mutableStateOf(false) }
     var showSummaryStyleSheet by remember { mutableStateOf(false) }
+    var showWebSummaryStyleSheet by remember { mutableStateOf(false) }
     var selectedSummaryStyle by remember { mutableStateOf(SummaryStyle.SIMPLE) }
 
     // 요약 콘텐츠 접기/펼치기 상태 (summaryContent 별도 컬럼에서 로드)
@@ -580,6 +582,12 @@ fun MemoScreen(
                 // 제목 — 개행 시 내용으로 포커스 이동
                 val bodyFocusRequester = remember { FocusRequester() }
 
+                // 메모 진입 시 본문에 자동 포커스 + 키보드 표시 (노션 스타일) — 신규/편집 모두
+                LaunchedEffect(Unit) {
+                    kotlinx.coroutines.delay(100) // 컴포지션 안정화 대기
+                    try { bodyFocusRequester.requestFocus() } catch (_: Throwable) {}
+                }
+
                 BasicTextField(
                     value = nameText,
                     onValueChange = { newValue ->
@@ -745,7 +753,20 @@ fun MemoScreen(
                         onAskAi = if (onAiCustomSend != null) { {
                             showAiCustomInput = true
                         } } else null,
+                        onStyleSelect = { showWebSummaryStyleSheet = true },
                         colors = colors
+                    )
+                }
+
+                // 웹 요약 양식 선택 바텀시트
+                if (showWebSummaryStyleSheet) {
+                    SummaryStyleBottomSheet(
+                        onSelect = { style ->
+                            val url = savedWebUrl ?: return@SummaryStyleBottomSheet
+                            currentSummaryMode = style.summaryMode
+                            onWebSummaryStyleSelected?.invoke(style, url)
+                        },
+                        onDismiss = { showWebSummaryStyleSheet = false }
                     )
                 }
 
@@ -757,20 +778,20 @@ fun MemoScreen(
                     state = richTextState,
                     modifier = Modifier
                         .fillMaxWidth()
-                        .heightIn(min = 150.dp)
+                        .heightIn(min = 200.dp)
                         .focusRequester(bodyFocusRequester),
                     textStyle = TextStyle(
                         fontSize = fontSettings.bodySize,
-                        lineHeight = (fontSettings.bodySize.value * 1.8f).sp,
+                        lineHeight = (fontSettings.bodySize.value * 1.5f).sp,
                         color = colors.textBody,
                         fontFamily = fontSettings.fontFamily,
                         lineHeightStyle = LineHeightStyle(
-                            alignment = LineHeightStyle.Alignment.Center,
+                            alignment = LineHeightStyle.Alignment.Top,
                             trim = LineHeightStyle.Trim.None
                         )
                     ),
                     decorationBox = { innerTextField ->
-                        Box(modifier = Modifier.heightIn(min = 150.dp)) {
+                        Box {
                             if (richTextState.annotatedString.text.isEmpty()) {
                                 Text(
                                     text = stringResource(Res.string.memo_content_placeholder),
@@ -782,6 +803,17 @@ fun MemoScreen(
                             innerTextField()
                         }
                     }
+                )
+
+                // 본문 아래 빈 공간도 탭하면 본문에 포커스
+                Spacer(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .heightIn(min = 300.dp)
+                        .clickable(
+                            interactionSource = remember { androidx.compose.foundation.interaction.MutableInteractionSource() },
+                            indication = null
+                        ) { bodyFocusRequester.requestFocus() }
                 )
 
                 // Memozy AI 응답 중 표시 (본문 내 인라인, X 없음)

--- a/feature/memo-plain/impl/src/commonMain/kotlin/me/pecos/memozy/presentation/screen/memo/components/WebSummaryInlineCard.kt
+++ b/feature/memo-plain/impl/src/commonMain/kotlin/me/pecos/memozy/presentation/screen/memo/components/WebSummaryInlineCard.kt
@@ -40,6 +40,7 @@ import me.pecos.memozy.feature.core.resource.generated.resources.summary_card_we
 import me.pecos.memozy.feature.core.resource.generated.resources.summary_collapse
 import me.pecos.memozy.feature.core.resource.generated.resources.summary_copy
 import me.pecos.memozy.feature.core.resource.generated.resources.summary_expand
+import me.pecos.memozy.feature.core.resource.generated.resources.summarize
 import me.pecos.memozy.feature.core.resource.generated.resources.summary_mode_detailed
 import me.pecos.memozy.feature.core.resource.generated.resources.summary_mode_simple
 import me.pecos.memozy.feature.core.resource.generated.resources.web_summarizing
@@ -67,6 +68,7 @@ fun WebSummaryInlineCard(
     onResummarize: (SummaryMode) -> Unit,
     onDeleteSummary: (() -> Unit)? = null,
     onAskAi: (() -> Unit)? = null,
+    onStyleSelect: (() -> Unit)? = null,
     colors: AppColors
 ) {
     val fontSettings = LocalFontSettings.current
@@ -147,21 +149,14 @@ fun WebSummaryInlineCard(
                     Spacer(modifier = Modifier.width(3.dp))
                     Text(stringResource(Res.string.memo_copy), fontSize = fontSettings.scaled(10), color = colors.chipText, fontWeight = FontWeight.Medium)
                 }
-                if (onSummarize != null && summaryText == null) {
+                if (onStyleSelect != null && summaryText == null) {
                     Row(
-                        modifier = Modifier.weight(1f).clip(RoundedCornerShape(6.dp)).background(Color(0xFF2196F3).copy(alpha = 0.1f))
-                            .clickable { onSummarize(webUrl, SummaryMode.SIMPLE) }
+                        modifier = Modifier.weight(2f).clip(RoundedCornerShape(6.dp)).background(Color(0xFF2196F3).copy(alpha = 0.1f))
+                            .clickable { onStyleSelect() }
                             .padding(vertical = 5.dp),
                         verticalAlignment = Alignment.CenterVertically,
                         horizontalArrangement = Arrangement.Center
-                    ) { Text(stringResource(Res.string.summary_mode_simple), fontSize = fontSettings.scaled(10), color = Color(0xFF2196F3), fontWeight = FontWeight.Medium) }
-                    Row(
-                        modifier = Modifier.weight(1f).clip(RoundedCornerShape(6.dp)).background(Color(0xFFFF9800).copy(alpha = 0.1f))
-                            .clickable { onSummarize(webUrl, SummaryMode.DETAILED) }
-                            .padding(vertical = 5.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.Center
-                    ) { Text(stringResource(Res.string.summary_mode_detailed), fontSize = fontSettings.scaled(10), color = Color(0xFFFF9800), fontWeight = FontWeight.Medium) }
+                    ) { Text(stringResource(Res.string.summarize), fontSize = fontSettings.scaled(10), color = Color(0xFF2196F3), fontWeight = FontWeight.Medium) }
                 }
             }
 

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -10,6 +10,10 @@
 		AAAA00000000000000000009 /* iOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAA00000000000000000007 /* iOSApp.swift */; };
 		AAAA0000000000000000000A /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAA00000000000000000008 /* ContentView.swift */; };
 		AAAA00000000000000000016 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AAAA00000000000000000015 /* Assets.xcassets */; };
+		C88587002FA595DA00DC5BAB /* StoreKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C88586FF2FA595DA00DC5BAB /* StoreKit.framework */; };
+		C88587042FA5AA7500DC5BAB /* GoogleSignIn in Frameworks */ = {isa = PBXBuildFile; productRef = C88587032FA5AA7500DC5BAB /* GoogleSignIn */; };
+		C88587062FA5AA7500DC5BAB /* GoogleSignInSwift in Frameworks */ = {isa = PBXBuildFile; productRef = C88587052FA5AA7500DC5BAB /* GoogleSignInSwift */; };
+		C88587082FA5AB0400DC5BAB /* IosGoogleSignInBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = C88587072FA5AB0400DC5BAB /* IosGoogleSignInBridge.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -17,6 +21,9 @@
 		AAAA00000000000000000007 /* iOSApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iOSApp.swift; sourceTree = "<group>"; };
 		AAAA00000000000000000008 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		AAAA00000000000000000015 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		C88586FF2FA595DA00DC5BAB /* StoreKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = StoreKit.framework; path = System/Library/Frameworks/StoreKit.framework; sourceTree = SDKROOT; };
+		C88587012FA5A2DB00DC5BAB /* iosApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = iosApp.entitlements; sourceTree = "<group>"; };
+		C88587072FA5AB0400DC5BAB /* IosGoogleSignInBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IosGoogleSignInBridge.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -24,6 +31,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C88587062FA5AA7500DC5BAB /* GoogleSignInSwift in Frameworks */,
+				C88587002FA595DA00DC5BAB /* StoreKit.framework in Frameworks */,
+				C88587042FA5AA7500DC5BAB /* GoogleSignIn in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -34,6 +44,7 @@
 			isa = PBXGroup;
 			children = (
 				AAAA00000000000000000003 /* iosApp */,
+				C88586FE2FA595DA00DC5BAB /* Frameworks */,
 				AAAA00000000000000000004 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -41,6 +52,8 @@
 		AAAA00000000000000000003 /* iosApp */ = {
 			isa = PBXGroup;
 			children = (
+				C88587072FA5AB0400DC5BAB /* IosGoogleSignInBridge.swift */,
+				C88587012FA5A2DB00DC5BAB /* iosApp.entitlements */,
 				AAAA00000000000000000007 /* iOSApp.swift */,
 				AAAA00000000000000000008 /* ContentView.swift */,
 				AAAA00000000000000000015 /* Assets.xcassets */,
@@ -54,6 +67,14 @@
 				AAAA00000000000000000006 /* iosApp.app */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		C88586FE2FA595DA00DC5BAB /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				C88586FF2FA595DA00DC5BAB /* StoreKit.framework */,
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -101,6 +122,9 @@
 				Base,
 			);
 			mainGroup = AAAA00000000000000000002;
+			packageReferences = (
+				C88587022FA5AA7500DC5BAB /* XCRemoteSwiftPackageReference "GoogleSignIn-iOS" */,
+			);
 			productRefGroup = AAAA00000000000000000004 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -148,6 +172,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C88587082FA5AB0400DC5BAB /* IosGoogleSignInBridge.swift in Sources */,
 				AAAA00000000000000000009 /* iOSApp.swift in Sources */,
 				AAAA0000000000000000000A /* ContentView.swift in Sources */,
 			);
@@ -161,6 +186,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = iosApp/iosApp.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
@@ -197,6 +223,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = iosApp/iosApp.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
@@ -369,6 +396,30 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		C88587022FA5AA7500DC5BAB /* XCRemoteSwiftPackageReference "GoogleSignIn-iOS" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/google/GoogleSignIn-iOS";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 9.1.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		C88587032FA5AA7500DC5BAB /* GoogleSignIn */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C88587022FA5AA7500DC5BAB /* XCRemoteSwiftPackageReference "GoogleSignIn-iOS" */;
+			productName = GoogleSignIn;
+		};
+		C88587052FA5AA7500DC5BAB /* GoogleSignInSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C88587022FA5AA7500DC5BAB /* XCRemoteSwiftPackageReference "GoogleSignIn-iOS" */;
+			productName = GoogleSignInSwift;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = AAAA00000000000000000001 /* Project object */;
 }

--- a/iosApp/iosApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iosApp/iosApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,69 @@
+{
+  "originHash" : "68aa00e3cba36db2e0a76f54dbc84d1f079d8aa9a19bfa9fce02d6286bd620b7",
+  "pins" : [
+    {
+      "identity" : "app-check",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/app-check.git",
+      "state" : {
+        "revision" : "61b85103a1aeed8218f17c794687781505fbbef5",
+        "version" : "11.2.0"
+      }
+    },
+    {
+      "identity" : "appauth-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/openid/AppAuth-iOS.git",
+      "state" : {
+        "revision" : "145104f5ea9d58ae21b60add007c33c1cc0c948e",
+        "version" : "2.0.0"
+      }
+    },
+    {
+      "identity" : "googlesignin-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleSignIn-iOS",
+      "state" : {
+        "revision" : "913b4005ea26aebe1c97d54e35ad82a515924c71",
+        "version" : "9.1.0"
+      }
+    },
+    {
+      "identity" : "googleutilities",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleUtilities.git",
+      "state" : {
+        "revision" : "60da361632d0de02786f709bdc0c4df340f7613e",
+        "version" : "8.1.0"
+      }
+    },
+    {
+      "identity" : "gtm-session-fetcher",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/gtm-session-fetcher.git",
+      "state" : {
+        "revision" : "a2ab612cb980066ee56d90d60d8462992c07f24b",
+        "version" : "3.5.0"
+      }
+    },
+    {
+      "identity" : "gtmappauth",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GTMAppAuth.git",
+      "state" : {
+        "revision" : "56e0ccf09a6dd29dc7e68bdf729598240ca8aa16",
+        "version" : "5.0.0"
+      }
+    },
+    {
+      "identity" : "promises",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/promises.git",
+      "state" : {
+        "revision" : "540318ecedd63d883069ae7f1ed811a2df00b6ac",
+        "version" : "2.4.0"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -22,6 +22,17 @@
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>GIDClientID</key>
+	<string>470786671712-ein20r5ogai99v056tqkforadbvl56fn.apps.googleusercontent.com</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>com.googleusercontent.apps.470786671712-ein20r5ogai99v056tqkforadbvl56fn</string>
+			</array>
+		</dict>
+	</array>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/iosApp/iosApp/IosGoogleSignInBridge.swift
+++ b/iosApp/iosApp/IosGoogleSignInBridge.swift
@@ -1,0 +1,58 @@
+import Foundation
+import UIKit
+import GoogleSignIn
+import Shared
+
+final class IosGoogleSignInBridge: NSObject, GoogleSignInHandler {
+    func signIn(callback: GoogleSignInCallback) {
+        let work: () -> Void = { [weak self] in
+            guard let rootVC = Self.topViewController() else {
+                callback.onError(message: "No presenting view controller")
+                return
+            }
+            GIDSignIn.sharedInstance.signIn(withPresenting: rootVC) { signInResult, error in
+                if let error = error as NSError? {
+                    if error.domain == kGIDSignInErrorDomain &&
+                        error.code == GIDSignInError.canceled.rawValue {
+                        callback.onCancelled()
+                    } else {
+                        callback.onError(message: error.localizedDescription)
+                    }
+                    return
+                }
+                guard let idToken = signInResult?.user.idToken?.tokenString else {
+                    callback.onError(message: "No id token returned")
+                    return
+                }
+                callback.onSuccess(idToken: idToken)
+            }
+            _ = self
+        }
+        // 이미 메인 스레드면 즉시 실행 (DispatchQueue.main.async 의 1프레임 지연 제거)
+        if Thread.isMainThread {
+            work()
+        } else {
+            DispatchQueue.main.async { work() }
+        }
+    }
+
+    private static func topViewController(
+        base: UIViewController? = nil
+    ) -> UIViewController? {
+        let baseVC = base ?? UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .first?.windows
+            .first(where: { $0.isKeyWindow })?
+            .rootViewController
+        if let nav = baseVC as? UINavigationController {
+            return topViewController(base: nav.visibleViewController)
+        }
+        if let tab = baseVC as? UITabBarController, let selected = tab.selectedViewController {
+            return topViewController(base: selected)
+        }
+        if let presented = baseVC?.presentedViewController {
+            return topViewController(base: presented)
+        }
+        return baseVC
+    }
+}

--- a/iosApp/iosApp/iOSApp.swift
+++ b/iosApp/iosApp/iOSApp.swift
@@ -1,15 +1,20 @@
 import SwiftUI
+import GoogleSignIn
 import Shared
 
 @main
 struct iOSApp: App {
     init() {
         SharedKoinKt.doInitKoin()
+        GoogleSignInRegistrar.shared.handler = IosGoogleSignInBridge()
     }
 
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .onOpenURL { url in
+                    GIDSignIn.sharedInstance.handle(url)
+                }
         }
     }
 }

--- a/iosApp/iosApp/iosApp.entitlements
+++ b/iosApp/iosApp/iosApp.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+</dict>
+</plist>

--- a/platform/billing/impl/src/androidMain/kotlin/me/pecos/memozy/platform/billing/AndroidBillingService.kt
+++ b/platform/billing/impl/src/androidMain/kotlin/me/pecos/memozy/platform/billing/AndroidBillingService.kt
@@ -2,6 +2,7 @@ package me.pecos.memozy.platform.billing
 
 import android.app.Activity
 import android.content.Context
+import android.content.SharedPreferences
 import com.android.billingclient.api.AcknowledgePurchaseParams
 import com.android.billingclient.api.BillingClient
 import com.android.billingclient.api.BillingClientStateListener
@@ -14,8 +15,13 @@ import com.android.billingclient.api.Purchase
 import com.android.billingclient.api.PurchasesUpdatedListener
 import com.android.billingclient.api.QueryProductDetailsParams
 import com.android.billingclient.api.QueryPurchasesParams
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
 import me.pecos.memozy.presentation.theme.SubscriptionTier
 
 fun provideBillingService(context: Context): BillingService = AndroidBillingService(context)
@@ -25,8 +31,12 @@ internal class AndroidBillingService(
 ) : BillingService, PurchasesUpdatedListener {
 
     private val appContext = context.applicationContext
+    private val prefs: SharedPreferences =
+        appContext.getSharedPreferences("billing_cache", Context.MODE_PRIVATE)
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     private companion object {
+        const val KEY_TIER = "subscription_tier"
         const val PRODUCT_RICE_1 = "donation_rice_1"
         const val PRODUCT_RICE_2 = "donation_rice_2"
         const val PRODUCT_RICE_3 = "donation_rice_3"
@@ -72,8 +82,16 @@ internal class AndroidBillingService(
     private val _isConnected = MutableStateFlow(false)
     override val isConnected: StateFlow<Boolean> = _isConnected
 
-    private val _subscriptionTier = MutableStateFlow(SubscriptionTier.FREE)
+    private val _subscriptionTier = MutableStateFlow(
+        if (prefs.getString(KEY_TIER, null) == SubscriptionTier.PRO.name) SubscriptionTier.PRO
+        else SubscriptionTier.FREE
+    )
     override val subscriptionTier: StateFlow<SubscriptionTier> = _subscriptionTier
+
+    private fun setTier(tier: SubscriptionTier) {
+        _subscriptionTier.value = tier
+        prefs.edit().putString(KEY_TIER, tier.name).apply()
+    }
 
     override fun connect() {
         if (billingClient.isReady) return
@@ -92,7 +110,10 @@ internal class AndroidBillingService(
 
             override fun onBillingServiceDisconnected() {
                 _isConnected.value = false
-                connect()
+                scope.launch {
+                    delay(3_000)
+                    connect()
+                }
             }
         })
     }
@@ -204,6 +225,10 @@ internal class AndroidBillingService(
     }
 
     override fun queryExistingSubscriptions() {
+        if (!billingClient.isReady) {
+            connect()
+            return
+        }
         billingClient.queryPurchasesAsync(
             QueryPurchasesParams.newBuilder()
                 .setProductType(BillingClient.ProductType.SUBS)
@@ -214,7 +239,7 @@ internal class AndroidBillingService(
                     purchase.purchaseState == Purchase.PurchaseState.PURCHASED &&
                         purchase.products.any { it in SUBSCRIPTION_IDS }
                 }
-                _subscriptionTier.value = if (hasActiveSub) SubscriptionTier.PRO else SubscriptionTier.FREE
+                setTier(if (hasActiveSub) SubscriptionTier.PRO else SubscriptionTier.FREE)
 
                 purchases.filter {
                     it.purchaseState == Purchase.PurchaseState.PURCHASED && !it.isAcknowledged
@@ -234,7 +259,7 @@ internal class AndroidBillingService(
                         val isSubscription = purchase.products.any { it in SUBSCRIPTION_IDS }
                         if (isSubscription) {
                             acknowledgePurchase(purchase)
-                            _subscriptionTier.value = SubscriptionTier.PRO
+                            setTier(SubscriptionTier.PRO)
                             _purchaseState.value = PurchaseState.Success
                         } else {
                             consumePurchase(purchase)
@@ -265,12 +290,19 @@ internal class AndroidBillingService(
         }
     }
 
-    private fun acknowledgePurchase(purchase: Purchase) {
+    private fun acknowledgePurchase(purchase: Purchase, retryCount: Int = 0) {
         if (purchase.isAcknowledged) return
         val params = AcknowledgePurchaseParams.newBuilder()
             .setPurchaseToken(purchase.purchaseToken)
             .build()
-        billingClient.acknowledgePurchase(params) { /* no-op */ }
+        billingClient.acknowledgePurchase(params) { result ->
+            if (result.responseCode != BillingClient.BillingResponseCode.OK && retryCount < 3) {
+                scope.launch {
+                    delay(2_000L * (retryCount + 1))
+                    acknowledgePurchase(purchase, retryCount + 1)
+                }
+            }
+        }
     }
 
     override fun resetPurchaseState() {

--- a/platform/billing/impl/src/iosMain/kotlin/me/pecos/memozy/platform/billing/IosBillingService.kt
+++ b/platform/billing/impl/src/iosMain/kotlin/me/pecos/memozy/platform/billing/IosBillingService.kt
@@ -1,31 +1,41 @@
 package me.pecos.memozy.platform.billing
 
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 import me.pecos.memozy.presentation.theme.SubscriptionTier
+import platform.Foundation.NSError
+import platform.Foundation.NSNumberFormatter
+import platform.Foundation.NSUserDefaults
+import platform.StoreKit.SKPayment
+import platform.StoreKit.SKPaymentQueue
+import platform.StoreKit.SKPaymentTransaction
+import platform.StoreKit.SKPaymentTransactionObserverProtocol
+import platform.StoreKit.SKPaymentTransactionState.*
+import platform.StoreKit.SKProduct
+import platform.StoreKit.SKProductPeriodUnit.*
+import platform.StoreKit.SKProductsRequest
+import platform.StoreKit.SKProductsRequestDelegateProtocol
+import platform.StoreKit.SKProductsResponse
+import platform.StoreKit.SKRequest
+import platform.darwin.NSObject
 
-/**
- * iOS 측 BillingService — KMP Wave 3-I 단계 stub.
- *
- * 이 시점에선 StoreKit 1 (SKProductsRequest / SKPaymentQueue) 의 delegate / observer 패턴을
- * 풀로 K/N 인터롭하는 작업과, App Store Connect 의 IAP 상품 등록 / Sandbox tester / Xcode
- * StoreKit Configuration 파일 등 외부 작업이 동시에 필요. 이 PR 스코프는 BillingService
- * 인터페이스가 iOS 에서도 만족되어 앱이 충돌 없이 실행되는 것까지 — 실 결제는 모두 follow-up.
- *
- * 동작:
- * - subscriptionTier 항상 FREE 반환
- * - 상품 목록은 빈 리스트
- * - launchSubscriptionFlow / launchPurchaseFlow 호출 시 PurchaseState.Error 로 안내
- * - queryExistingSubscriptions 는 no-op
- *
- * 후속:
- * - SKProductsRequest / SKProductsRequestDelegate 로 IAP 상품 메타데이터 로드
- * - SKPaymentQueue 옵저버 등록 후 결제 결과 PurchaseState 매핑
- * - Transaction.updates 모방 (SKPaymentTransactionObserver) → Pro 활성/만료 SubscriptionTier 갱신
- * - Server-side receipt validation (Supabase Edge Function 재사용)
- */
+private const val KEY_TIER = "billing_tier"
+
 class IosBillingService : BillingService {
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+    private val productMap = mutableMapOf<String, SKProduct>()
+    private var productsDelegate: ProductsDelegate? = null
+    private val observer = PaymentObserver(
+        onPurchased = { productId -> handlePurchased(productId) },
+        onRestored = { productId -> handlePurchased(productId) },
+        onFailed = { error -> handleFailed(error) },
+    )
 
     private val _products = MutableStateFlow<List<DonationProduct>>(emptyList())
     override val products: StateFlow<List<DonationProduct>> = _products.asStateFlow()
@@ -39,35 +49,181 @@ class IosBillingService : BillingService {
     private val _isConnected = MutableStateFlow(false)
     override val isConnected: StateFlow<Boolean> = _isConnected.asStateFlow()
 
-    private val _subscriptionTier = MutableStateFlow(SubscriptionTier.FREE)
+    private val _subscriptionTier = MutableStateFlow(loadCachedTier())
     override val subscriptionTier: StateFlow<SubscriptionTier> = _subscriptionTier.asStateFlow()
 
     override fun connect() {
-        // StoreKit 풀 연결은 follow-up. 일단 connected 로만 표시해 SubscriptionScreen UI 가
-        // "연결 중" 상태에서 멈추지 않도록.
+        SKPaymentQueue.defaultQueue().addTransactionObserver(observer)
         _isConnected.value = true
+        loadProducts()
+        queryExistingSubscriptions()
     }
 
     override fun disconnect() {
+        SKPaymentQueue.defaultQueue().removeTransactionObserver(observer)
         _isConnected.value = false
     }
 
-    override fun launchPurchaseFlow(activity: Any?, productId: String) {
-        _purchaseState.value = PurchaseState.Error("iOS 결제는 곧 지원됩니다.")
+    override fun launchSubscriptionFlow(activity: Any?, productId: String) {
+        val product = productMap[productId] ?: run {
+            _purchaseState.value = PurchaseState.Error("상품 정보를 불러오는 중입니다. 잠시 후 다시 시도해주세요.")
+            return
+        }
+        _purchaseState.value = PurchaseState.Loading
+        val payment = SKPayment.paymentWithProduct(product)
+        SKPaymentQueue.defaultQueue().addPayment(payment)
     }
 
-    override fun launchSubscriptionFlow(activity: Any?, productId: String) {
-        _purchaseState.value = PurchaseState.Error("iOS 구독은 곧 지원됩니다.")
+    override fun launchPurchaseFlow(activity: Any?, productId: String) {
+        launchSubscriptionFlow(activity, productId)
     }
 
     override fun queryExistingSubscriptions() {
-        // no-op — 실 구현 시 SKPaymentQueue.default().restoreCompletedTransactions() 또는
-        // Transaction.currentEntitlements 를 통해 현재 활성 구독 조회.
+        SKPaymentQueue.defaultQueue().restoreCompletedTransactions()
     }
 
-    override fun isProductAvailable(productId: String): Boolean = false
+    override fun isProductAvailable(productId: String): Boolean =
+        productMap.containsKey(productId)
 
     override fun resetPurchaseState() {
         _purchaseState.value = PurchaseState.Idle
+    }
+
+    private fun loadProducts() {
+        val ids = setOf(BillingService.SUB_PRO_MONTHLY, BillingService.SUB_PRO_YEARLY)
+        println("[Billing] loadProducts START — requesting ids=$ids")
+        val delegate = ProductsDelegate(
+            onLoaded = { products, invalidIds ->
+                println("[Billing] products RESPONSE — loaded=${products.size}, invalid=$invalidIds")
+                products.forEach { p ->
+                    println("[Billing]  - product: id=${p.productIdentifier}, title=${p.localizedTitle}, price=${p.price}")
+                }
+                scope.launch {
+                    products.forEach { productMap[it.productIdentifier] = it }
+                    _subscriptionProducts.value = products
+                        .sortedBy { it.productIdentifier }
+                        .map { it.toSubscriptionProduct() }
+                }
+                productsDelegate = null
+            },
+            onError = { error ->
+                println("[Billing] products REQUEST FAILED: $error")
+                productsDelegate = null
+            }
+        )
+        productsDelegate = delegate
+        val request = SKProductsRequest(productIdentifiers = ids)
+        request.delegate = delegate
+        delegate.retainRequest(request)
+        request.start()
+    }
+
+    private fun handlePurchased(productId: String) {
+        val subIds = setOf(BillingService.SUB_PRO_MONTHLY, BillingService.SUB_PRO_YEARLY)
+        if (productId in subIds) {
+            setTier(SubscriptionTier.PRO)
+            _purchaseState.value = PurchaseState.Success
+        }
+    }
+
+    private fun handleFailed(error: String?) {
+        _purchaseState.value = if (error == null) PurchaseState.Idle
+        else PurchaseState.Error(error)
+    }
+
+    private fun setTier(tier: SubscriptionTier) {
+        _subscriptionTier.value = tier
+        NSUserDefaults.standardUserDefaults.setObject(tier.name, KEY_TIER)
+        NSUserDefaults.standardUserDefaults.synchronize()
+    }
+
+    private fun loadCachedTier(): SubscriptionTier {
+        val cached = NSUserDefaults.standardUserDefaults.stringForKey(KEY_TIER)
+        return if (cached == SubscriptionTier.PRO.name) SubscriptionTier.PRO else SubscriptionTier.FREE
+    }
+}
+
+private fun SKProduct.toSubscriptionProduct(): SubscriptionProduct {
+    val formatter = NSNumberFormatter()
+    formatter.numberStyle = 2uL // NSNumberFormatterCurrencyStyle
+    formatter.locale = priceLocale
+    val formattedPrice = formatter.stringFromNumber(price) ?: price.stringValue
+    val period = subscriptionPeriod?.let {
+        when (it.unit) {
+            SKProductPeriodUnitDay -> "P${it.numberOfUnits}D"
+            SKProductPeriodUnitWeek -> "P${it.numberOfUnits}W"
+            SKProductPeriodUnitMonth -> "P${it.numberOfUnits}M"
+            SKProductPeriodUnitYear -> "P${it.numberOfUnits}Y"
+            else -> ""
+        }
+    } ?: ""
+    return SubscriptionProduct(
+        productId = productIdentifier,
+        name = localizedTitle,
+        description = localizedDescription,
+        formattedPrice = formattedPrice,
+        billingPeriod = period,
+    )
+}
+
+private class PaymentObserver(
+    private val onPurchased: (String) -> Unit,
+    private val onRestored: (String) -> Unit,
+    private val onFailed: (String?) -> Unit,
+) : NSObject(), SKPaymentTransactionObserverProtocol {
+
+    @Suppress("UNCHECKED_CAST")
+    override fun paymentQueue(queue: SKPaymentQueue, updatedTransactions: List<*>) {
+        (updatedTransactions as List<SKPaymentTransaction>).forEach { tx ->
+            when (tx.transactionState) {
+                SKPaymentTransactionStatePurchased -> {
+                    queue.finishTransaction(tx)
+                    onPurchased(tx.payment.productIdentifier)
+                }
+                SKPaymentTransactionStateRestored -> {
+                    queue.finishTransaction(tx)
+                    tx.originalTransaction?.payment?.productIdentifier?.let { onRestored(it) }
+                }
+                SKPaymentTransactionStateFailed -> {
+                    queue.finishTransaction(tx)
+                    val isCancelled = tx.error?.code?.toInt() == 2
+                    onFailed(if (isCancelled) null else tx.error?.localizedDescription)
+                }
+                SKPaymentTransactionStatePurchasing,
+                SKPaymentTransactionStateDeferred -> { /* 진행 중 */ }
+            }
+        }
+    }
+
+    override fun paymentQueueRestoreCompletedTransactionsFinished(queue: SKPaymentQueue) {}
+
+    override fun paymentQueue(
+        queue: SKPaymentQueue,
+        restoreCompletedTransactionsFailedWithError: NSError,
+    ) {}
+}
+
+private class ProductsDelegate(
+    private val onLoaded: (List<SKProduct>, List<String>) -> Unit,
+    private val onError: (String) -> Unit = {},
+) : NSObject(), SKProductsRequestDelegateProtocol {
+
+    private var requestRef: SKProductsRequest? = null
+
+    fun retainRequest(request: SKProductsRequest) {
+        requestRef = request
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    override fun productsRequest(request: SKProductsRequest, didReceiveResponse: SKProductsResponse) {
+        val products = didReceiveResponse.products as List<SKProduct>
+        val invalid = (didReceiveResponse.invalidProductIdentifiers as List<String>)
+        onLoaded(products, invalid)
+        requestRef = null
+    }
+
+    override fun request(request: SKRequest, didFailWithError: NSError) {
+        onError("${didFailWithError.localizedDescription} (code=${didFailWithError.code})")
+        requestRef = null
     }
 }

--- a/platform/billing/impl/src/iosMain/kotlin/me/pecos/memozy/platform/billing/IosBillingService.kt
+++ b/platform/billing/impl/src/iosMain/kotlin/me/pecos/memozy/platform/billing/IosBillingService.kt
@@ -91,13 +91,8 @@ class IosBillingService : BillingService {
 
     private fun loadProducts() {
         val ids = setOf(BillingService.SUB_PRO_MONTHLY, BillingService.SUB_PRO_YEARLY)
-        println("[Billing] loadProducts START — requesting ids=$ids")
         val delegate = ProductsDelegate(
-            onLoaded = { products, invalidIds ->
-                println("[Billing] products RESPONSE — loaded=${products.size}, invalid=$invalidIds")
-                products.forEach { p ->
-                    println("[Billing]  - product: id=${p.productIdentifier}, title=${p.localizedTitle}, price=${p.price}")
-                }
+            onLoaded = { products, _ ->
                 scope.launch {
                     products.forEach { productMap[it.productIdentifier] = it }
                     _subscriptionProducts.value = products
@@ -106,8 +101,7 @@ class IosBillingService : BillingService {
                 }
                 productsDelegate = null
             },
-            onError = { error ->
-                println("[Billing] products REQUEST FAILED: $error")
+            onError = { _ ->
                 productsDelegate = null
             }
         )

--- a/platform/credential/impl/src/iosMain/kotlin/me/pecos/memozy/platform/credential/IosCredentialService.kt
+++ b/platform/credential/impl/src/iosMain/kotlin/me/pecos/memozy/platform/credential/IosCredentialService.kt
@@ -18,7 +18,6 @@ import platform.AuthenticationServices.ASAuthorizationScopeFullName
 import platform.AuthenticationServices.ASPresentationAnchor
 import platform.CoreCrypto.CC_SHA256
 import platform.CoreCrypto.CC_SHA256_DIGEST_LENGTH
-import platform.Foundation.NSData
 import platform.Foundation.NSError
 import platform.Foundation.NSString
 import platform.Foundation.NSUTF8StringEncoding
@@ -30,14 +29,45 @@ import platform.UIKit.UIWindow
 import platform.darwin.NSObject
 import kotlin.coroutines.resume
 
+interface GoogleSignInCallback {
+    fun onSuccess(idToken: String)
+    fun onCancelled()
+    fun onError(message: String)
+}
+
+interface GoogleSignInHandler {
+    fun signIn(callback: GoogleSignInCallback)
+}
+
+object GoogleSignInRegistrar {
+    var handler: GoogleSignInHandler? = null
+}
+
 class IosCredentialService : CredentialService {
 
     override suspend fun signInWithGoogle(
         activity: Any?,
         serverClientId: String,
-    ): GoogleSignInResult = GoogleSignInResult.Error(
-        message = "Google Sign-In is not available on iOS. Use Apple Sign-In instead.",
-    )
+    ): GoogleSignInResult = suspendCancellableCoroutine { cont ->
+        val handler = GoogleSignInRegistrar.handler
+        if (handler == null) {
+            if (cont.isActive) {
+                cont.resume(GoogleSignInResult.Error("Google Sign-In이 초기화되지 않았습니다."))
+            }
+            return@suspendCancellableCoroutine
+        }
+        handler.signIn(object : GoogleSignInCallback {
+            override fun onSuccess(idToken: String) {
+                if (cont.isActive) cont.resume(GoogleSignInResult.Success(idToken))
+            }
+            override fun onCancelled() {
+                if (cont.isActive) cont.resume(GoogleSignInResult.Cancelled)
+            }
+            override fun onError(message: String) {
+                if (cont.isActive) cont.resume(GoogleSignInResult.Error(message))
+            }
+        })
+    }
 
     @OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
     override suspend fun signInWithApple(activity: Any?): AppleSignInResult =
@@ -57,7 +87,6 @@ class IosCredentialService : CredentialService {
             val controller = ASAuthorizationController(authorizationRequests = listOf(request))
             controller.delegate = handler
             controller.presentationContextProvider = handler
-            // 핸들러를 cont 의 invokeOnCancellation 에 묶어 GC 지연 — 인증 끝날 때까지 살아있어야 함
             cont.invokeOnCancellation { _ -> handler.detach() }
             controller.performRequests()
         }

--- a/run-ios.sh
+++ b/run-ios.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -e
+
+UDID="49B46EBC-C773-439F-9A3A-35469BDF8FE9"  # iPhone 17 Pro
+BUNDLE_ID="me.pecos.memozy.ios"
+PROJECT_ROOT="$(cd "$(dirname "$0")" && pwd)"
+
+echo "▶ 1/3 Gradle KMM 프레임워크 빌드..."
+cd "$PROJECT_ROOT"
+./gradlew :shared:umbrella:linkDebugFrameworkIosSimulatorArm64
+
+echo "▶ 2/3 Xcode 빌드..."
+xcodebuild \
+  -project "$PROJECT_ROOT/iosApp/iosApp.xcodeproj" \
+  -scheme iosApp \
+  -destination "id=$UDID" \
+  -configuration Debug \
+  build
+
+echo "▶ 3/3 시뮬레이터 실행..."
+xcrun simctl boot "$UDID" 2>/dev/null || true
+open -a Simulator
+
+APP_PATH=$(find ~/Library/Developer/Xcode/DerivedData/iosApp-*/Build/Products/Debug-iphonesimulator -name "iosApp.app" -maxdepth 1 2>/dev/null | head -1)
+xcrun simctl install "$UDID" "$APP_PATH"
+xcrun simctl launch "$UDID" "$BUNDLE_ID"
+
+echo "✅ iOS 앱 실행 완료"

--- a/shared/umbrella/build.gradle.kts
+++ b/shared/umbrella/build.gradle.kts
@@ -68,6 +68,7 @@ kotlin {
             xcf.add(this)
             export(projects.feature.core.viewmodel)
             export(projects.data.repository.memo.api)
+            export(projects.platform.credential.impl)
         }
     }
 
@@ -108,7 +109,7 @@ kotlin {
             implementation(projects.platform.intent.api)
             implementation(projects.platform.intent.impl)
             implementation(projects.platform.credential.api)
-            implementation(projects.platform.credential.impl)
+            api(projects.platform.credential.impl)
             implementation(projects.platform.ads.impl)
             implementation(projects.platform.billing.api)
             implementation(projects.platform.billing.impl)

--- a/shared/umbrella/src/iosMain/kotlin/me/pecos/memozy/shared/umbrella/SharedKoin.kt
+++ b/shared/umbrella/src/iosMain/kotlin/me/pecos/memozy/shared/umbrella/SharedKoin.kt
@@ -195,6 +195,7 @@ fun initKoin() {
     startKoin {
         modules(sharedModule, memoPlainModule)
     }
+    KoinPlatform.getKoin().get<BillingService>().connect()
 }
 
 fun provideMainViewModel(): MainViewModel = KoinPlatform.getKoin().get()


### PR DESCRIPTION
## Summary

iOS 출시 준비 전반. 네이티브 Google/Apple 사인인, 결제 UI 다듬기, 메모 화면 노션 스타일 자동 포커스, 웹 요약 4-style 바텀시트 통합.

## Auth — 네이티브 사인인

- **Google**: GoogleSignIn-iOS SPM + Swift 브릿지 (`IosGoogleSignInBridge`)
  - Supabase OAuth 웹플로우 → GIDSignIn idToken 흐름으로 전환
  - supabase.co 도메인 노출 없음, 메인스레드 즉시 실행으로 ripple 딜레이 제거
- **Apple**: Capability + entitlements, 설정 화면에 버튼 노출
- 다국어화 — 하드코딩 \"Apple 로 계속하기\" 제거, `sign_in_apple` 리소스 (ko/en/ja)
- 계정 버튼 간격 6dp 통일 (테마/데이터 섹션과 일관성)

## Billing

- iOS StoreKit: SKProductsRequest 로깅 강화 (loaded/invalid/error 구분)
- ProductsDelegate GC 방지 (`productsDelegate` 보유)
- 결제 UI 배경 `screenBackground` 통일 (라이트=흰색, 다크=다크그레이)
- 뒤로가기 ↔ \"Memozy Pro\" 좌측 정렬 (offset -12dp)

## 메모 화면

- 메모 진입 시 본문 자동 포커스 + 키보드 (노션 스타일, 신규/편집 공통)
- line-height 1.8x → 1.5x, alignment Center → Top — 커서 위치 자연스럽게
- 본문 아래 빈 영역도 탭하면 포커스 (300dp clickable Spacer)
- 웹 요약 4-style 바텀시트 (간단/상세/노트/언어) — YouTube 동일
- `buildWebPrompt(SummaryStyle, lang)` 오버로드 (NOTE/LANGUAGE 추가)

## ⚠️ 주의사항

- **AI 한도 일시 해제** (`canUseAi = true`) — 테스트용, 출시 전 반드시 원복
- 디버그 로깅 (`[AuthService]`, `[Billing]`) — 머지 후 정리

## Follow-up

- [ ] AI 한도 원복 (canUseAi 정상 로직)
- [ ] 디버그 로깅 정리
- [ ] prod Supabase Google/Apple Provider 동일 설정
- [ ] StoreKit 상품 \"제출 준비 완료\" 상태 (현재 \"메타데이터 누락됨\")
- [ ] 유료 앱 계약 활성화 대기 중

## Test plan

- [ ] iOS 실기기: Google 로그인 → 즉시 OAuth 시트 → 정상 로그인
- [ ] iOS 실기기: Apple 로그인 → Touch/Face ID → 정상 로그인
- [ ] iOS 실기기: Memozy Pro 화면 → 상품 로드 (유료 앱 계약 활성 후)
- [ ] iOS 시뮬: 메모 진입 → 본문 자동 포커스 + 키보드 표시
- [ ] iOS 시뮬: 웹 URL 공유 → 요약 카드 → 4-style 바텀시트 → 요약 정상
- [ ] 다크모드 전환 → 결제 UI 배경 자연스러움
- [ ] 일본어/영어 전환 → Apple/Google 버튼 텍스트 변경

🤖 Generated with [Claude Code](https://claude.com/claude-code)