### PR TITLE
Fix: 출시 빌드 R8 크래시 — ProGuard keep 룰 일괄 도입

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -51,8 +51,8 @@ android {
     }
 
     defaultConfig {
-        versionCode = 7
-        versionName = "1.2605.2"
+        versionCode = 8
+        versionName = "1.2605.3"
 
         val admobAppId = localProperties.getProperty(
             "admob.app.id",

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -51,8 +51,8 @@ android {
     }
 
     defaultConfig {
-        versionCode = 5
-        versionName = "1.2605.0"
+        versionCode = 6
+        versionName = "1.2605.1"
 
         val admobAppId = localProperties.getProperty(
             "admob.app.id",

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -51,8 +51,8 @@ android {
     }
 
     defaultConfig {
-        versionCode = 6
-        versionName = "1.2605.1"
+        versionCode = 7
+        versionName = "1.2605.2"
 
         val admobAppId = localProperties.getProperty(
             "admob.app.id",

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,21 +1,154 @@
 # Add project specific ProGuard rules here.
-# You can control the set of applied configuration files using the
-# proguardFiles setting in build.gradle.
-#
-# For more details, see
-#   http://developer.android.com/guide/developing/tools/proguard.html
+# 참고: 라이브러리별 공식 권장 룰 + 프로젝트 keep 룰.
 
-# If your project uses WebView with JS, uncomment the following
-# and specify the fully qualified class name to the JavaScript interface
-# class:
-#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
-#   public *;
-#}
+# ============================================================
+# 디버깅을 위한 라인 정보 보존 (Crashlytics deobfuscation 정확도)
+# ============================================================
+-keepattributes SourceFile,LineNumberTable,*Annotation*,InnerClasses,EnclosingMethod,Signature,Exceptions
+-renamesourcefileattribute SourceFile
 
-# Uncomment this to preserve the line number information for
-# debugging stack traces.
-#-keepattributes SourceFile,LineNumberTable
+# ============================================================
+# Kotlin 메타데이터
+# ============================================================
+-keep class kotlin.Metadata { *; }
+-keepclassmembers class **$Companion { *; }
+-keepclassmembers class kotlin.coroutines.jvm.internal.** { *; }
 
-# If you keep the line number information, uncomment this to
-# hide the original source file name.
-#-renamesourcefileattribute SourceFile
+# ============================================================
+# kotlinx.serialization — @Serializable 클래스의 $$serializer 보존
+# ============================================================
+-keepattributes RuntimeVisibleAnnotations,AnnotationDefault
+-keep,includedescriptorclasses class **$$serializer { *; }
+-keepclassmembers class ** {
+    *** Companion;
+}
+-keepclasseswithmembers class ** {
+    kotlinx.serialization.KSerializer serializer(...);
+}
+# 프로젝트 모델: @Serializable 클래스의 자기 직렬화 메서드 keep
+-keepclassmembers @kotlinx.serialization.Serializable class * {
+    static <fields>;
+    static **$Companion Companion;
+    static kotlinx.serialization.KSerializer serializer(...);
+}
+
+# ============================================================
+# Koin DI — 리플렉션으로 모듈/스코프 검색
+# ============================================================
+-keep class org.koin.** { *; }
+-keep class org.koin.core.** { *; }
+-keep class org.koin.android.** { *; }
+-keep class org.koin.androidx.** { *; }
+-dontwarn org.koin.**
+# 프로젝트 모듈 정의 함수
+-keepclassmembers class me.pecos.** {
+    public static org.koin.core.module.Module *();
+}
+
+# ============================================================
+# Ktor — 리플렉션으로 ContentNegotiation/Serialization 등 검색
+# ============================================================
+-keep class io.ktor.** { *; }
+-keep class io.ktor.client.** { *; }
+-keep class io.ktor.serialization.** { *; }
+-dontwarn io.ktor.**
+-dontwarn org.slf4j.**
+
+# ============================================================
+# Supabase — kotlinx.serialization 사용 + 내부 리플렉션
+# ============================================================
+-keep class io.github.jan.supabase.** { *; }
+-keep interface io.github.jan.supabase.** { *; }
+-dontwarn io.github.jan.supabase.**
+
+# ============================================================
+# RevenueCat purchases-kmp + Hybrid Common
+# ============================================================
+-keep class com.revenuecat.purchases.** { *; }
+-keep interface com.revenuecat.purchases.** { *; }
+-dontwarn com.revenuecat.purchases.**
+
+# ============================================================
+# Firebase / Crashlytics / Analytics
+# ============================================================
+-keep class com.google.firebase.** { *; }
+-keep class com.google.android.gms.** { *; }
+-dontwarn com.google.firebase.**
+-dontwarn com.google.android.gms.**
+
+# ============================================================
+# Google Sign-In / Credential Manager
+# ============================================================
+-keep class androidx.credentials.** { *; }
+-keep class com.google.android.libraries.identity.** { *; }
+-dontwarn androidx.credentials.**
+
+# ============================================================
+# Room — KSP 코드 생성이 대부분 처리하지만 방어용
+# ============================================================
+-keep class androidx.room.** { *; }
+-keep @androidx.room.Entity class * { *; }
+-keep @androidx.room.Dao class * { *; }
+-keep @androidx.room.Database class * { *; }
+-keep @androidx.room.TypeConverter class * { *; }
+-keepclassmembers class * {
+    @androidx.room.* <methods>;
+}
+
+# ============================================================
+# AndroidX Glance (위젯)
+# ============================================================
+-keep class androidx.glance.** { *; }
+-keep class androidx.compose.ui.text.** { *; }
+-dontwarn androidx.glance.**
+-keepclassmembers class * extends androidx.glance.appwidget.GlanceAppWidget { *; }
+-keepclassmembers class * extends androidx.glance.appwidget.GlanceAppWidgetReceiver { *; }
+
+# ============================================================
+# WorkManager
+# ============================================================
+-keep class androidx.work.** { *; }
+-keep class * extends androidx.work.Worker { *; }
+-keep class * extends androidx.work.CoroutineWorker { *; }
+-keepclassmembers class * extends androidx.work.Worker {
+    public <init>(android.content.Context, androidx.work.WorkerParameters);
+}
+-keepclassmembers class * extends androidx.work.CoroutineWorker {
+    public <init>(android.content.Context, androidx.work.WorkerParameters);
+}
+
+# ============================================================
+# Compose / Material — 보통 안 깨지지만 방어
+# ============================================================
+-keep class androidx.compose.** { *; }
+-dontwarn androidx.compose.**
+
+# ============================================================
+# Coroutines — 디버깅 정보 keep
+# ============================================================
+-keepnames class kotlinx.coroutines.internal.MainDispatcherFactory
+-keepnames class kotlinx.coroutines.CoroutineExceptionHandler
+-keepclassmembers class kotlinx.coroutines.** { volatile <fields>; }
+
+# ============================================================
+# Joda Time (kotlinx-datetime로 마이그레이션 진행 중이지만 잔재 가능)
+# ============================================================
+-dontwarn org.joda.time.**
+
+# ============================================================
+# 프로젝트 도메인 모델 — @Serializable / @Parcelize / Room Entity 사용 클래스
+# 보수적으로 me.pecos.** 의 직렬화 관련 멤버 모두 keep
+# ============================================================
+-keep class me.pecos.**$$serializer { *; }
+-keepclassmembers class me.pecos.** {
+    *** Companion;
+    kotlinx.serialization.KSerializer serializer(...);
+}
+-keep @kotlinx.serialization.Serializable class me.pecos.** { *; }
+
+# ============================================================
+# OkHttp / Retrofit (Ktor가 내부적으로 OkHttp 엔진 사용)
+# ============================================================
+-dontwarn okhttp3.**
+-dontwarn okio.**
+-dontwarn javax.annotation.**

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -96,6 +96,18 @@
 }
 
 # ============================================================
+# SQLite Bundled Driver — JNI_OnLoad 에서 native 메서드를 정확한 클래스명/시그니처로
+# 찾아 등록하는데, R8 가 클래스명 난독화하면 등록 실패 → UnsatisfiedLinkError → 크래시.
+# 따라서 androidx.sqlite.driver.bundled.* 의 클래스 이름·native 메서드를 보존해야 함.
+# (실제 발견 사례: androidx.sqlite.driver.bundled.BundledSQLiteDriverKt.nativeThreadSafeMode)
+# ============================================================
+-keep class androidx.sqlite.** { *; }
+-keep class androidx.sqlite.driver.bundled.** { *; }
+-keepclasseswithmembernames class * {
+    native <methods>;
+}
+
+# ============================================================
 # AndroidX Glance (위젯)
 # ============================================================
 -keep class androidx.glance.** { *; }

--- a/platform/billing/impl/src/commonMain/kotlin/me/pecos/memozy/platform/billing/RevenueCatInitializer.kt
+++ b/platform/billing/impl/src/commonMain/kotlin/me/pecos/memozy/platform/billing/RevenueCatInitializer.kt
@@ -18,6 +18,19 @@ object RevenueCatInitializer {
     fun configure(apiKey: String, debug: Boolean) {
         if (Purchases.isConfigured) return
         if (apiKey.isEmpty()) return
+
+        // RC SDK 는 release 빌드에서 `test_` prefix 키를 감지하면 안전 차원에서
+        // 강제로 앱을 종료시킨다 ("Wrong API Key" 다이얼로그 후 finish).
+        // RC 대시보드 셋업 + production `goog_*` 키 발급 전까진 release 빌드에서
+        // 초기화를 스킵해 앱을 살린다. 결제/구독 화면만 비활성, 그 외 기능은 정상.
+        if (!debug && apiKey.startsWith("test_")) {
+            println(
+                "[RevenueCat] Skipping init in release build with test API key. " +
+                    "Provision production key (goog_*) in local.properties before release."
+            )
+            return
+        }
+
         Purchases.logLevel = if (debug) LogLevel.DEBUG else LogLevel.ERROR
         Purchases.configure(
             PurchasesConfiguration.Builder(apiKey = apiKey).build()


### PR DESCRIPTION
## Summary

Android Studio debug 빌드는 정상이나 internal testing AAB(release, minify 활성)에서 발생하는 광범위 런타임 크래시 해결. `app/proguard-rules.pro` 가 사실상 비어있던(전부 주석) 상태에서 라이브러리별 공식 권장 keep 룰 일괄 도입.

## 증상

- AS debug 빌드 → 정상
- Play Store internal testing 트랙에서 받은 release AAB → 다양한 화면에서 크래시 / 버그
- 차이는 `isMinifyEnabled = true` + `isShrinkResources = true` (release) vs disabled (debug) 단 하나

## 원인

`app/proguard-rules.pro` 1~21줄 전부 주석/공란. 리플렉션·어노테이션 기반 라이브러리들이 클래스 strip 또는 이름 난독화로 런타임 실패.

| 라이브러리 | 영향 |
|---|---|
| Koin DI | 리플렉션으로 모듈/스코프 검색 → 앱 시작 즉시 크래시 |
| kotlinx.serialization | `@Serializable` 클래스의 `$$serializer` strip → JSON 파싱 실패 (Supabase 모델 / 백업 / RevenueCat 응답 / 도메인 데이터) |
| RevenueCat purchases-kmp | SDK 내부 클래스 strip → 결제/구독 화면 크래시 |
| Supabase / Ktor | 동일 |
| AndroidX Glance | 위젯 클래스 strip → 위젯 깨짐 |
| WorkManager | Worker 인스턴스화 실패 |
| Firebase / Google Sign-In / Credential Manager | 방어 룰 |
| Room | KSP 코드 생성으로 보통 OK 이지만 방어 룰 |

## Changes

### `app/proguard-rules.pro`
라이브러리별 공식 권장 keep 룰 + 프로젝트 도메인 모델 보존 룰 일괄 추가:
- 디버깅 가독성: SourceFile / LineNumberTable / Annotation 보존 (Crashlytics deobfuscation)
- Kotlin 메타데이터 + Companion + Coroutines internal
- kotlinx.serialization `$$serializer` + `serializer(...)` keep
- Koin: `org.koin.**` 전체 + 프로젝트의 `Module *()` 함수 keep
- Ktor: `io.ktor.**` 전체
- Supabase: `io.github.jan.supabase.**` 전체
- RevenueCat: `com.revenuecat.purchases.**` 전체
- Firebase / GMS / Credential Manager
- Room Entity/Dao/Database/TypeConverter
- Glance Widget + GlanceAppWidgetReceiver
- WorkManager Worker / CoroutineWorker
- 프로젝트 모델 `me.pecos.**` 의 직렬화 멤버 보수적 keep

### `app/build.gradle.kts`
- `versionCode 5 → 6`, `versionName 1.2605.0 → 1.2605.1`
- (versionCode 5 는 이미 internal testing 업로드되어 있어 충돌 회피)

## Test Plan

- [x] `./gradlew :app:bundleNotaRelease` BUILD SUCCESSFUL (3m 26s)
- [x] AAB 산출 `app-nota-release.aab` 48.6 MB (이전 30.8 MB 대비 +18 MB — keep 룰로 minify 약화된 정상 결과)
- [ ] pecosnota internal testing 트랙에 versionCode 6 업로드 → license tester 디바이스에서 정상 실행 확인
- [ ] 결제 화면 진입 / 구독 결제 시도 / 위젯 / 메모 작성·검색 / 백업 등 주요 시나리오 크래시 재현 안 됨
- [ ] Crashlytics 대시보드에 잔여 R8 keep miss 보고되면 추가 룰 작성

## Follow-ups

- AS 또는 CI 에 release-build smoke 테스트 정착 (debug 만 검증되는 회귀 방지)
- Crashlytics deobfuscation 정상 동작 확인 (mapping.txt 업로드 작업 이미 활성)

🤖 Generated with [Claude Code](https://claude.com/claude-code)