### PR TITLE
Add: #294 RevenueCat webhook Edge Function + user_subscriptions 캐시 (Epic 섹션 4)

### DIFF
--- a/supabase/functions/revenuecat-webhook/.npmrc
+++ b/supabase/functions/revenuecat-webhook/.npmrc
@@ -1,0 +1,3 @@
+# Configuration for private npm package dependencies
+# For more information on using private registries with Edge Functions, see:
+# https://supabase.com/docs/guides/functions/import-maps#importing-from-private-registries

--- a/supabase/functions/revenuecat-webhook/deno.json
+++ b/supabase/functions/revenuecat-webhook/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "@supabase/functions-js": "jsr:@supabase/functions-js@^2"
+  }
+}

--- a/supabase/functions/revenuecat-webhook/index.ts
+++ b/supabase/functions/revenuecat-webhook/index.ts
@@ -1,0 +1,172 @@
+import "@supabase/functions-js/edge-runtime.d.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.39.3";
+
+// RevenueCat 대시보드에서 webhook URL 등록 시 Authorization 헤더 값 설정 →
+// 이 환경변수와 정확히 일치해야 통과. RC 는 HMAC signing 미제공이라 단순 토큰 비교.
+const RC_AUTH = Deno.env.get("REVENUECAT_WEBHOOK_AUTH");
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
+const SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+
+// RevenueCat 대시보드에 정의된 entitlement id (Epic 섹션 1).
+const ENTITLEMENT_PRO = "pro";
+
+// ── 타입 ──────────────────────────────────────────────────────────────
+interface RevenueCatEvent {
+  type: string;
+  id: string;
+  app_user_id: string;
+  product_id?: string;
+  entitlement_ids?: string[] | null;
+  expiration_at_ms?: number | null;
+  purchased_at_ms?: number | null;
+  event_timestamp_ms?: number | null;
+  store?: string | null;
+}
+
+interface RevenueCatPayload {
+  api_version?: string;
+  event?: RevenueCatEvent;
+}
+
+type TierChange = "GRANT" | "REVOKE" | "NEUTRAL";
+
+// ── 유틸 ──────────────────────────────────────────────────────────────
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function isSupabaseUserId(value: string): boolean {
+  return UUID_REGEX.test(value);
+}
+
+// 이벤트 타입 → tier 방향 매핑.
+// Epic 섹션 5 라이프사이클: 갱신/만료/은혜기간/취소 모두 여기서 분기.
+function deriveTierChange(eventType: string): TierChange {
+  switch (eventType) {
+    case "INITIAL_PURCHASE":
+    case "RENEWAL":
+    case "UNCANCELLATION":
+    case "PRODUCT_CHANGE":
+    case "SUBSCRIPTION_EXTENDED":
+    case "TEMPORARY_ENTITLEMENT_GRANT":
+    case "TRANSFER":
+      return "GRANT";
+    case "EXPIRATION":
+    case "CANCELLATION":
+      return "REVOKE";
+    case "BILLING_ISSUE":
+    case "SUBSCRIPTION_PAUSED":
+      // 은혜기간/일시정지 — 진행 중에는 entitlement 유지. RC 가 종료 시 EXPIRATION 으로 finalize.
+      return "NEUTRAL";
+    default:
+      return "NEUTRAL";
+  }
+}
+
+function msToIso(ms: number | null | undefined): string | null {
+  if (ms == null) return null;
+  return new Date(ms).toISOString();
+}
+
+function jsonResponse(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+// ── 핸들러 ────────────────────────────────────────────────────────────
+Deno.serve(async (req) => {
+  if (req.method !== "POST") {
+    return jsonResponse({ error: "Method Not Allowed" }, 405);
+  }
+
+  const got = req.headers.get("authorization");
+  if (!RC_AUTH || !got || got !== RC_AUTH) {
+    return jsonResponse({ error: "Unauthorized" }, 401);
+  }
+
+  let payload: RevenueCatPayload;
+  try {
+    payload = await req.json();
+  } catch {
+    return jsonResponse({ error: "Invalid JSON" }, 400);
+  }
+
+  const event = payload.event;
+  if (!event?.type || !event?.id || !event?.app_user_id) {
+    return jsonResponse({ error: "Missing event fields" }, 400);
+  }
+
+  const userId = event.app_user_id;
+
+  // 익명 RC user (logIn 전 발급된 $RCAnonymousID:...) 또는 외부 식별자는 무시.
+  // 클라이언트가 Supabase 로그인 시점에 awaitLogIn(supabaseUserId) 호출하므로
+  // PRO 결제 후 webhook 의 app_user_id 는 항상 Supabase UUID 형식이어야 함.
+  if (!isSupabaseUserId(userId)) {
+    return jsonResponse({ ignored: "non_supabase_user", app_user_id: userId }, 200);
+  }
+
+  // entitlement_ids 에 "pro" 가 없으면 우리가 관심 없는 이벤트(도네이션 등).
+  // entitlement_ids 가 null/undefined 인 경우(NON_RENEWING_PURCHASE 등)도 동일 처리.
+  if (!event.entitlement_ids?.includes(ENTITLEMENT_PRO)) {
+    return jsonResponse({ ignored: "other_entitlement", type: event.type }, 200);
+  }
+
+  const supabase = createClient(SUPABASE_URL, SERVICE_ROLE_KEY);
+
+  // Idempotency — RC 가 동일 event.id 를 재전송할 수 있음.
+  const { data: existing, error: selectError } = await supabase
+    .from("user_subscriptions")
+    .select("last_event_id")
+    .eq("user_id", userId)
+    .maybeSingle();
+
+  if (selectError) {
+    console.error("Select user_subscriptions failed:", selectError);
+    return jsonResponse({ error: selectError.message }, 500);
+  }
+
+  if (existing?.last_event_id === event.id) {
+    return jsonResponse({ idempotent: true, event_id: event.id }, 200);
+  }
+
+  const tierChange = deriveTierChange(event.type);
+
+  // upsert payload 구성 — NEUTRAL 이면 last_event_* 만 갱신.
+  const update: Record<string, unknown> = {
+    user_id: userId,
+    last_event_id: event.id,
+    last_event_type: event.type,
+    last_event_at: msToIso(event.event_timestamp_ms) ?? new Date().toISOString(),
+  };
+
+  if (tierChange === "GRANT") {
+    update.tier = "PRO";
+    update.entitlement_id = ENTITLEMENT_PRO;
+    update.product_id = event.product_id ?? null;
+    update.store = event.store ?? null;
+    update.purchased_at = msToIso(event.purchased_at_ms);
+    update.expires_at = msToIso(event.expiration_at_ms);
+  } else if (tierChange === "REVOKE") {
+    update.tier = "FREE";
+    update.entitlement_id = null;
+    update.product_id = null;
+    update.store = null;
+    update.purchased_at = null;
+    update.expires_at = null;
+  }
+
+  const { error: upsertError } = await supabase
+    .from("user_subscriptions")
+    .upsert(update, { onConflict: "user_id" });
+
+  if (upsertError) {
+    console.error("Upsert user_subscriptions failed:", upsertError);
+    return jsonResponse({ error: upsertError.message }, 500);
+  }
+
+  return jsonResponse({
+    ok: true,
+    type: event.type,
+    tier_change: tierChange,
+  }, 200);
+});

--- a/supabase/migrations/20260505_001_create_user_subscriptions.sql
+++ b/supabase/migrations/20260505_001_create_user_subscriptions.sql
@@ -1,0 +1,52 @@
+-- ============================================================
+-- RevenueCat 구독 캐시 테이블
+-- Issue: #294 (Epic 섹션 4)
+--
+-- revenuecat-webhook Edge Function 이 entitlement 변경 이벤트를 받아 이 테이블에 캐시.
+-- 클라이언트의 진실은 RC SDK(`awaitCustomerInfoResult()`) — 이 테이블은 서버측
+-- gating/조회용 캐시일 뿐. 정합성 깨질 시 클라이언트가 RC 로 재동기화.
+-- ============================================================
+
+CREATE TABLE public.user_subscriptions (
+    user_id              UUID REFERENCES auth.users(id) ON DELETE CASCADE PRIMARY KEY,
+    tier                 TEXT NOT NULL DEFAULT 'FREE' CHECK (tier IN ('FREE', 'PRO')),
+    entitlement_id       TEXT,
+    product_id           TEXT,
+    store                TEXT,           -- APP_STORE / PLAY_STORE / STRIPE / PROMOTIONAL / AMAZON / MAC_APP_STORE
+    purchased_at         TIMESTAMPTZ,
+    expires_at           TIMESTAMPTZ,
+    last_event_id        TEXT,           -- RC event.id — webhook idempotency key
+    last_event_type      TEXT,
+    last_event_at        TIMESTAMPTZ,
+    updated_at           TIMESTAMPTZ DEFAULT now() NOT NULL
+);
+
+CREATE INDEX idx_user_subscriptions_expires ON public.user_subscriptions(expires_at)
+    WHERE tier = 'PRO' AND expires_at IS NOT NULL;
+
+ALTER TABLE public.user_subscriptions ENABLE ROW LEVEL SECURITY;
+
+-- 본인 행만 읽기 — Edge Function gating / 클라이언트 조회 모두 cover
+CREATE POLICY "Users read own subscription"
+    ON public.user_subscriptions FOR SELECT
+    USING (auth.uid() = user_id);
+
+-- 클라이언트 직접 쓰기 차단 — service_role(webhook) 만 INSERT/UPDATE/DELETE 가능
+CREATE POLICY "Block client writes"
+    ON public.user_subscriptions FOR ALL
+    USING (false)
+    WITH CHECK (false);
+
+-- updated_at 자동 갱신
+CREATE OR REPLACE FUNCTION public.update_user_subscriptions_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = now();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_user_subscriptions_updated_at
+    BEFORE UPDATE ON public.user_subscriptions
+    FOR EACH ROW
+    EXECUTE FUNCTION public.update_user_subscriptions_updated_at();


### PR DESCRIPTION
## Summary
- RevenueCat webhook 수신용 Supabase Edge Function 추가
- entitlement 변경 이벤트를 `public.user_subscriptions` 캐시 테이블에 동기화
- 클라이언트 진실은 여전히 RC SDK; 이 캐시는 서버측 gating + 빠른 조회용

#294 Epic 섹션 4 (Supabase Edge Function 동기화). #332 (클라이언트측 RC 교체) 와 독립적으로 머지 가능.

## 변경 구성
| 파일 | 내용 |
|---|---|
| `supabase/migrations/20260505_001_create_user_subscriptions.sql` | 캐시 테이블 + RLS (service_role 만 쓰기) + updated_at 트리거 |
| `supabase/functions/revenuecat-webhook/index.ts` | Authorization 헤더 검증 → idempotency 체크 → tier 매핑 → upsert |
| `supabase/functions/revenuecat-webhook/deno.json` | functions-js import map |
| `supabase/functions/revenuecat-webhook/.npmrc` | 다른 함수와 동일 placeholder |

## 설계 결정
- **Authorization 헤더 정확 일치 검증** — RC 가 HMAC signing 미제공이라 단순 토큰 비교. 대시보드 등록 시 강한 random 토큰 권장.
- **app_user_id UUID 검증** — 익명 RC user(\`\$RCAnonymousID:...\`)나 외부 식별자는 무시. 클라이언트가 Supabase 로그인 시 \`awaitLogIn(supabaseUserId)\` 호출하므로 PRO 결제는 항상 Supabase UUID.
- **entitlement_ids 필터** — \"pro\" 없는 이벤트는 무시 (도네이션, 다른 entitlement).
- **Idempotency via \`last_event_id\`** — RC 가 동일 event.id 를 재전송할 수 있어 row 단위 마지막 처리 이벤트 기록.
- **이벤트 → tier 매핑**:
  - GRANT: \`INITIAL_PURCHASE\` / \`RENEWAL\` / \`UNCANCELLATION\` / \`PRODUCT_CHANGE\` / \`SUBSCRIPTION_EXTENDED\` / \`TEMPORARY_ENTITLEMENT_GRANT\` / \`TRANSFER\`
  - REVOKE: \`EXPIRATION\` / \`CANCELLATION\`
  - NEUTRAL: \`BILLING_ISSUE\` / \`SUBSCRIPTION_PAUSED\` — 은혜기간 동안 entitlement 유지, RC 가 종료 시 \`EXPIRATION\` 으로 finalize
- **service_role 사용** — RLS 가 클라이언트 쓰기를 차단하므로 webhook 은 service_role 키로 RLS 우회.

## 🚧 Draft 사유 — 머지 전 필수
1. **RevenueCat 대시보드 셋업 + webhook 등록** (#332 의존)
   - Edge Function URL 등록
   - Authorization 헤더 값 설정 (대시보드)
2. **Supabase 환경변수 설정**
   - \`REVENUECAT_WEBHOOK_AUTH\` = 위 Authorization 값과 동일
   - \`SUPABASE_SERVICE_ROLE_KEY\`, \`SUPABASE_URL\` (이미 다른 function 에서 사용 중)
3. **Migration 적용** — \`supabase db push\` 또는 dashboard SQL editor
4. **Function 배포** — \`supabase functions deploy revenuecat-webhook\`

## 검증 상태
- ✅ 코드 manual review (Deno/Supabase CLI 미설치 환경이라 type-check 미수행)
- ❌ 런타임 — RC 대시보드/webhook 등록 후

## Test plan
- [ ] RC dashboard test event 전송 → 200 + 적절한 \`tier_change\` 응답
- [ ] 잘못된 Authorization → 401
- [ ] 같은 event.id 재전송 → 200 \`{ idempotent: true }\`
- [ ] 익명 app_user_id → 200 \`{ ignored: \"non_supabase_user\" }\`
- [ ] 도네이션 이벤트 → 200 \`{ ignored: \"other_entitlement\" }\`
- [ ] INITIAL_PURCHASE → \`tier=PRO\`, expires_at 적절히 설정
- [ ] EXPIRATION → \`tier=FREE\`, 캐시 컬럼 null
- [ ] BILLING_ISSUE → tier 변경 없이 last_event_* 만 갱신
- [ ] RLS: 일반 클라이언트 키로 다른 user_id 행 SELECT 차단 확인

## 후속 (이 PR 범위 외)
- 캐시 컬럼 활용 — Tier 게이팅 (Epic 섹션 6 / #209 / #190): 한도 체크 Edge Function 에서 \`user_subscriptions\` 조회 후 분기
- 클라이언트 측 fallback 보강 — RC SDK 실패 시 이 테이블 조회 (선택)

🤖 Generated with [Claude Code](https://claude.com/claude-code)