### PR TITLE
Fix: #348 구독 카드 미노출 + Restore misleading popup

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -51,8 +51,8 @@ android {
     }
 
     defaultConfig {
-        versionCode = 8
-        versionName = "1.2605.3"
+        versionCode = 12
+        versionName = "1.2605.7"
 
         val admobAppId = localProperties.getProperty(
             "admob.app.id",

--- a/feature/core/resource/src/commonMain/composeResources/values-en/strings.xml
+++ b/feature/core/resource/src/commonMain/composeResources/values-en/strings.xml
@@ -256,7 +256,7 @@
     <string name="subscription_desc">Use AI features more generously</string>
     <string name="subscription_monthly">Monthly</string>
     <string name="subscription_yearly">Yearly</string>
-    <string name="subscription_yearly_discount">30%% off</string>
+    <string name="subscription_yearly_discount">30% off</string>
     <string name="subscription_feature_youtube">YouTube summary</string>
     <string name="subscription_feature_web">Web page summary</string>
     <string name="subscription_feature_ocr">Photo summary</string>

--- a/feature/core/resource/src/commonMain/composeResources/values-ja/strings.xml
+++ b/feature/core/resource/src/commonMain/composeResources/values-ja/strings.xml
@@ -256,7 +256,7 @@
     <string name="subscription_desc">AI機能をもっと使いましょう</string>
     <string name="subscription_monthly">月額</string>
     <string name="subscription_yearly">年額</string>
-    <string name="subscription_yearly_discount">30%%オフ</string>
+    <string name="subscription_yearly_discount">30%オフ</string>
     <string name="subscription_feature_youtube">YouTube要約</string>
     <string name="subscription_feature_web">Webページ要約</string>
     <string name="subscription_feature_ocr">写真要約</string>

--- a/feature/core/resource/src/commonMain/composeResources/values/strings.xml
+++ b/feature/core/resource/src/commonMain/composeResources/values/strings.xml
@@ -256,7 +256,7 @@
     <string name="subscription_desc">AI 기능을 더 넉넉하게 사용하세요</string>
     <string name="subscription_monthly">월간 구독</string>
     <string name="subscription_yearly">연간 구독</string>
-    <string name="subscription_yearly_discount">30%% 할인</string>
+    <string name="subscription_yearly_discount">30% 할인</string>
     <string name="subscription_feature_youtube">유튜브 요약</string>
     <string name="subscription_feature_web">웹페이지 요약</string>
     <string name="subscription_feature_ocr">사진 요약</string>

--- a/feature/home/impl/src/commonMain/kotlin/me/pecos/memozy/presentation/screen/subscription/SubscriptionScreen.kt
+++ b/feature/home/impl/src/commonMain/kotlin/me/pecos/memozy/presentation/screen/subscription/SubscriptionScreen.kt
@@ -311,8 +311,27 @@ fun SubscriptionScreen(
             }
 
             // ── 구독 상품 카드 ──
-            val monthly = subscriptionProducts.find { it.productId == BillingService.SUB_PRO_MONTHLY }
-            val yearly = subscriptionProducts.find { it.productId == BillingService.SUB_PRO_YEARLY }
+            // Google Play 는 storeProduct.id 를 "pro_monthly:monthly-base" 형태로 반환할 수 있음.
+            // BillingService.SUB_PRO_MONTHLY 는 base subscription product id ("pro_monthly") 라
+            // 정확히 == 비교하면 매칭 실패. startsWith 로 base plan suffix 까지 허용.
+            val monthly = subscriptionProducts.find { it.productId.startsWith(BillingService.SUB_PRO_MONTHLY) }
+            val yearly = subscriptionProducts.find { it.productId.startsWith(BillingService.SUB_PRO_YEARLY) }
+
+            if (monthly != null) {
+                SubscriptionCard(
+                    label = stringResource(Res.string.subscription_monthly),
+                    price = monthly.formattedPrice,
+                    isCurrentPlan = currentTier.isPro,
+                    onClick = {
+                        if (activity != null && !currentTier.isPro) {
+                            // 실제 storeProduct.id (예: "pro_monthly:monthly-base") 그대로 전달.
+                            // BillingService 의 subscriptionPackages 맵 키와 일치시켜야 lookup 성공.
+                            billingService.launchSubscriptionFlow(activity, monthly.productId)
+                        }
+                    }
+                )
+                Spacer(modifier = Modifier.height(12.dp))
+            }
 
             if (yearly != null) {
                 SubscriptionCard(
@@ -323,21 +342,7 @@ fun SubscriptionScreen(
                     isRecommended = true,
                     onClick = {
                         if (activity != null && !currentTier.isPro) {
-                            billingService.launchSubscriptionFlow(activity, BillingService.SUB_PRO_YEARLY)
-                        }
-                    }
-                )
-                Spacer(modifier = Modifier.height(12.dp))
-            }
-
-            if (monthly != null) {
-                SubscriptionCard(
-                    label = stringResource(Res.string.subscription_monthly),
-                    price = monthly.formattedPrice,
-                    isCurrentPlan = currentTier.isPro,
-                    onClick = {
-                        if (activity != null && !currentTier.isPro) {
-                            billingService.launchSubscriptionFlow(activity, BillingService.SUB_PRO_MONTHLY)
+                            billingService.launchSubscriptionFlow(activity, yearly.productId)
                         }
                     }
                 )

--- a/platform/billing/impl/src/commonMain/kotlin/me/pecos/memozy/platform/billing/RevenueCatBillingService.kt
+++ b/platform/billing/impl/src/commonMain/kotlin/me/pecos/memozy/platform/billing/RevenueCatBillingService.kt
@@ -68,6 +68,7 @@ class RevenueCatBillingService(
     override val subscriptionDetail: StateFlow<SubscriptionDetail> = _subscriptionDetail.asStateFlow()
 
     override fun connect() {
+        println("[RC] connect() called — isConfigured=${Purchases.isConfigured}")
         if (!Purchases.isConfigured) {
             _isConnected.value = false
             return
@@ -133,7 +134,14 @@ class RevenueCatBillingService(
             Purchases.sharedInstance.awaitRestoreResult()
                 .onSuccess { info ->
                     applyCustomerInfo(info)
-                    _purchaseState.value = PurchaseState.Success
+                    // active entitlement 가 없으면 "Pro 활성화" 메시지는 misleading.
+                    // 복원할 활성 구독이 없다고 명확히 알림.
+                    val hasActivePro = info.entitlements.active[ENTITLEMENT_PRO] != null
+                    _purchaseState.value = if (hasActivePro) {
+                        PurchaseState.Success
+                    } else {
+                        PurchaseState.Error("복원할 활성 구독이 없습니다.")
+                    }
                 }
                 .onFailure { handlePurchaseFailure(it) }
         }
@@ -154,21 +162,42 @@ class RevenueCatBillingService(
     private fun startAuthSync() {
         authJob?.cancel()
         authJob = scope.launch {
+            println("[RC] startAuthSync: collection started")
             authRepository.authState
-                .map { state -> (state as? AuthState.Authenticated)?.user?.id }
+                .map { state ->
+                    println("[RC] authState raw: ${state::class.simpleName}")
+                    (state as? AuthState.Authenticated)?.user?.id
+                }
                 .distinctUntilChanged()
-                .collect { userId -> syncAppUserId(userId) }
+                .collect { userId ->
+                    println("[RC] authState mapped userId=$userId")
+                    syncAppUserId(userId)
+                }
         }
     }
 
     private suspend fun syncAppUserId(userId: String?) {
-        if (!Purchases.isConfigured) return
+        if (!Purchases.isConfigured) {
+            println("[RC] syncAppUserId skipped: Purchases not configured")
+            return
+        }
         if (userId != null) {
+            println("[RC] syncAppUserId: logIn($userId)")
             Purchases.sharedInstance.awaitLogInResult(userId)
-                .onSuccess { applyCustomerInfo(it.customerInfo) }
+                .onSuccess {
+                    println("[RC] logIn success — created=${it.created}")
+                    applyCustomerInfo(it.customerInfo)
+                }
+                .onFailure { error ->
+                    println("[RC] logIn failure: ${error.message}")
+                }
         } else {
+            println("[RC] syncAppUserId: logOut (anonymous)")
             Purchases.sharedInstance.awaitLogOutResult()
                 .onSuccess { applyCustomerInfo(it) }
+                .onFailure { error ->
+                    println("[RC] logOut failure: ${error.message}")
+                }
         }
     }
 
@@ -176,6 +205,11 @@ class RevenueCatBillingService(
         Purchases.sharedInstance.awaitOfferingsResult()
             .onSuccess { offerings ->
                 val current = offerings.current
+                println(
+                    "[RC] Offerings result: current.identifier=${current?.identifier}, " +
+                        "availablePackages.size=${current?.availablePackages?.size ?: 0}, " +
+                        "productIds=${current?.availablePackages?.map { it.storeProduct.id }}"
+                )
                 if (current == null) {
                     _subscriptionProducts.value = emptyList()
                     return@onSuccess
@@ -193,6 +227,9 @@ class RevenueCatBillingService(
                         billingPeriod = pkg.storeProduct.period?.toIso8601().orEmpty(),
                     )
                 }
+            }
+            .onFailure { error ->
+                println("[RC] Offerings failure: ${error.message}")
             }
     }
 
@@ -220,6 +257,11 @@ class RevenueCatBillingService(
     }
 
     private fun applyCustomerInfo(info: CustomerInfo) {
+        println(
+            "[RC] CustomerInfo applied: active=${info.entitlements.active.keys}, " +
+                "all=${info.entitlements.all.keys}, " +
+                "active['$ENTITLEMENT_PRO']=${info.entitlements.active[ENTITLEMENT_PRO]?.productIdentifier}"
+        )
         val proEntitlement = info.entitlements.active[ENTITLEMENT_PRO]
         if (proEntitlement != null) {
             _subscriptionTier.value = SubscriptionTier.PRO


### PR DESCRIPTION
## Summary

- **Bug 1 (카드 미노출 fix)**: `subscriptionProducts.find { it.productId == BillingService.SUB_PRO_* }` 가 항상 null. RC SDK 가 `storeProduct.id` 를 Google Play 의 `pro_monthly:monthly-base` 형식으로 반환하기 때문. `==` 비교를 `startsWith` 로 변경 + 카드 클릭 시 실제 storeProduct.id 를 `launchSubscriptionFlow` 에 전달 (`subscriptionPackages` 맵 키와 일치시키기 위해).
- **Bug 3 (misleading popup fix)**: `restorePurchases` 가 `active=[]` 일 때도 `PurchaseState.Success` 로 설정해서 "Pro 구독이 활성화되었어요!" popup 이 잘못 표시됨. `info.entitlements.active['pro']` 검사 후 분기 — 활성 구독이 없으면 "복원할 활성 구독이 없습니다" 에러 popup 으로 정정.
- **진단 로그 추가**: release 빌드는 RC LogLevel.ERROR 기본이라 매핑 흐름이 logcat 에 안 잡힘. `connect()` / `startAuthSync` / `syncAppUserId` 에 `println` keep — 다음 릴리스 회귀 추적용. (PR 리뷰에서 일부 정리 가능)
- **`%%` → `%`**: `subscription_yearly_discount` 의 \"30%% 할인\" 이 화면에 \"30%% 할인\" 으로 그대로 출력 (Compose 의 stringResource 는 String.format 미처리). 3개 언어 (ko/en/ja) 모두 단일 % 로 보정.
- **카드 순서**: 월간 → 연간 (연간에 추천 배지). UX 결정.
- **versionCode 8 → 12, versionName 1.2605.3 → 1.2605.7**.

## Verification (단말 검증 완료)

| 항목 | 결과 |
|---|---|
| D-4 카드 노출 | ✅ logcat: \`productIds=[pro_monthly:monthly-base, pro_yearly:yearly-base]\` 확인 + 화면에 두 카드 표시 |
| D-5 결제 시도 | ✅ Play 결제 sheet 응답 (license tester 환불/재결제 흐름 검증) |
| D-6 RC ↔ Supabase 매핑 | ✅ logcat: \`logIn(00bfe4a0-4dff-4eef-a369-cc709045a0b1) success — created=false\` |
| Bug 3 popup fix | ✅ \`active=[]\` 인 user 가 Restore 누르면 더 이상 misleading 메시지 안 뜸 |

## 학습된 것 (#348 부수 효과로 푼 것 — 별도 commit 아니라 이슈/메모리 기록)

- Play Store 빌드는 **Play 앱 서명 키 SHA-1** 도 GCP Android OAuth client 에 별도 등록 필수 (28444 회피)
- Supabase Google provider 의 **Authorized Client IDs** 필드 (native idToken flow 화이트리스트) 채워야 함 (Web Client + Secret 만으론 부족)

## Test plan

- [x] release 빌드 (versionCode 12) 단말 설치 후 구독 화면 진입 — 카드 노출 확인
- [x] 카드 가격 표시 (₩4,900 / ₩39,000) 확인
- [x] 카드 탭 → Play 결제 sheet 응답 확인
- [x] 구매 복원 → \`active=[]\` 인 상태에서 misleading "Pro 활성화" 안 뜨는지 확인
- [x] logIn → CustomerInfo applied: \`active=[pro]\` 매핑 검증
- [ ] dev 빌드/iOS 측 회귀 (별도 검증 필요시)

## Related

- 상위 에픽: #294 RevenueCat Epic
- Parent: #346 (#346 D-4 ~ D-6 검증 막힘 해소)
- #348 (release OAuth 회귀) 의 부수 효과로 발견된 카드/popup 버그 picks up

🤖 Generated with [Claude Code](https://claude.com/claude-code)