### PR TITLE
Remove: #336 lint ExtraTranslation 우회 제거 — 차단 검사 복원

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -35,10 +35,6 @@ android {
         buildConfig = true
     }
 
-    lint {
-        disable += "ExtraTranslation"
-    }
-
     signingConfigs {
         create("release") {
             val storeFilePath = keystoreProperties.getProperty("storeFile")


### PR DESCRIPTION
## Summary
PR #337 (stale strings 정리) 가 ExtraTranslation 에러 원인을 해소했으므로, \`app/build.gradle.kts\` 의 \`lint { disable += \"ExtraTranslation\" }\` 워카라운드를 제거.

Closes #336.

## 검증
\`./gradlew :app:lintVitalRelease\` → \`BUILD SUCCESSFUL\` ✅ (lint disable 없이 통과)

## 효과
- 향후 default locale 에 누락된 키가 새로 들어오면 release 빌드가 다시 차단됨 — 의도한 안전망 복원.
- \`#294 AAB 서명 설정\` (#335) 에서 임시로 켰던 우회 닫음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)