### PR TITLE
Update: #346 release 빌드 RC API key 분리 (debug/prod 격리)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -103,7 +103,7 @@ android {
             buildConfigField("String", "SUPABASE_ANON_KEY", "\"${localProperties.getProperty("supabase.prod.anon.key", "")}\"")
             buildConfigField("String", "ADMOB_REWARD_AD_UNIT_ID", "\"${localProperties.getProperty("admob.reward.ad.unit.id", testRewardAdUnitId)}\"")
             buildConfigField("String", "ADMOB_TEST_DEVICE_IDS", "\"${localProperties.getProperty("admob.test.device.ids", "")}\"")
-            buildConfigField("String", "REVENUECAT_API_KEY", "\"${localProperties.getProperty("revenuecat.android.api.key", "")}\"")
+            buildConfigField("String", "REVENUECAT_API_KEY", "\"${localProperties.getProperty("revenuecat.android.prod.api.key", "")}\"")
         }
     }
 }


### PR DESCRIPTION
## Summary

`#346` 출시 빌드 강제 종료 (Wrong API Key 다이얼로그) 의 코드 측 대응.
release 빌드의 RC API key 를 다른 prod 키들 (`worker.prod.url` / `supabase.prod.url` / `app.prod.secret.key`) 과 동일한 `.prod.` 접두 패턴으로 분리해, `goog_*` production key 가 release 빌드에 주입되도록 한다.

## Changes

- `app/build.gradle.kts:106` — release 블록의 `revenuecat.android.api.key` → `revenuecat.android.prod.api.key` 한 줄 변경
- debug 블록 (line 90) 은 기존 `revenuecat.android.api.key` 그대로 사용 → debug 빌드는 test key (`test_*`) 유지
- `local.properties` 에 신규 라인 `revenuecat.android.prod.api.key=goog_*` 필요 (.gitignore 대상이라 PR 에는 미포함)

## Test plan

- [x] release AAB 빌드 성공 (`./gradlew :app:bundleNotaRelease`, versionCode 8, signing OK)
- [x] Play Console 내부 테스트 트랙 업로드 + rollout
- [x] License tester 단말 업데이트 후 앱 실행 — **Wrong API Key 다이얼로그 사라짐 확인** ✅ (이슈 본질 검증)
- [ ] 구독 화면 진입 + Monthly/Annual 패키지 노출 (로그인 회귀로 인해 차단 — 별도 이슈로 분리 예정)
- [ ] 결제 검증 / RC Customers 매핑 / 환불 시나리오 (위와 동일 차단)

## Related

Refs #346 (#346 의 C 단계 — 코드 분리만 다룸. D-4 이후 결제 검증은 prod Supabase OAuth provider 설정 누락으로 차단됨, 별도 이슈에서 진행)

🤖 Generated with [Claude Code](https://claude.com/claude-code)