### PR TITLE
Update: #330 출시 전 정리 — AI 한도 원복 + Apple Sign-In Android hide + iOS 디버그 로그 정리

### DIFF
--- a/feature/home/impl/src/commonMain/kotlin/me/pecos/memozy/presentation/screen/login/LoginScreen.kt
+++ b/feature/home/impl/src/commonMain/kotlin/me/pecos/memozy/presentation/screen/login/LoginScreen.kt
@@ -118,32 +118,35 @@ fun LoginScreen(
                 Spacer(modifier = Modifier.height(12.dp))
             }
 
-            // Apple 로 계속하기 — Apple HIG: 검정 배경 + 사과 로고. iOS 에서만 실제 동작 (Android 는 미구현 안내).
-            OutlinedButton(
-                onClick = {
-                    scope.launch {
-                        val result = credentialService.signInWithApple(activity = activity)
-                        when (result) {
-                            is AppleSignInResult.Success -> onAppleSignIn(result.idToken, result.rawNonce)
-                            is AppleSignInResult.Cancelled -> Unit
-                            is AppleSignInResult.Error -> {
-                                println("LoginScreen: Apple sign-in failed: ${result.message}")
-                                toastPresenter.show(getString(Res.string.sign_in_error))
+            // Apple 로 계속하기 — Apple HIG: 검정 배경 + 사과 로고. iOS 에서만 실제 동작.
+            // Android 는 OAuth Web flow (Custom Tabs) 미구현이라 버튼 자체를 숨김 (#330 Option C).
+            if (credentialService.isAppleSignInAvailable) {
+                OutlinedButton(
+                    onClick = {
+                        scope.launch {
+                            val result = credentialService.signInWithApple(activity = activity)
+                            when (result) {
+                                is AppleSignInResult.Success -> onAppleSignIn(result.idToken, result.rawNonce)
+                                is AppleSignInResult.Cancelled -> Unit
+                                is AppleSignInResult.Error -> {
+                                    println("LoginScreen: Apple sign-in failed: ${result.message}")
+                                    toastPresenter.show(getString(Res.string.sign_in_error))
+                                }
                             }
                         }
-                    }
-                },
-                modifier = Modifier.fillMaxWidth(),
-                border = BorderStroke(1.dp, colors.cardBorder),
-                shape = RoundedCornerShape(12.dp),
-                colors = ButtonDefaults.outlinedButtonColors(contentColor = colors.textTitle),
-            ) {
-                Text("\uF8FF", fontSize = fontSettings.scaled(16))
-                Spacer(modifier = Modifier.width(8.dp))
-                Text(stringResource(Res.string.sign_in_apple), fontSize = fontSettings.scaled(14))
-            }
+                    },
+                    modifier = Modifier.fillMaxWidth(),
+                    border = BorderStroke(1.dp, colors.cardBorder),
+                    shape = RoundedCornerShape(12.dp),
+                    colors = ButtonDefaults.outlinedButtonColors(contentColor = colors.textTitle),
+                ) {
+                    Text("\uF8FF", fontSize = fontSettings.scaled(16))
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(stringResource(Res.string.sign_in_apple), fontSize = fontSettings.scaled(14))
+                }
 
-            Spacer(modifier = Modifier.height(16.dp))
+                Spacer(modifier = Modifier.height(16.dp))
+            }
 
             OutlinedButton(
                 onClick = onSkip,

--- a/feature/memo-plain/impl/src/commonMain/kotlin/me/pecos/memozy/feature/memoplain/impl/MemoPlainNavigationImpl.kt
+++ b/feature/memo-plain/impl/src/commonMain/kotlin/me/pecos/memozy/feature/memoplain/impl/MemoPlainNavigationImpl.kt
@@ -431,8 +431,7 @@ class MemoPlainNavigationImpl(
             }
             val dailyLimit = subscriptionTier.dailyAiLimit + adBonusCount
             val canUseAiQuota = dailyUsageCount < dailyLimit
-            // TEST: AI 한도 일시 해제 — 출시 전 원복 필요
-            val canUseAi = true // isLoggedIn && canUseAiQuota
+            val canUseAi = isLoggedIn && canUseAiQuota
             val canWatchAd = !subscriptionTier.isPro && dailyAdViewCount < MAX_DAILY_AD_VIEWS
             val remainingAdViews = MAX_DAILY_AD_VIEWS - dailyAdViewCount
             var showLimitBottomSheet by remember { mutableStateOf(false) }

--- a/iosApp/iosApp/IosLiveTranscriptionBridge.swift
+++ b/iosApp/iosApp/IosLiveTranscriptionBridge.swift
@@ -3,6 +3,12 @@ import Speech
 import AVFoundation
 import Shared
 
+#if DEBUG
+private func dbg(_ msg: String) { NSLog("[LiveSTT] \(msg)") }
+#else
+private func dbg(_ msg: String) {}
+#endif
+
 /// SFSpeechRecognizer + AVAudioEngine 으로 실시간 받아쓰기.
 /// SFSpeech 세션은 ~60초 한도. 한 세션이 끝나면 (final result 또는 timeout) 즉시 새 세션 시작.
 final class IosLiveTranscriptionBridge: LiveTranscriptionBridge {
@@ -18,7 +24,7 @@ final class IosLiveTranscriptionBridge: LiveTranscriptionBridge {
     private var outputPath: String?
 
     func start(languageCode: String, outputPath: String?) {
-        NSLog("[LiveSTT] start lang=\(languageCode) outputPath=\(outputPath ?? "nil")")
+        dbg("start lang=\(languageCode) outputPath=\(outputPath ?? "nil")")
         self.languageCode = languageCode
         self.outputPath = outputPath
         self.stillListening = true
@@ -28,13 +34,13 @@ final class IosLiveTranscriptionBridge: LiveTranscriptionBridge {
         SFSpeechRecognizer.requestAuthorization { [weak self] status in
             guard let self = self else { return }
             DispatchQueue.main.async {
-                NSLog("[LiveSTT] auth status raw=\(status.rawValue)")
+                dbg("auth status raw=\(status.rawValue)")
                 switch status {
                 case .authorized:
-                    NSLog("[LiveSTT] authorized — beginning session")
+                    dbg("authorized — beginning session")
                     self.beginSession()
                 case .denied:
-                    NSLog("[LiveSTT] DENIED")
+                    dbg("DENIED")
                     LiveTranscriptionRegistrar.shared.onError(message: "Speech permission denied")
                 case .restricted:
                     LiveTranscriptionRegistrar.shared.onError(message: "Speech recognition restricted")
@@ -53,15 +59,15 @@ final class IosLiveTranscriptionBridge: LiveTranscriptionBridge {
     }
 
     private func beginSession() {
-        NSLog("[LiveSTT] beginSession()")
+        dbg("beginSession()")
         let locale = mapLocale(languageCode)
         guard let rec = SFSpeechRecognizer(locale: locale) else {
-            NSLog("[LiveSTT] recognizer init nil for \(locale.identifier)")
+            dbg("recognizer init nil for \(locale.identifier)")
             LiveTranscriptionRegistrar.shared.onError(message: "Recognizer not available for \(locale.identifier)")
             return
         }
         guard rec.isAvailable else {
-            NSLog("[LiveSTT] recognizer.isAvailable = false")
+            dbg("recognizer.isAvailable = false")
             LiveTranscriptionRegistrar.shared.onError(message: "Recognizer temporarily unavailable")
             return
         }
@@ -72,9 +78,9 @@ final class IosLiveTranscriptionBridge: LiveTranscriptionBridge {
         do {
             try session.setCategory(.playAndRecord, mode: .default, options: [.allowBluetooth, .defaultToSpeaker])
             try session.setActive(true, options: .notifyOthersOnDeactivation)
-            NSLog("[LiveSTT] session set OK")
+            dbg("session set OK")
         } catch {
-            NSLog("[LiveSTT] session error: \(error.localizedDescription)")
+            dbg("session error: \(error.localizedDescription)")
             LiveTranscriptionRegistrar.shared.onError(message: "Audio session: \(error.localizedDescription)")
             return
         }
@@ -97,9 +103,9 @@ final class IosLiveTranscriptionBridge: LiveTranscriptionBridge {
             do {
                 let url = URL(fileURLWithPath: path)
                 self.audioFile = try AVAudioFile(forWriting: url, settings: recordingFormat.settings)
-                NSLog("[LiveSTT] audioFile opened at \(path)")
+                dbg("audioFile opened at \(path)")
             } catch {
-                NSLog("[LiveSTT] audioFile open failed: \(error.localizedDescription) — Gemini polish 비활성")
+                dbg("audioFile open failed: \(error.localizedDescription) — Gemini polish 비활성")
                 self.audioFile = nil
             }
         }
@@ -115,9 +121,9 @@ final class IosLiveTranscriptionBridge: LiveTranscriptionBridge {
         audioEngine.prepare()
         do {
             try audioEngine.start()
-            NSLog("[LiveSTT] audio engine started")
+            dbg("audio engine started")
         } catch {
-            NSLog("[LiveSTT] engine start error: \(error.localizedDescription)")
+            dbg("engine start error: \(error.localizedDescription)")
             LiveTranscriptionRegistrar.shared.onError(message: "Audio engine: \(error.localizedDescription)")
             return
         }
@@ -127,7 +133,7 @@ final class IosLiveTranscriptionBridge: LiveTranscriptionBridge {
             guard let self = self else { return }
             if let result = result {
                 let text = result.bestTranscription.formattedString
-                NSLog("[LiveSTT] result text='\(text)' isFinal=\(result.isFinal)")
+                dbg("result text='\(text)' isFinal=\(result.isFinal)")
                 if result.isFinal {
                     // 한 세션 종료 — 누적 confirmed 로 이관
                     if !text.isEmpty {
@@ -176,7 +182,7 @@ final class IosLiveTranscriptionBridge: LiveTranscriptionBridge {
             audioFile = nil
             try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
             LiveTranscriptionRegistrar.shared.onIdle()
-            NSLog("[LiveSTT] session ended (final), audioFile closed")
+            dbg("session ended (final), audioFile closed")
         }
     }
 

--- a/platform/credential/api/src/commonMain/kotlin/me/pecos/memozy/platform/credential/CredentialService.kt
+++ b/platform/credential/api/src/commonMain/kotlin/me/pecos/memozy/platform/credential/CredentialService.kt
@@ -13,6 +13,12 @@ sealed class AppleSignInResult {
 }
 
 interface CredentialService {
+    /**
+     * Apple Sign-In 가능 여부. iOS 는 native AuthenticationServices, Android 는 OAuth Web flow
+     * (Custom Tabs) 미구현 상태라 false. 로그인 화면에서 false 면 Apple 버튼 숨김.
+     */
+    val isAppleSignInAvailable: Boolean
+
     suspend fun signInWithGoogle(
         activity: Any?,
         serverClientId: String,

--- a/platform/credential/impl/src/androidMain/kotlin/me/pecos/memozy/platform/credential/AndroidCredentialService.kt
+++ b/platform/credential/impl/src/androidMain/kotlin/me/pecos/memozy/platform/credential/AndroidCredentialService.kt
@@ -15,6 +15,8 @@ internal class AndroidCredentialService(
 
     private val appContext = context.applicationContext
 
+    override val isAppleSignInAvailable: Boolean = false
+
     override suspend fun signInWithGoogle(
         activity: Any?,
         serverClientId: String,

--- a/platform/credential/impl/src/iosMain/kotlin/me/pecos/memozy/platform/credential/IosCredentialService.kt
+++ b/platform/credential/impl/src/iosMain/kotlin/me/pecos/memozy/platform/credential/IosCredentialService.kt
@@ -45,6 +45,8 @@ object GoogleSignInRegistrar {
 
 class IosCredentialService : CredentialService {
 
+    override val isAppleSignInAvailable: Boolean = true
+
     override suspend fun signInWithGoogle(
         activity: Any?,
         serverClientId: String,

--- a/platform/media/impl/src/iosMain/kotlin/me/pecos/memozy/platform/media/IosMediaService.kt
+++ b/platform/media/impl/src/iosMain/kotlin/me/pecos/memozy/platform/media/IosMediaService.kt
@@ -1,156 +1,29 @@
 package me.pecos.memozy.platform.media
 
-import kotlinx.cinterop.BetaInteropApi
 import kotlinx.cinterop.ExperimentalForeignApi
-import kotlinx.cinterop.alloc
-import kotlinx.cinterop.memScoped
-import kotlinx.cinterop.ptr
-import kotlinx.cinterop.value
 import platform.AVFAudio.AVAudioPlayer
 import platform.AVFAudio.AVAudioPlayerDelegateProtocol
-import platform.AVFAudio.AVAudioRecorder
 import platform.AVFAudio.AVAudioSession
-import platform.AVFAudio.AVAudioSessionCategoryOptionDefaultToSpeaker
-import platform.AVFAudio.AVAudioSessionCategoryPlayAndRecord
 import platform.AVFAudio.AVAudioSessionCategoryPlayback
-import platform.AVFAudio.AVAudioSessionModeDefault
-import platform.AVFAudio.AVAudioSessionRecordPermissionDenied
-import platform.AVFAudio.AVAudioSessionRecordPermissionGranted
-import platform.AVFAudio.AVEncoderAudioQualityKey
-import platform.AVFAudio.AVEncoderBitRateKey
-import platform.AVFAudio.AVFormatIDKey
-import platform.AVFAudio.AVNumberOfChannelsKey
-import platform.AVFAudio.AVSampleRateKey
 import platform.AVFAudio.setActive
-import platform.CoreAudioTypes.kAudioFormatMPEG4AAC
-import platform.Foundation.NSError
-import platform.Foundation.NSFileManager
-import platform.Foundation.NSNumber
 import platform.Foundation.NSURL
 import platform.darwin.NSObject
-import kotlinx.cinterop.ObjCObjectVar
 
 /**
- * iOS Media — AVFoundation 기반 실 구현.
- * - 녹음: AVAudioRecorder, MPEG4 AAC 16kHz 64kbps (Android 와 일치)
+ * iOS Media — 재생 전용 실구현.
  * - 재생: AVAudioPlayer
- * - AVAudioSession 카테고리는 녹음 시 playAndRecord, 재생 시 playback 으로 전환
+ * - 녹음: LiveTranscription 의 AVAudioEngine.inputNode tap 으로 통합 캡처되므로 별도 recorder 미사용.
+ *   AVAudioRecorder 동시 사용 시 mic 점유 충돌이라 NoopAudioRecorder 로 차단.
  */
 class IosMediaService : MediaService {
     override fun createAudioPlayer(sourcePath: String): AudioPlayer = IosAudioPlayer(sourcePath)
-    /**
-     * iOS: 별도 AVAudioRecorder 사용 시 LiveTranscription 의 AVAudioEngine.inputNode tap 과 mic 점유 충돌.
-     * → no-op 으로 전환. 실시간 받아쓰기로 대체. 오디오 파일 캡처는 follow-up
-     * (AVAudioFile + AVAudioEngine.inputNode tap 으로 통합 캡처).
-     */
     override fun createAudioRecorder(): AudioRecorder = NoopAudioRecorder
 }
 
 private object NoopAudioRecorder : AudioRecorder {
-    override fun start(outputPath: String) { println("[IosRecorder] no-op (LiveSTT 가 mic 사용)") }
+    override fun start(outputPath: String) { /* LiveSTT 가 mic 사용 — no-op */ }
     override fun stop() {}
     override fun release() {}
-}
-
-@OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
-private class IosAudioRecorder : AudioRecorder {
-    private var recorder: AVAudioRecorder? = null
-    private var currentPath: String? = null
-
-    override fun start(outputPath: String) {
-        currentPath = outputPath
-        println("[IosRecorder] start path=$outputPath")
-
-        val session = AVAudioSession.sharedInstance()
-        // 권한 확인 (실 디바이스에서만 의미 있음, 시뮬레이터는 자동 GRANTED)
-        val perm = session.recordPermission
-        when (perm) {
-            AVAudioSessionRecordPermissionDenied -> {
-                println("[IosRecorder] mic permission DENIED — Settings 에서 허용 필요")
-                return
-            }
-            AVAudioSessionRecordPermissionGranted -> {
-                println("[IosRecorder] mic permission GRANTED")
-            }
-            else -> {
-                // Undetermined — requestRecordPermission 동기 호출 어려우므로 일단 진행 (시스템이 다이얼로그 표시)
-                println("[IosRecorder] mic permission UNDETERMINED — 다이얼로그 노출 예정")
-                session.requestRecordPermission { granted ->
-                    println("[IosRecorder] permission callback granted=$granted")
-                }
-            }
-        }
-
-        memScoped {
-            val errSession = alloc<ObjCObjectVar<NSError?>>()
-            val ok1 = session.setCategory(
-                AVAudioSessionCategoryPlayAndRecord,
-                mode = AVAudioSessionModeDefault,
-                options = AVAudioSessionCategoryOptionDefaultToSpeaker,
-                error = errSession.ptr,
-            )
-            if (!ok1 || errSession.value != null) {
-                println("[IosRecorder] setCategory FAILED: ${errSession.value?.localizedDescription}")
-                return
-            }
-            val errActive = alloc<ObjCObjectVar<NSError?>>()
-            val ok2 = session.setActive(true, error = errActive.ptr)
-            if (!ok2 || errActive.value != null) {
-                println("[IosRecorder] setActive FAILED: ${errActive.value?.localizedDescription}")
-                return
-            }
-        }
-
-        val url = NSURL.fileURLWithPath(outputPath)
-        // AAC 인코더가 모든 sampleRate/bitrate 조합 지원하지 않음.
-        // 16kHz + 64kbps mono 는 prepareToRecord 실패. 44.1kHz mono + AVAudioQualityHigh 로 안전하게.
-        val settings = mapOf<Any?, Any>(
-            AVFormatIDKey to NSNumber(int = kAudioFormatMPEG4AAC.toInt()),
-            AVSampleRateKey to NSNumber(double = 44100.0),
-            AVNumberOfChannelsKey to NSNumber(int = 1),
-            AVEncoderAudioQualityKey to NSNumber(int = 96), // .high
-        )
-
-        memScoped {
-            val errInit = alloc<ObjCObjectVar<NSError?>>()
-            val rec = AVAudioRecorder(uRL = url, settings = settings, error = errInit.ptr)
-            if (errInit.value != null) {
-                println("[IosRecorder] init FAILED: ${errInit.value?.localizedDescription}")
-                return
-            }
-            val prepared = rec.prepareToRecord()
-            println("[IosRecorder] prepareToRecord = $prepared")
-            if (!prepared) return
-            val started = rec.record()
-            println("[IosRecorder] record() returned = $started")
-            if (!started) return
-            recorder = rec
-        }
-    }
-
-    override fun stop() {
-        val rec = recorder
-        rec?.stop()
-        recorder = null
-        memScoped {
-            val err = alloc<ObjCObjectVar<NSError?>>()
-            AVAudioSession.sharedInstance().setActive(false, error = err.ptr)
-            if (err.value != null) {
-                println("[IosRecorder] setActive(false) error: ${err.value?.localizedDescription}")
-            }
-        }
-        val path = currentPath
-        if (path != null) {
-            val exists = NSFileManager.defaultManager.fileExistsAtPath(path)
-            val attrs = NSFileManager.defaultManager.attributesOfItemAtPath(path, error = null)
-            val size = (attrs?.get(platform.Foundation.NSFileSize) as? Number)?.toLong() ?: 0L
-            println("[IosRecorder] stop — file exists=$exists, size=$size bytes")
-        }
-    }
-
-    override fun release() {
-        recorder = null
-    }
 }
 
 @OptIn(ExperimentalForeignApi::class)


### PR DESCRIPTION
## Summary
#330 양 플랫폼 동등성 검증 Epic 의 Mac 코드 작업 부분 (3개 cleanup 통합).

## 변경

### 1. AI 한도 TEST override 제거 🟢
\`MemoPlainNavigationImpl.kt:435\`
\`\`\`diff
- val canUseAi = true // isLoggedIn && canUseAiQuota
+ val canUseAi = isLoggedIn && canUseAiQuota
\`\`\`
출시 전 원복 항목. 양 플랫폼 모두 적용.

### 2. Apple Sign-In Android hide (Option C) 🔴
- \`CredentialService\` 인터페이스에 \`isAppleSignInAvailable: Boolean\` 추가
- Android: \`false\` (OAuth Custom Tabs 미구현), iOS: \`true\`
- \`LoginScreen\` 에서 false 면 Apple 버튼 미렌더 → 출시 차단 위험 해소

향후 Apple Sign-In Android 정식 구현은 별 이슈/PR.

### 3. iOS 디버그 로깅 정리 🟢
- \`IosLiveTranscriptionBridge.swift\`: \`NSLog(\"[LiveSTT]...\")\` 14곳 → DEBUG 가드된 \`dbg()\` 헬퍼
- \`IosMediaService.kt\`: dead code \`IosAudioRecorder\` 클래스(100줄 + println 11개) 제거. 실제 사용되는 \`NoopAudioRecorder\` 만 유지

## 검증 (Mac)
- ✅ \`:app:compileDebugKotlin\`
- ✅ \`:feature:home:impl:compileKotlinIosSimulatorArm64\`
- ✅ \`:feature:memo-plain:impl:compileKotlinIosSimulatorArm64\`
- ✅ \`:platform:media:impl:compileKotlinIosSimulatorArm64\`
- ✅ \`:platform:credential:impl:compileKotlinIosSimulatorArm64\`

## 분량
+126 / -235 (dead code 정리로 net 감소)

## Test plan (디바이스 — 별 이슈로 인수인계)
- [ ] Android 에서 LoginScreen → Apple 버튼 미노출 확인
- [ ] iOS 에서 LoginScreen → Apple 버튼 정상 노출 + 동작
- [ ] AI 한도 도달 시 LimitBottomSheet 정상 동작
- [ ] iOS Live STT / 녹음 — 로그 \"[LiveSTT]\"/\"[IosRecorder]\" 노출 안 됨 확인 (release 빌드)

## 후속
- Apple Sign-In Android 정식 구현 (Custom Tabs OAuth + Supabase OAuth redirect)
- 디바이스 검증 인수인계 이슈 — 곧 생성 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)