### PR TITLE
Add: #294 Product flavors — memozy / nota 동시 배포 지원

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -51,15 +51,30 @@ android {
     }
 
     defaultConfig {
-        applicationId = "me.pecos.memozy"
-        versionCode = 4
-        versionName = "1.2604.0"
+        versionCode = 5
+        versionName = "1.2605.0"
 
         val admobAppId = localProperties.getProperty(
             "admob.app.id",
             "ca-app-pub-3940256099942544~3347511713"
         )
         manifestPlaceholders["admobAppId"] = admobAppId
+    }
+
+    // 두 Play Console listing 동시 운영을 위한 flavor:
+    //   memozy: 개발/내부 테스트용 (me.pecos.memozy 출시)
+    //   nota:   기존 출시 listing 유지용 (me.pecos.nota — Play Store applicationId 영구 고정)
+    // 빌드: ./gradlew :app:bundleMemozyRelease  /  ./gradlew :app:bundleNotaRelease
+    flavorDimensions += "distribution"
+    productFlavors {
+        create("memozy") {
+            dimension = "distribution"
+            applicationId = "me.pecos.memozy"
+        }
+        create("nota") {
+            dimension = "distribution"
+            applicationId = "me.pecos.nota"
+        }
     }
     buildTypes {
         // AdMob 광고 단위 ID — local.properties 미지정 시 AdMob 공식 테스트 ID 사용 (계정 정지 위험 제로).

--- a/app/google-services.json
+++ b/app/google-services.json
@@ -12,7 +12,12 @@
           "package_name": "me.pecos.memozy"
         }
       },
