### PR TITLE
Add: #294 라이프사이클 매핑 + 복원 플로우 + UI 노출 (Epic 섹션 5)

### DIFF
--- a/feature/core/resource/src/commonMain/composeResources/values-en/strings.xml
+++ b/feature/core/resource/src/commonMain/composeResources/values-en/strings.xml
@@ -265,6 +265,9 @@
     <string name="subscription_current_plan">Current plan</string>
     <string name="subscription_manage">Manage subscription</string>
     <string name="subscription_restore">Restore purchases</string>
+    <string name="subscription_status_renews_at">Renews on %s</string>
+    <string name="subscription_status_expires_at">Expires on %s</string>
+    <string name="subscription_status_grace_period">Billing issue — please resolve by %s</string>
 
     <!-- Memozy AI -->
     <string name="memozy_ai">Memozy AI</string>

--- a/feature/core/resource/src/commonMain/composeResources/values-ja/strings.xml
+++ b/feature/core/resource/src/commonMain/composeResources/values-ja/strings.xml
@@ -265,6 +265,9 @@
     <string name="subscription_current_plan">現在のプラン</string>
     <string name="subscription_manage">サブスクリプション管理</string>
     <string name="subscription_restore">購入を復元</string>
+    <string name="subscription_status_renews_at">%sに自動更新</string>
+    <string name="subscription_status_expires_at">%sに期限切れ</string>
+    <string name="subscription_status_grace_period">決済の問題 — %sまでに解決してください</string>
 
     <!-- Memozy AI -->
     <string name="memozy_ai">Memozy AI</string>

--- a/feature/core/resource/src/commonMain/composeResources/values/strings.xml
+++ b/feature/core/resource/src/commonMain/composeResources/values/strings.xml
@@ -265,6 +265,9 @@
     <string name="subscription_current_plan">현재 이용 중</string>
     <string name="subscription_manage">구독 관리</string>
     <string name="subscription_restore">구매 복원</string>
+    <string name="subscription_status_renews_at">%s에 자동 갱신</string>
+    <string name="subscription_status_expires_at">%s에 만료</string>
+    <string name="subscription_status_grace_period">결제 문제 발생 — %s까지 해결 필요</string>
 
     <!-- Login Prompt -->
     <string name="login_prompt_title">로그인이 필요해요</string>

--- a/feature/home/impl/src/commonMain/kotlin/me/pecos/memozy/presentation/screen/subscription/SubscriptionScreen.kt
+++ b/feature/home/impl/src/commonMain/kotlin/me/pecos/memozy/presentation/screen/subscription/SubscriptionScreen.kt
@@ -52,13 +52,21 @@ import me.pecos.memozy.feature.core.resource.generated.resources.subscription_fe
 import me.pecos.memozy.feature.core.resource.generated.resources.subscription_manage
 import me.pecos.memozy.feature.core.resource.generated.resources.subscription_monthly
 import me.pecos.memozy.feature.core.resource.generated.resources.subscription_restore
+import me.pecos.memozy.feature.core.resource.generated.resources.subscription_status_expires_at
+import me.pecos.memozy.feature.core.resource.generated.resources.subscription_status_grace_period
+import me.pecos.memozy.feature.core.resource.generated.resources.subscription_status_renews_at
 import me.pecos.memozy.feature.core.resource.generated.resources.subscription_title
 import me.pecos.memozy.feature.core.resource.generated.resources.subscription_yearly
 import me.pecos.memozy.feature.core.resource.generated.resources.subscription_yearly_discount
 import me.pecos.memozy.platform.ads.AdsService
 import me.pecos.memozy.platform.billing.BillingService
 import me.pecos.memozy.platform.billing.PurchaseState
+import me.pecos.memozy.platform.billing.SubscriptionDetail
 import me.pecos.memozy.platform.intent.UrlLauncher
+import me.pecos.memozy.presentation.util.stringResourceFormatted
+import kotlin.time.Instant
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.koinInject
 import me.pecos.memozy.presentation.components.AppPopup
