### PR TITLE
Remove: iosApp.xcodeproj StoreKit.framework 직접 link 제거 — RC 트랜지티브 link로 충분

### DIFF
--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -10,7 +10,6 @@
 		AAAA00000000000000000009 /* iOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAA00000000000000000007 /* iOSApp.swift */; };
 		AAAA0000000000000000000A /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAA00000000000000000008 /* ContentView.swift */; };
 		AAAA00000000000000000016 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AAAA00000000000000000015 /* Assets.xcassets */; };
-		C88587002FA595DA00DC5BAB /* StoreKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C88586FF2FA595DA00DC5BAB /* StoreKit.framework */; };
 		C88587042FA5AA7500DC5BAB /* GoogleSignIn in Frameworks */ = {isa = PBXBuildFile; productRef = C88587032FA5AA7500DC5BAB /* GoogleSignIn */; };
 		C88587062FA5AA7500DC5BAB /* GoogleSignInSwift in Frameworks */ = {isa = PBXBuildFile; productRef = C88587052FA5AA7500DC5BAB /* GoogleSignInSwift */; };
 		C88587082FA5AB0400DC5BAB /* IosGoogleSignInBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = C88587072FA5AB0400DC5BAB /* IosGoogleSignInBridge.swift */; };
@@ -27,7 +26,6 @@
 		AAAA00000000000000000007 /* iOSApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iOSApp.swift; sourceTree = "<group>"; };
 		AAAA00000000000000000008 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		AAAA00000000000000000015 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
-		C88586FF2FA595DA00DC5BAB /* StoreKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = StoreKit.framework; path = System/Library/Frameworks/StoreKit.framework; sourceTree = SDKROOT; };
 		C88587012FA5A2DB00DC5BAB /* iosApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = iosApp.entitlements; sourceTree = "<group>"; };
 		C88587072FA5AB0400DC5BAB /* IosGoogleSignInBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IosGoogleSignInBridge.swift; sourceTree = "<group>"; };
 		C88587092FA5EEDE00DC5BAB /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
@@ -42,7 +40,6 @@
 			files = (
 				C88587062FA5AA7500DC5BAB /* GoogleSignInSwift in Frameworks */,
 				C88587112FA5F2A900DC5BAB /* FirebaseCore in Frameworks */,
-				C88587002FA595DA00DC5BAB /* StoreKit.framework in Frameworks */,
 				C885870F2FA5F29D00DC5BAB /* FirebaseAnalytics in Frameworks */,
 				C88587042FA5AA7500DC5BAB /* GoogleSignIn in Frameworks */,
 				C88587222FA700000000DC5BAB /* PurchasesHybridCommon in Frameworks */,
@@ -56,7 +53,6 @@
 			isa = PBXGroup;
 			children = (
 				AAAA00000000000000000003 /* iosApp */,
-				C88586FE2FA595DA00DC5BAB /* Frameworks */,
 				AAAA00000000000000000004 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -82,14 +78,6 @@
 				AAAA00000000000000000006 /* iosApp.app */,
 			);
 			name = Products;
-			sourceTree = "<group>";
-		};
-		C88586FE2FA595DA00DC5BAB /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				C88586FF2FA595DA00DC5BAB /* StoreKit.framework */,
-			);
-			name = Frameworks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */


### PR DESCRIPTION
## Summary
\`IosBillingService\`(StoreKit cinterop) 가 \`RevenueCatBillingService\` 로 교체된 후 \`iosApp.xcodeproj\` 에 남아있던 \`StoreKit.framework\` 직접 link 제거. \`PurchasesHybridCommon\` 이 트랜지티브로 link 하므로 명시적 link 불필요.

#294 follow-up. **Base: \`feature/294-revenuecat-billing-impl\` (PR #332)** — SPM 추가 커밋 위에 chain.

## 배경
- 이전 시도: PR #332 의 8a04da3 (Revert 0eace89) — PurchasesHybridCommon SPM 없이 cleanup 시도 → 빌드 검증 불가능 → revert
- 현재: SPM 추가됨(f3dc75f) → cleanup 검증 가능

## 검증
\`\`\`
$ xcodebuild -project iosApp.xcodeproj -scheme iosApp -configuration Debug \\
    -destination "platform=iOS Simulator,name=iPhone 17" clean build
...
** BUILD SUCCEEDED **
\`\`\`

## 변경 (5곳)
| 위치 | 제거 |
|---|---|
| PBXBuildFile | \`StoreKit.framework in Frameworks\` 항목 |
| PBXFileReference | \`StoreKit.framework\` 시스템 ref |
| PBXFrameworksBuildPhase | files 리스트의 StoreKit 라인 |
| 루트 PBXGroup | \`Frameworks\` 그룹 child 참조 |
| PBXGroup \`Frameworks\` | StoreKit만 들어있던 빈 그룹 자체 |

총 12줄 감소.

## 후속
- 없음. dead link 정리 완결.

🤖 Generated with [Claude Code](https://claude.com/claude-code)