-      "oauth_client": [],
+      "oauth_client": [
+        {
+          "client_id": "470786671712-tod7qadobkmj3oo2u0oabua8gm4dmgkj.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
       "api_key": [
         {
           "current_key": "AIzaSyCWBfurhpfDutHWxL4WPuoXDGyBbpPwg6U"
@@ -20,7 +25,55 @@
       ],
       "services": {
         "appinvite_service": {
-          "other_platform_oauth_client": []
+          "other_platform_oauth_client": [
+            {
+              "client_id": "470786671712-tod7qadobkmj3oo2u0oabua8gm4dmgkj.apps.googleusercontent.com",
+              "client_type": 3
+            },
+            {
+              "client_id": "470786671712-ein20r5ogai99v056tqkforadbvl56fn.apps.googleusercontent.com",
+              "client_type": 2,
+              "ios_info": {
+                "bundle_id": "me.pecos.memozy.ios"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:470786671712:android:7559fe639dcd0e5371ef05",
+        "android_client_info": {
+          "package_name": "me.pecos.nota"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "470786671712-tod7qadobkmj3oo2u0oabua8gm4dmgkj.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyCWBfurhpfDutHWxL4WPuoXDGyBbpPwg6U"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "470786671712-tod7qadobkmj3oo2u0oabua8gm4dmgkj.apps.googleusercontent.com",
+              "client_type": 3
+            },
+            {
+              "client_id": "470786671712-ein20r5ogai99v056tqkforadbvl56fn.apps.googleusercontent.com",
+              "client_type": 2,
+              "ios_info": {
+                "bundle_id": "me.pecos.memozy.ios"
+              }
+            }
+          ]
         }
       }
     }

--- a/app/src/androidTest/java/me/pecos/memozy/ExampleInstrumentedTest.kt
+++ b/app/src/androidTest/java/me/pecos/memozy/ExampleInstrumentedTest.kt
@@ -19,6 +19,6 @@ class ExampleInstrumentedTest {
     fun useAppContext() {
         // Context of the app under test.
         val appContext = InstrumentationRegistry.getInstrumentation().targetContext
-        assertEquals("me.pecos.memozy", appContext.packageName)
+        assertEquals(BuildConfig.APPLICATION_ID, appContext.packageName)
     }
 }


### PR DESCRIPTION
## Summary

Play Console 두 listing(개발용 `memozy` / 출시용 `pecosnota`) 동시 운영을 위해 product flavor 도입. 한 번의 commit / 한 번의 PR / 두 개의 AAB.

## 배경

- #160 에서 applicationId 를 `me.pecos.nota → me.pecos.memozy` 일괄 교체
- 그런데 **Play Console 은 첫 출시 후 applicationId 가 영구 고정** → 기존 `pecosnota` 출시 listing 에 업로드 시 \"패키지 이름에는 me.pecos.nota 가 있어야 합니다\" 에러
- 단순 revert 대신 두 listing 모두 살리는 표준 패턴(flavors)으로 해결

## Changes

### `app/build.gradle.kts`
\`\`\`kotlin
flavorDimensions += \"distribution\"
productFlavors {
    create(\"memozy\") { applicationId = \"me.pecos.memozy\" }
    create(\"nota\")   { applicationId = \"me.pecos.nota\" }
}
\`\`\`
- `defaultConfig.applicationId` 제거 → flavor 단독 정의
- `versionCode 4 → 5` (이전 4 가 이미 업로드되어 충돌)
- `versionName 1.2604.0 → 1.2605.0`

### `app/google-services.json`
- pecosnota Firebase 프로젝트에 `me.pecos.nota` Android 앱 추가 등록 후 multi-app 버전으로 교체
- Google Services 플러그인이 빌드 시 active `applicationId` 와 매칭되는 client 자동 선택 → flavor 별 디렉터리 분리 불필요

### `ExampleInstrumentedTest.kt`
- 하드코딩 `\"me.pecos.memozy\"` → `BuildConfig.APPLICATION_ID` (nota flavor 에서도 통과)

### 영향 범위 스캔 결과 (변경 불필요 확인)
- 모듈 28개의 `namespace = \"me.pecos.memozy.*\"` — R 클래스 위치, applicationId 와 무관
- Manifest FileProvider authority `\${applicationId}.fileprovider` — 빌드 placeholder 자동 치환
- Service/Activity FQN (`me.pecos.memozy.platform.media.RecordingService` 등) — 컴파일된 Kotlin 클래스 경로
- Intent action 문자열 `\"me.pecos.memozy.recording.START/STOP\"` — 앱 내부용, 값 형식만 유지하면 OK
- ProGuard rules — `me.pecos.memozy` 하드코딩 0건
- backup_rules.xml / data_extraction_rules.xml / file_paths.xml — 패키지명 하드코딩 0건

## 빌드/배포 명령

\`\`\`bash
./gradlew :app:bundleMemozyRelease
# → app/build/outputs/bundle/memozyRelease/app-memozy-release.aab (memozy Play Console 업로드)

./gradlew :app:bundleNotaRelease
# → app/build/outputs/bundle/notaRelease/app-nota-release.aab     (pecosnota Play Console 업로드)
\`\`\`

## 검증 (이번 PR 빌드)

- [x] `./gradlew :app:bundleNotaRelease` BUILD SUCCESSFUL (1m 56s)
- [x] AAB 산출물 `app-nota-release.aab` 30.79 MB
- [x] 서명 SHA1 `3D:A0:F0:97:14:6E:7B:E3:78:B5:3F:0D:85:E0:0B:1E:13:91:50:C7` (기존 업로드 키 매치)
- [x] applicationId `me.pecos.nota` AAB 매니페스트에 정상 반영
- [x] 기존 KMP 모듈 namespace `me.pecos.memozy.*` 그대로 (충돌 없음)

## Test Plan

- [ ] `./gradlew :app:bundleMemozyRelease` 빌드 성공 (memozy flavor 도)
- [ ] `./gradlew :app:assembleMemozyDebug` / `:app:assembleNotaDebug` 모두 통과
- [ ] pecosnota Play Console Internal testing 트랙에 `app-nota-release.aab` 업로드 성공
- [ ] memozy Play Console Internal testing 트랙에 `app-memozy-release.aab` 업로드 성공
- [ ] 디바이스에서 memozy/nota 앱 동시 설치 가능 (별도 applicationId)

🤖 Generated with [Claude Code](https://claude.com/claude-code)