@@ -79,6 +87,7 @@ fun SubscriptionScreen(
 ) {
     val subscriptionProducts by billingService.subscriptionProducts.collectAsState()
     val purchaseState by billingService.purchaseState.collectAsState()
+    val subscriptionDetail by billingService.subscriptionDetail.collectAsState()
     val currentTier = LocalSubscriptionTier.current
     val isLoggedIn = LocalIsLoggedIn.current
     val colors = LocalAppColors.current
@@ -190,6 +199,11 @@ fun SubscriptionScreen(
                                 .clip(RoundedCornerShape(6.dp))
                                 .background(colors.chipText.copy(alpha = 0.1f))
                                 .padding(horizontal = 10.dp, vertical = 4.dp)
+                        )
+                        SubscriptionLifecycleStatus(
+                            detail = subscriptionDetail,
+                            textColor = colors.textSecondary,
+                            fontSize = fontSettings.scaled(12),
                         )
                     }
                 }
@@ -369,13 +383,47 @@ fun SubscriptionScreen(
                 textAlign = TextAlign.Center,
                 modifier = Modifier
                     .fillMaxWidth()
-                    .clickable { billingService.queryExistingSubscriptions() }
+                    .clickable { billingService.restorePurchases() }
                     .padding(12.dp)
             )
 
             Spacer(modifier = Modifier.height(24.dp))
         }
     }
+}
+
+@Composable
+private fun SubscriptionLifecycleStatus(
+    detail: SubscriptionDetail,
+    textColor: Color,
+    fontSize: androidx.compose.ui.unit.TextUnit,
+) {
+    val expiresAt = detail.expiresAt ?: return
+    val dateText = formatDate(expiresAt)
+    val statusText = when {
+        detail.inGracePeriod -> stringResourceFormatted(
+            Res.string.subscription_status_grace_period, dateText
+        )
+        detail.willRenew -> stringResourceFormatted(
+            Res.string.subscription_status_renews_at, dateText
+        )
+        else -> stringResourceFormatted(
+            Res.string.subscription_status_expires_at, dateText
+        )
+    }
+    Spacer(modifier = Modifier.height(6.dp))
+    Text(
+        text = statusText,
+        fontSize = fontSize,
+        color = textColor,
+    )
+}
+
+private fun formatDate(instant: Instant): String {
+    val date = instant.toLocalDateTime(TimeZone.currentSystemDefault()).date
+    val month = (date.month.ordinal + 1).toString().padStart(2, '0')
+    val day = date.day.toString().padStart(2, '0')
+    return "${date.year}-$month-$day"
 }
 
 @Composable

--- a/platform/billing/api/src/commonMain/kotlin/me/pecos/memozy/platform/billing/BillingService.kt
+++ b/platform/billing/api/src/commonMain/kotlin/me/pecos/memozy/platform/billing/BillingService.kt
@@ -1,5 +1,6 @@
 package me.pecos.memozy.platform.billing
 
+import kotlin.time.Instant
 import kotlinx.coroutines.flow.StateFlow
 import me.pecos.memozy.presentation.theme.SubscriptionTier
 
@@ -18,6 +19,32 @@ data class SubscriptionProduct(
     val billingPeriod: String,
 )
 
