### PR TITLE
Add: Analytics 이벤트 호출 지점 추가 (Follow-up #322)

### DIFF
--- a/app/src/main/java/me/pecos/memozy/di/ViewModelModule.kt
+++ b/app/src/main/java/me/pecos/memozy/di/ViewModelModule.kt
@@ -27,6 +27,7 @@ val viewModelModule = module {
             memoDao = get(),
             authRepository = get(),
             backupRepository = get(),
+            analyticsService = get(),
         )
     }
 

--- a/feature/core/viewmodel/build.gradle.kts
+++ b/feature/core/viewmodel/build.gradle.kts
@@ -15,6 +15,7 @@ kotlin {
             implementation(projects.data.backup.api)
             implementation(projects.data.repository.user.api)
             implementation(projects.datasource.remote.auth.api)
+            implementation(projects.platform.analytics.api)
             implementation(libs.kotlinx.coroutines.core)
             implementation(libs.kotlinx.serialization.json)
             implementation(libs.androidx.lifecycle.viewmodel)

--- a/feature/core/viewmodel/src/commonMain/kotlin/me/pecos/memozy/feature/core/viewmodel/SettingsViewModel.kt
+++ b/feature/core/viewmodel/src/commonMain/kotlin/me/pecos/memozy/feature/core/viewmodel/SettingsViewModel.kt
@@ -36,6 +36,7 @@ class SettingsViewModel(
     private val memoDao: MemoDao,
     private val authRepository: AuthRepository,
     private val backupRepository: BackupRepository,
+    private val analyticsService: me.pecos.memozy.platform.analytics.AnalyticsService,
 ) : ViewModel() {
 
     private val json = Json {
@@ -114,19 +115,41 @@ class SettingsViewModel(
 
     fun signInWithGoogle(idToken: String) {
         viewModelScope.launch {
-            authRepository.signInWithGoogle(idToken)
+            val result = authRepository.signInWithGoogle(idToken)
+            logSignInResult(result, provider = "google")
         }
     }
 
     fun signInWithApple(idToken: String, rawNonce: String) {
         viewModelScope.launch {
-            authRepository.signInWithApple(idToken, rawNonce)
+            val result = authRepository.signInWithApple(idToken, rawNonce)
+            logSignInResult(result, provider = "apple")
         }
     }
 
     fun signOut() {
         viewModelScope.launch {
             authRepository.signOut()
+            analyticsService.setUserId(null)
+            analyticsService.logEvent(me.pecos.memozy.platform.analytics.AnalyticsEvents.LOGOUT)
+        }
+    }
+
+    private fun logSignInResult(
+        result: Result<me.pecos.memozy.data.datasource.remote.auth.AuthUser>,
+        provider: String,
+    ) {
+        result.onSuccess { user ->
+            analyticsService.setUserId(user.id)
+            analyticsService.logEvent(
+                me.pecos.memozy.platform.analytics.AnalyticsEvents.LOGIN_SUCCEEDED,
+                mapOf(me.pecos.memozy.platform.analytics.AnalyticsParams.PROVIDER to provider),
+            )
+        }.onFailure {
+            analyticsService.logEvent(
+                me.pecos.memozy.platform.analytics.AnalyticsEvents.LOGIN_FAILED,
+                mapOf(me.pecos.memozy.platform.analytics.AnalyticsParams.PROVIDER to provider),
+            )
         }
     }
 

--- a/feature/home/impl/build.gradle.kts
+++ b/feature/home/impl/build.gradle.kts
@@ -115,6 +115,7 @@ kotlin {
             implementation(projects.data.backup.api)
             implementation(projects.platform.billing.api)
             implementation(projects.platform.ads.api)
+            implementation(projects.platform.analytics.api)
             implementation(projects.platform.credential.api)
             implementation(projects.platform.intent.api)
             implementation(libs.haze)

--- a/feature/home/impl/src/commonMain/kotlin/me/pecos/memozy/presentation/screen/subscription/SubscriptionScreen.kt
+++ b/feature/home/impl/src/commonMain/kotlin/me/pecos/memozy/presentation/screen/subscription/SubscriptionScreen.kt
@@ -85,7 +85,22 @@ fun SubscriptionScreen(
     val fontSettings = LocalFontSettings.current
     val activity = LocalActivity.current
     val urlLauncher: UrlLauncher = koinInject()
+    val analyticsService: me.pecos.memozy.platform.analytics.AnalyticsService = koinInject()
     val isSystemDark = colors.screenBackground == Color(0xFF1C1C1E)
+
+    androidx.compose.runtime.LaunchedEffect(Unit) {
+        analyticsService.logEvent(
+            me.pecos.memozy.platform.analytics.AnalyticsEvents.SUBSCRIPTION_VIEWED,
+        )
+    }
+
+    androidx.compose.runtime.LaunchedEffect(purchaseState) {
+        if (purchaseState is PurchaseState.Success) {
+            analyticsService.logEvent(
+                me.pecos.memozy.platform.analytics.AnalyticsEvents.SUBSCRIPTION_PURCHASED,
+            )
+        }
+    }
 
     if (purchaseState is PurchaseState.Success) {
         AppPopup(

--- a/feature/memo-plain/impl/build.gradle.kts
+++ b/feature/memo-plain/impl/build.gradle.kts
@@ -25,6 +25,7 @@ kotlin {
             implementation(projects.datasource.remote.ai.api)
             implementation(projects.platform.media.api)
             implementation(projects.platform.intent.api)
+            implementation(projects.platform.analytics.api)
             implementation(libs.haze)
             implementation(libs.koin.core)
             implementation(libs.koin.compose)

--- a/feature/memo-plain/impl/src/commonMain/kotlin/me/pecos/memozy/feature/memoplain/impl/MemoPlainNavigationImpl.kt
+++ b/feature/memo-plain/impl/src/commonMain/kotlin/me/pecos/memozy/feature/memoplain/impl/MemoPlainNavigationImpl.kt
@@ -90,7 +90,8 @@ class MemoPlainNavigationImpl(
     private val youtubeSummaryDao: YoutubeSummaryDao,
     private val captionService: YouTubeCaptionService,
     private val aiUsageDao: AiUsageDao,
-    private val webScrapeService: me.pecos.memozy.data.datasource.remote.ai.WebScrapeService
+    private val webScrapeService: me.pecos.memozy.data.datasource.remote.ai.WebScrapeService,
+    private val analyticsService: me.pecos.memozy.platform.analytics.AnalyticsService,
 ) : MemoPlainNavigation {
 
     // 화면 dispose 후에도 살아있어야 하는 저장 작업용 (싱글톤 라이프타임)
@@ -436,6 +437,9 @@ class MemoPlainNavigationImpl(
             var showLimitBottomSheet by remember { mutableStateOf(false) }
             val notifyAiBlocked: () -> Unit = {
                 if (!isLoggedIn) showLoginPrompt = true else showLimitBottomSheet = true
+                analyticsService.logEvent(
+                    me.pecos.memozy.platform.analytics.AnalyticsEvents.AI_LIMIT_REACHED,
+                )
             }
 
             // 이미지 OCR 처리
@@ -769,6 +773,10 @@ class MemoPlainNavigationImpl(
                         notifyAiBlocked()
                         return@MemoScreen
                     }
+                    analyticsService.logEvent(
+                        me.pecos.memozy.platform.analytics.AnalyticsEvents.WEB_SUMMARY_REQUESTED,
+                        mapOf(me.pecos.memozy.platform.analytics.AnalyticsParams.SUMMARY_STYLE to style.name),
+                    )
                     currentSummarizeJob?.cancel()
                     currentSummarizeJob = scope.launch {
                         isWebSummarizing = true
@@ -803,6 +811,10 @@ class MemoPlainNavigationImpl(
                 },
                 onSummaryStyleSelected = { style, url ->
                     activeSummaryStyle = style
+                    analyticsService.logEvent(
+                        me.pecos.memozy.platform.analytics.AnalyticsEvents.YOUTUBE_SUMMARY_REQUESTED,
+                        mapOf(me.pecos.memozy.platform.analytics.AnalyticsParams.SUMMARY_STYLE to style.name),
+                    )
                     // 바텀시트에서 양식 선택 시 즉시 요약 실행
                     currentSummarizeJob?.cancel()
                     currentSummarizeJob = scope.launch {
@@ -950,6 +962,9 @@ class MemoPlainNavigationImpl(
                 onDelete = if (memoId > 0) { id ->
                     scope.launch {
                         repository.deleteMemo(id)
+                        analyticsService.logEvent(
+                            me.pecos.memozy.platform.analytics.AnalyticsEvents.MEMO_DELETED,
+                        )
                         onNavigateToHome()
                     }
                 } else null,

--- a/feature/memo-plain/impl/src/commonMain/kotlin/me/pecos/memozy/feature/memoplain/impl/di/MemoPlainModule.kt
+++ b/feature/memo-plain/impl/src/commonMain/kotlin/me/pecos/memozy/feature/memoplain/impl/di/MemoPlainModule.kt
@@ -13,6 +13,7 @@ val memoPlainModule = module {
             captionService = get(),
             aiUsageDao = get(),
             webScrapeService = get(),
+            analyticsService = get(),
         )
     }
 }

--- a/shared/umbrella/src/iosMain/kotlin/me/pecos/memozy/shared/umbrella/SharedKoin.kt
+++ b/shared/umbrella/src/iosMain/kotlin/me/pecos/memozy/shared/umbrella/SharedKoin.kt
@@ -192,6 +192,7 @@ val sharedModule: Module = module {
             memoDao = get(),
             authRepository = get(),
             backupRepository = get(),
+            analyticsService = get(),
         )
     }
 }


### PR DESCRIPTION
## Summary

PR #325 (Firebase Analytics 인프라) 후속 — 주요 사용자 행동에 \`logEvent\` 호출 추가. 출시 직후부터 데이터 수집 시작.

## 추가된 이벤트

### 🔐 인증 (\`SettingsViewModel\`)
- \`login_succeeded\` (provider: google/apple) — \`setUserId(uid)\` 동기 설정
- \`login_failed\` (provider)
- \`logout\` — \`setUserId(null)\`

### 🤖 AI 요약 (\`MemoPlainNavigationImpl\`)
- \`youtube_summary_requested\` (\`summary_style\`: SIMPLE/DETAILED/NOTE/LANGUAGE)
- \`web_summary_requested\` (\`summary_style\`)
- \`ai_limit_reached\` — 한도 도달 시점

### 📝 메모
- \`memo_deleted\`

### 💳 구독 (\`SubscriptionScreen\`)
- \`subscription_viewed\` — 화면 진입
- \`subscription_purchased\` — \`PurchaseState.Success\` 시점

## DI 변경

- \`SettingsViewModel\` 생성자에 \`analyticsService\` 추가 (Android \`ViewModelModule\` + iOS \`SharedKoin\` 동기화)
- \`MemoPlainNavigationImpl\` 생성자에 \`analyticsService\` 추가 (\`MemoPlainModule\`)
- \`SubscriptionScreen\` 은 \`koinInject()\` 직접 주입
- 관련 모듈 build.gradle.kts 에 \`platform.analytics.api\` 의존성 추가

## Follow-up

- [ ] 메모 생성/업데이트 이벤트 (repository.upsertMemo 분기 정리 후 별도)
- [ ] User properties (구독 tier, language 등)
- [ ] DebugView 검증 (Android Studio Logcat + Xcode Console 에서 -FIRDebugEnabled)

## Test plan

- [x] Android \`./gradlew :app:compileDebugKotlin\` ✅
- [x] iOS \`./gradlew :shared:umbrella:linkDebugFrameworkIosSimulatorArm64\` ✅
- [ ] 실제 디바이스에서 각 이벤트 발생시키고 Firebase Console DebugView 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)