+/**
+ * 구독 라이프사이클 상태 — entitlement 활성/만료일/자동갱신/은혜기간 등 UI 노출용 정보.
+ *
+ * RC `EntitlementInfo` 의 핵심 필드 매핑 (#294 Epic 섹션 5).
+ * FREE 사용자는 [Empty] 싱글톤.
+ */
+data class SubscriptionDetail(
+    val tier: SubscriptionTier,
+    val productId: String?,
+    val expiresAt: Instant?,
+    /** RC `willRenew` — 자동 갱신 예정 여부. false 면 만료일에 PRO 종료. */
+    val willRenew: Boolean,
+    /** RC `billingIssueDetectedAt` 가 셋 + entitlement 활성 → 결제 실패 후 은혜기간 진행 중. */
+    val inGracePeriod: Boolean,
+) {
+    companion object {
+        val Empty = SubscriptionDetail(
+            tier = SubscriptionTier.FREE,
+            productId = null,
+            expiresAt = null,
+            willRenew = false,
+            inGracePeriod = false,
+        )
+    }
+}
+
 sealed class PurchaseState {
     data object Idle : PurchaseState()
     data object Loading : PurchaseState()
@@ -31,12 +58,18 @@ interface BillingService {
     val purchaseState: StateFlow<PurchaseState>
     val isConnected: StateFlow<Boolean>
     val subscriptionTier: StateFlow<SubscriptionTier>
+    val subscriptionDetail: StateFlow<SubscriptionDetail>
 
     fun connect()
     fun disconnect()
     fun launchPurchaseFlow(activity: Any?, productId: String)
     fun launchSubscriptionFlow(activity: Any?, productId: String)
     fun queryExistingSubscriptions()
+    /**
+     * 다른 기기/계정에서 구매한 구독을 현재 RC appUserId 로 복원 시도.
+     * 결과는 [purchaseState] 로 흘러간다 (Loading → Success/Error).
+     */
+    fun restorePurchases()
     fun isProductAvailable(productId: String): Boolean
     fun resetPurchaseState()
 

--- a/platform/billing/impl/src/commonMain/kotlin/me/pecos/memozy/platform/billing/RevenueCatBillingService.kt
+++ b/platform/billing/impl/src/commonMain/kotlin/me/pecos/memozy/platform/billing/RevenueCatBillingService.kt
@@ -2,6 +2,7 @@ package me.pecos.memozy.platform.billing
 
 import com.revenuecat.purchases.kmp.Purchases
 import com.revenuecat.purchases.kmp.models.CustomerInfo
+import com.revenuecat.purchases.kmp.models.EntitlementInfo
 import com.revenuecat.purchases.kmp.models.Package
 import com.revenuecat.purchases.kmp.models.Period
 import com.revenuecat.purchases.kmp.models.PeriodUnit
@@ -14,6 +15,8 @@ import com.revenuecat.purchases.kmp.result.awaitLogInResult
 import com.revenuecat.purchases.kmp.result.awaitLogOutResult
 import com.revenuecat.purchases.kmp.result.awaitOfferingsResult
 import com.revenuecat.purchases.kmp.result.awaitPurchaseResult
+import com.revenuecat.purchases.kmp.result.awaitRestoreResult
+import kotlin.time.Instant
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -60,6 +63,9 @@ class RevenueCatBillingService(
 
     private val _subscriptionTier = MutableStateFlow(SubscriptionTier.FREE)
     override val subscriptionTier: StateFlow<SubscriptionTier> = _subscriptionTier.asStateFlow()
+
+    private val _subscriptionDetail = MutableStateFlow(SubscriptionDetail.Empty)
+    override val subscriptionDetail: StateFlow<SubscriptionDetail> = _subscriptionDetail.asStateFlow()
 
     override fun connect() {
         if (!Purchases.isConfigured) {
@@ -115,6 +121,22 @@ class RevenueCatBillingService(
 
     override fun queryExistingSubscriptions() {
         scope.launch { refreshCustomerInfo() }
+    }
+
+    override fun restorePurchases() {
+        if (!Purchases.isConfigured) {
+            _purchaseState.value = PurchaseState.Error("결제 서비스가 준비되지 않았습니다.")
+            return
+        }
+        _purchaseState.value = PurchaseState.Loading
+        scope.launch {
+            Purchases.sharedInstance.awaitRestoreResult()
+                .onSuccess { info ->
+                    applyCustomerInfo(info)
+                    _purchaseState.value = PurchaseState.Success
+                }
+                .onFailure { handlePurchaseFailure(it) }
+        }
     }
 
     override fun isProductAvailable(productId: String): Boolean =
@@ -198,10 +220,13 @@ class RevenueCatBillingService(
     }
 
     private fun applyCustomerInfo(info: CustomerInfo) {
-        _subscriptionTier.value = if (info.entitlements.active.containsKey(ENTITLEMENT_PRO)) {
-            SubscriptionTier.PRO
+        val proEntitlement = info.entitlements.active[ENTITLEMENT_PRO]
+        if (proEntitlement != null) {
+            _subscriptionTier.value = SubscriptionTier.PRO
+            _subscriptionDetail.value = proEntitlement.toSubscriptionDetail()
         } else {
-            SubscriptionTier.FREE
+            _subscriptionTier.value = SubscriptionTier.FREE
+            _subscriptionDetail.value = SubscriptionDetail.Empty
         }
     }
 
@@ -242,3 +267,12 @@ private fun Period.toIso8601(): String = when (unit) {
     PeriodUnit.YEAR -> "P${value}Y"
     PeriodUnit.UNKNOWN -> ""
 }
+
+private fun EntitlementInfo.toSubscriptionDetail(): SubscriptionDetail = SubscriptionDetail(
+    tier = SubscriptionTier.PRO,
+    productId = productIdentifier,
+    expiresAt = expirationDateMillis?.let { Instant.fromEpochMilliseconds(it) },
+    willRenew = willRenew,
+    // billingIssueDetectedAt 가 셋이고 entitlement 가 여전히 active → RC 가 grace period 처리 중.
+    inGracePeriod = billingIssueDetectedAtMillis != null && isActive,
+)


### PR DESCRIPTION
## Summary
- entitlement 활성/비활성 binary 매핑을 \`SubscriptionDetail\` (expiresAt, willRenew, inGracePeriod, productId)로 확장
- SubscriptionScreen 에 갱신/만료/은혜기간 상태 텍스트 노출
- 잘못 와이어 된 \"구매 복원\" 버튼을 RC \`awaitRestoreResult\` 로 교체

#294 Epic 섹션 5. **base = \`feature/294-revenuecat-billing-impl\` (PR #332)** 위에 chain — #332 머지 후 develop 으로 re-target.

## 변경 구성
| 분류 | 변경 |
|---|---|
| API 확장 | \`SubscriptionDetail\` 데이터 클래스, \`BillingService.subscriptionDetail\` StateFlow, \`restorePurchases()\` 추가 |
| Impl | \`applyCustomerInfo\` 가 \`EntitlementInfo\` 의 \`expirationDateMillis\`/\`willRenew\`/\`billingIssueDetectedAtMillis\` 를 매핑. \`restorePurchases\` 가 \`awaitRestoreResult\` 호출 |
| UI | SubscriptionScreen 에 라이프사이클 상태 텍스트 + 복원 버튼 실제 RC 복원 호출 |
| i18n | 3 locales (한국어 default / en / ja) 에 3개 신규 string |

## 매핑 로직
| 조건 | 노출 |
|---|---|
| entitlement \"pro\" active + \`willRenew=true\` | \`{만료일}에 자동 갱신\` |
| entitlement \"pro\" active + \`willRenew=false\` | \`{만료일}에 만료\` |
| entitlement \"pro\" active + \`billingIssueDetectedAtMillis != null\` | \`결제 문제 발생 — {만료일}까지 해결 필요\` |
| entitlement 미활성 (FREE) | 텍스트 없음 |

## 설계 결정
- **\`SubscriptionDetail.expiresAt: kotlin.time.Instant?\`** — 메모리 정책(kotlin.time.Instant 우선) 따름. 표시 시 \`kotlinx.datetime.toLocalDateTime\` 으로 \`yyyy-MM-dd\` 포맷.
- **복원 ≠ 캐시 갱신** — 기존 코드는 \`queryExistingSubscriptions()\` (=\`refreshCustomerInfo\` 만 호출, RC 캐시만 봄) 호출. 실제 \"다른 기기에서 산 구독 복원\"은 \`awaitRestoreResult\` 로 Apple/Google 에 능동 요청 필요. 교체.
- **\`SubscriptionDetail.Empty\` 싱글톤** — FREE 사용자는 default 값. Tier/UI 분기 단순화.
- **grace period 정의** — \`billingIssueDetectedAtMillis != null AND isActive\`. RC 가 결제 retry 중인 동안 entitlement 가 active 로 유지되는 윈도. 종료 시 RC 가 \`EXPIRATION\` webhook (PR #333 처리) 발송.

## 검증 상태
- ✅ \`:platform:billing:impl:assembleAndroidMain\`
- ✅ \`:feature:home:impl:compileKotlinIosSimulatorArm64\`
- ✅ \`:app:compileDebugKotlin\`
- ❌ 런타임 — RC 키/대시보드 미준비 (#332 의 머지 전 필수와 동일)

## Test plan
- [ ] 활성 PRO + 자동 갱신 → \"YYYY-MM-DD에 자동 갱신\" 표시
- [ ] 활성 PRO + 취소됨(willRenew=false) → \"YYYY-MM-DD에 만료\"
- [ ] 결제 실패 후 RC grace period 진입 → 결제 문제 메시지
- [ ] FREE 사용자 → 라이프사이클 텍스트 미노출
- [ ] 복원 버튼 → Loading → 다른 기기/계정 구매 정상 복원되면 PRO 변경 + Success popup
- [ ] 복원 실패(복원할 구매 없음 등) → 적절한 에러 popup
- [ ] 다국어 — en/ja locale 에서 status 텍스트 정상 노출

## 후속
- 캐시 \`user_subscriptions\` (PR #333) 활용한 서버측 gating
- \`PurchasesError.code\` 매핑에 복원 전용 분기 (e.g. ReceiptInUseByOtherSubscriber 등) — 현재는 #332 의 9가지 매핑이 그대로 적용되어 동작은 함

🤖 Generated with [Claude Code](https://claude.com/claude-code)