### PR TITLE
Add: #324 App Store 리스팅용 GitHub Pages 사이트 (Privacy / Support)

### DIFF
--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Memozy</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <main>
+        <header>
+            <h1>Memozy</h1>
+            <nav>
+                <a href="index.html">Home</a>
+                <a href="privacy.html">Privacy</a>
+                <a href="support.html">Support</a>
+            </nav>
+        </header>
+
+        <section class="locale" lang="ko">
+            <h2>Memozy — AI 메모 앱</h2>
+            <p>YouTube · 웹 · 음성 메모를 AI 가 한 번에 요약합니다. 회의나 강의도 실시간 받아쓰기로 정리하세요.</p>
+
+            <h3>주요 기능</h3>
+            <ul>
+                <li>🎬 YouTube 영상 요약 (Gemini AI)</li>
+                <li>🌐 웹페이지 요약</li>
+                <li>🎙 음성 녹음 + 실시간 받아쓰기</li>
+                <li>📂 11 가지 카테고리 분류</li>
+                <li>✏ 리치 텍스트 편집</li>
+                <li>🌙 다크 / 라이트 모드</li>
+                <li>🌐 한국어 · English · 日本語</li>
+                <li>☁ Apple / Google 로그인 클라우드 백업</li>
+            </ul>
+        </section>
+
+        <section class="locale" lang="en">
+            <h2>Memozy — AI Note App</h2>
+            <p>AI summaries for YouTube videos, web articles, and voice memos. Live transcription for meetings and lectures.</p>
+
+            <h3>Highlights</h3>
+            <ul>
+                <li>YouTube video summaries (Gemini AI)</li>
+                <li>Web article summaries</li>
+                <li>Voice memos with live transcription</li>
+                <li>11 categories</li>
+                <li>Rich text editing</li>
+                <li>Light / Dark mode</li>
+                <li>한국어 · English · 日本語</li>
+                <li>Cloud backup with Apple / Google sign-in</li>
+            </ul>
+        </section>
+
+        <footer>© 2026 pecos-lab · <a href="mailto:pecos6246@gmail.com">pecos6246@gmail.com</a></footer>
+    </main>
+</body>
+</html>

--- a/docs/site/privacy.html
+++ b/docs/site/privacy.html
@@ -1,0 +1,183 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Privacy Policy — Memozy</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <main>
+        <header>
+            <h1>Memozy</h1>
+            <nav>
+                <a href="index.html">Home</a>
+                <a href="privacy.html">Privacy</a>
+                <a href="support.html">Support</a>
+            </nav>
+        </header>
+
+        <!-- ============= 한국어 ============= -->
+        <section class="locale" lang="ko">
+            <h2>개인정보 처리방침</h2>
+            <p class="meta">시행일: 2026년 5월 9일 · 최종 수정: 2026년 5월 9일</p>
+
+            <p>Memozy(이하 "서비스")는 사용자의 개인정보를 소중히 다루며, 「개인정보 보호법」 및 관련 법령을 준수합니다. 본 방침은 Memozy iOS · Android 앱이 수집·이용하는 데이터, 처리 목적, 제3자 제공, 보관 기간, 사용자 권리에 대해 설명합니다.</p>
+
+            <h3>1. 운영자</h3>
+            <ul>
+                <li>운영자: pecos-lab (1인 개발자)</li>
+                <li>이메일: <a href="mailto:pecos6246@gmail.com">pecos6246@gmail.com</a></li>
+            </ul>
+
+            <h3>2. 수집하는 정보</h3>
+            <table>
+                <thead>
+                    <tr><th>항목</th><th>수집 시점</th><th>목적</th></tr>
+                </thead>
+                <tbody>
+                    <tr><td>이메일, 이름</td><td>Apple / Google 로그인</td><td>계정 식별, 클라우드 백업</td></tr>
+                    <tr><td>메모 본문, 첨부 이미지, 오디오 파일</td><td>사용자 입력</td><td>로컬 저장 + 로그인 시 클라우드 백업</td></tr>
+                    <tr><td>요약 요청 텍스트 / URL</td><td>요약 기능 사용 시</td><td>AI 요약 처리</td></tr>
+                    <tr><td>구독 상태, 결제 이력</td><td>유료 구독 시</td><td>구독 검증, 환불 / 복원</td></tr>
+                    <tr><td>광고 식별자 (IDFA / AAID)</td><td>무료 티어 사용 시</td><td>광고 송출</td></tr>
+                    <tr><td>이벤트 로그, 화면 진입, 기능 사용</td><td>앱 사용 중 자동</td><td>서비스 개선 (익명 통계)</td></tr>
+                    <tr><td>충돌 보고 (스택트레이스, 디바이스 모델)</td><td>앱 충돌 시 자동</td><td>버그 수정</td></tr>
+                    <tr><td>마이크 음성</td><td>녹음 / 받아쓰기 시</td><td>온디바이스 처리. 텍스트 변환 외 별도 저장하지 않음.</td></tr>
+                </tbody>
+            </table>
+
+            <h3>3. 제3자 처리위탁</h3>
+            <p>아래 서비스에 일부 데이터가 위탁 처리됩니다. 각 사의 자체 개인정보 처리방침을 따릅니다.</p>
+            <table>
+                <thead><tr><th>위탁사</th><th>처리 내용</th></tr></thead>
+                <tbody>
+                    <tr><td>Supabase</td><td>인증, 메모 클라우드 백업, 구독 캐시</td></tr>
+                    <tr><td>Google Cloud (Gemini API)</td><td>AI 요약 처리 (요청 텍스트)</td></tr>
+                    <tr><td>Google AdMob</td><td>무료 티어 광고 송출 (광고 ID)</td></tr>
+                    <tr><td>Google Firebase</td><td>익명 사용 통계 (Analytics), 충돌 보고 (Crashlytics)</td></tr>
+                    <tr><td>Apple Sign-In</td><td>계정 식별 (이름 / 릴레이 이메일)</td></tr>
+                    <tr><td>Google Sign-In</td><td>계정 식별 (이름 / 이메일)</td></tr>
+                    <tr><td>RevenueCat</td><td>구독 상태 동기화</td></tr>
+                    <tr><td>Cloudflare Workers</td><td>웹페이지 본문 추출 프록시</td></tr>
+                    <tr><td>Supadata</td><td>YouTube 자막 추출</td></tr>
+                    <tr><td>Apple App Store / Google Play</td><td>구독 결제 처리</td></tr>
+                </tbody>
+            </table>
+
+            <h3>4. 보관 기간</h3>
+            <ul>
+                <li>계정 정보 / 메모: 회원 탈퇴 또는 삭제 요청 시까지</li>
+                <li>익명 사용 통계: 최대 14 개월</li>
+                <li>충돌 로그: 90 일</li>
+                <li>구독 결제 기록: 관련 법령에 따라 5 년 이상 (전자상거래법, 세법)</li>
+            </ul>
+
+            <h3>5. 사용자 권리</h3>
+            <p>사용자는 언제든지 다음 권리를 행사할 수 있습니다:</p>
+            <ul>
+                <li>본인 정보의 열람 / 정정 / 삭제 요청</li>
+                <li>처리 정지 요청</li>
+                <li>동의 철회 (앱 내 로그아웃 / 계정 삭제 / 구독 해지)</li>
+            </ul>
+            <p>위 권리 행사는 <a href="mailto:pecos6246@gmail.com">pecos6246@gmail.com</a> 으로 요청해 주세요. 본인 확인 후 지체 없이 처리합니다.</p>
+
+            <h3>6. 국외 이전</h3>
+            <p>위 제3자 서비스 일부는 미국 등 해외에 서버를 운영합니다. 표준계약(SCC) 등을 통해 적법한 보호 조치를 따릅니다.</p>
+
+            <h3>7. 아동 정보</h3>
+            <p>본 서비스는 만 14 세 미만(또는 거주국 법정 연령) 아동을 대상으로 하지 않으며, 해당 사용자의 정보를 알면서 수집하지 않습니다.</p>
+
+            <h3>8. 보안</h3>
+            <p>전송 구간은 TLS 로 암호화하며, 클라우드 저장 시 Supabase Row Level Security 로 본인 데이터만 접근 가능하도록 분리합니다.</p>
+
+            <h3>9. 변경 고지</h3>
+            <p>중대한 변경 사항은 앱 내 또는 본 페이지에서 최소 7 일 전 공지합니다.</p>
+
+            <h3>10. 문의</h3>
+            <p><a href="mailto:pecos6246@gmail.com">pecos6246@gmail.com</a></p>
+        </section>
+
+        <!-- ============= English ============= -->
+        <section class="locale" lang="en">
+            <h2>Privacy Policy</h2>
+            <p class="meta">Effective: 2026-05-09 · Last updated: 2026-05-09</p>
+
+            <p>Memozy ("Service") respects your privacy. This policy describes the data the Memozy iOS / Android app collects, how it is used, third-party processors, retention, and your rights.</p>
+
+            <h3>1. Operator</h3>
+            <ul>
+                <li>Operator: pecos-lab (solo developer)</li>
+                <li>Email: <a href="mailto:pecos6246@gmail.com">pecos6246@gmail.com</a></li>
+            </ul>
+
+            <h3>2. Data we collect</h3>
+            <table>
+                <thead><tr><th>Data</th><th>Source</th><th>Purpose</th></tr></thead>
+                <tbody>
+                    <tr><td>Email, name</td><td>Apple / Google sign-in</td><td>Account identity, cloud backup</td></tr>
+                    <tr><td>Notes, attached images, audio files</td><td>User input</td><td>Local storage; cloud backup if signed in</td></tr>
+                    <tr><td>Summarisation request text / URL</td><td>When you request a summary</td><td>AI summarisation</td></tr>
+                    <tr><td>Subscription state, purchase history</td><td>Paid subscriptions</td><td>Validation, refund, restore</td></tr>
+                    <tr><td>Advertising identifier (IDFA / AAID)</td><td>Free tier</td><td>Ad serving</td></tr>
+                    <tr><td>Event logs, screen views, feature usage</td><td>Automatic during use</td><td>Anonymous analytics for service improvement</td></tr>
+                    <tr><td>Crash reports (stack traces, device model)</td><td>Automatic on crash</td><td>Bug fixing</td></tr>
+                    <tr><td>Microphone audio</td><td>Recording / live transcription</td><td>Processed on-device. Not stored beyond conversion to text.</td></tr>
+                </tbody>
+            </table>
+
+            <h3>3. Third-party processors</h3>
+            <p>Some data is processed by third-party services, each governed by its own privacy policy.</p>
+            <table>
+                <thead><tr><th>Processor</th><th>Use</th></tr></thead>
+                <tbody>
+                    <tr><td>Supabase</td><td>Authentication, note backup, subscription cache</td></tr>
+                    <tr><td>Google Cloud (Gemini API)</td><td>AI summarisation (request text)</td></tr>
+                    <tr><td>Google AdMob</td><td>Free-tier ad serving (advertising ID)</td></tr>
+                    <tr><td>Google Firebase</td><td>Anonymous analytics, crash reporting</td></tr>
+                    <tr><td>Apple Sign-In</td><td>Identity (name / relay email)</td></tr>
+                    <tr><td>Google Sign-In</td><td>Identity (name / email)</td></tr>
+                    <tr><td>RevenueCat</td><td>Subscription state sync</td></tr>
+                    <tr><td>Cloudflare Workers</td><td>Web article extraction proxy</td></tr>
+                    <tr><td>Supadata</td><td>YouTube transcript extraction</td></tr>
+                    <tr><td>Apple App Store / Google Play</td><td>Subscription billing</td></tr>
+                </tbody>
+            </table>
+
+            <h3>4. Retention</h3>
+            <ul>
+                <li>Account info / notes: until account deletion request</li>
+                <li>Anonymous analytics: up to 14 months</li>
+                <li>Crash reports: 90 days</li>
+                <li>Subscription billing records: as required by tax law (5+ years)</li>
+            </ul>
+
+            <h3>5. Your rights</h3>
+            <p>You may at any time:</p>
+            <ul>
+                <li>Access, correct, or delete your data</li>
+                <li>Request restriction of processing</li>
+                <li>Withdraw consent (sign out, delete account, cancel subscription)</li>
+            </ul>
+            <p>Email <a href="mailto:pecos6246@gmail.com">pecos6246@gmail.com</a> to exercise these rights. We respond promptly after identity verification.</p>
+
+            <h3>6. International transfers</h3>
+            <p>Some processors operate servers outside your country (e.g. United States). Transfers are protected by standard contractual clauses or equivalent safeguards.</p>
+
+            <h3>7. Children</h3>
+            <p>This service is not directed to children under 13 (or the legal age of consent in your country). We do not knowingly collect data from such users.</p>
+
+            <h3>8. Security</h3>
+            <p>Transit is encrypted with TLS. Cloud storage is isolated per user via Supabase Row Level Security.</p>
+
+            <h3>9. Changes</h3>
+            <p>Material changes are announced in-app and on this page at least 7 days in advance.</p>
+
+            <h3>10. Contact</h3>
+            <p><a href="mailto:pecos6246@gmail.com">pecos6246@gmail.com</a></p>
+        </section>
+
+        <footer>© 2026 pecos-lab</footer>
+    </main>
+</body>
+</html>

--- a/docs/site/style.css
+++ b/docs/site/style.css
@@ -1,0 +1,141 @@
+:root {
+    --bg: #ffffff;
+    --fg: #1a1a1a;
+    --muted: #5e5e5e;
+    --accent: #4a6cf7;
+    --border: #e5e5e5;
+    --radius: 8px;
+    --max-w: 760px;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg: #0f0f10;
+        --fg: #ececec;
+        --muted: #9a9a9a;
+        --accent: #7a93ff;
+        --border: #2a2a2c;
+    }
+}
+
+* {
+    box-sizing: border-box;
+}
+
+html,
+body {
+    margin: 0;
+    padding: 0;
+    background: var(--bg);
+    color: var(--fg);
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Apple SD Gothic Neo",
+        "Pretendard", "Noto Sans KR", "Noto Sans JP", sans-serif;
+    line-height: 1.7;
+    font-size: 16px;
+}
+
+main {
+    max-width: var(--max-w);
+    margin: 0 auto;
+    padding: 32px 24px 80px;
+}
+
+header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 32px;
+    padding-bottom: 16px;
+    border-bottom: 1px solid var(--border);
+    flex-wrap: wrap;
+    gap: 12px;
+}
+
+header h1 {
+    margin: 0;
+    font-size: 24px;
+    font-weight: 700;
+}
+
+nav a {
+    color: var(--muted);
+    text-decoration: none;
+    margin-left: 16px;
+    font-size: 14px;
+}
+
+nav a:hover {
+    color: var(--accent);
+}
+
+h2 {
+    margin-top: 40px;
+    margin-bottom: 8px;
+    font-size: 22px;
+}
+
+h3 {
+    margin-top: 28px;
+    margin-bottom: 4px;
+    font-size: 17px;
+}
+
+p,
+li {
+    color: var(--fg);
+}
+
+p.meta {
+    color: var(--muted);
+    font-size: 14px;
+    margin-top: 0;
+}
+
+a {
+    color: var(--accent);
+}
+
+ul {
+    padding-left: 20px;
+}
+
+table {
+    border-collapse: collapse;
+    width: 100%;
+    margin: 12px 0;
+    font-size: 14px;
+}
+
+th,
+td {
+    text-align: left;
+    padding: 8px 10px;
+    border-bottom: 1px solid var(--border);
+    vertical-align: top;
+}
+
+th {
+    color: var(--muted);
+    font-weight: 600;
+}
+
+section.locale {
+    margin-top: 56px;
+    padding-top: 24px;
+    border-top: 1px dashed var(--border);
+}
+
+section.locale:first-of-type {
+    border-top: none;
+    padding-top: 0;
+    margin-top: 0;
+}
+
+footer {
+    margin-top: 64px;
+    padding-top: 16px;
+    border-top: 1px solid var(--border);
+    color: var(--muted);
+    font-size: 13px;
+    text-align: center;
+}

--- a/docs/site/support.html
+++ b/docs/site/support.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Support — Memozy</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <main>
+        <header>
+            <h1>Memozy</h1>
+            <nav>
+                <a href="index.html">Home</a>
+                <a href="privacy.html">Privacy</a>
+                <a href="support.html">Support</a>
+            </nav>
+        </header>
+
+        <!-- ============= 한국어 ============= -->
+        <section class="locale" lang="ko">
+            <h2>고객 지원</h2>
+            <p>Memozy 사용 중 문제가 있거나 기능 제안이 있으시면 아래 이메일로 연락해 주세요.</p>
+
+            <h3>📩 문의</h3>
+            <p><a href="mailto:pecos6246@gmail.com">pecos6246@gmail.com</a></p>
+            <p>문의 시 다음 정보를 함께 보내주시면 빠르게 도와드립니다:</p>
+            <ul>
+                <li>OS 및 버전 (예: iOS 18.2 / Android 14)</li>
+                <li>디바이스 모델</li>
+                <li>앱 버전</li>
+                <li>발생 상황 및 재현 방법</li>
+                <li>(선택) 스크린샷 / 화면 녹화</li>
+            </ul>
+
+            <h3>❓ 자주 묻는 질문</h3>
+
+            <p><strong>Q. AI 요약이 작동하지 않아요.</strong></p>
+            <ul>
+                <li>인터넷 연결을 확인해 주세요.</li>
+                <li>무료 티어는 일일 요약 횟수 제한이 있습니다. 한도 도달 시 광고 시청 또는 Memozy Pro 업그레이드로 추가 요약이 가능합니다.</li>
+                <li>YouTube 영상에 자막이 없거나 자막 추출이 차단된 경우 요약할 수 없습니다.</li>
+            </ul>
+
+            <p><strong>Q. 클라우드 백업은 어떻게 작동하나요?</strong></p>
+            <ul>
+                <li>Apple 또는 Google 계정으로 로그인하면 메모가 자동으로 클라우드에 백업됩니다.</li>
+                <li>다른 기기에서 같은 계정으로 로그인하면 메모를 복원할 수 있습니다.</li>
+                <li>로그아웃해도 로컬 저장된 메모는 유지됩니다.</li>
+            </ul>
+
+            <p><strong>Q. Memozy Pro 구독을 취소하고 싶어요.</strong></p>
+            <ul>
+                <li>iOS: 설정 → Apple ID → 구독 → Memozy → 구독 취소</li>
+                <li>Android: Google Play 스토어 → 메뉴 → 구독 → Memozy → 구독 취소</li>
+                <li>취소 후에도 결제한 기간 만료까지는 Pro 기능을 사용할 수 있습니다.</li>
+            </ul>
+
+            <p><strong>Q. 환불이 가능한가요?</strong></p>
+            <ul>
+                <li>구독은 Apple App Store 또는 Google Play 정책에 따라 환불됩니다.</li>
+                <li>환불 신청은 각 스토어의 구매 내역에서 직접 진행해 주세요.</li>
+            </ul>
+
+            <p><strong>Q. 계정과 모든 데이터를 삭제하고 싶어요.</strong></p>
+            <ul>
+                <li>앱 → 설정 → 계정 → 계정 삭제</li>
+                <li>또는 <a href="mailto:pecos6246@gmail.com">pecos6246@gmail.com</a> 으로 요청해 주세요.</li>
+            </ul>
+
+            <p><strong>Q. 음성 인식이 잘 안돼요.</strong></p>
+            <ul>
+                <li>마이크 권한이 허용되었는지 확인해 주세요.</li>
+                <li>iOS 의 경우 음성 인식 권한도 별도로 필요합니다.</li>
+                <li>주변 소음이 큰 경우 인식 정확도가 떨어질 수 있습니다.</li>
+            </ul>
+        </section>
+
+        <!-- ============= English ============= -->
+        <section class="locale" lang="en">
+            <h2>Support</h2>
+            <p>If you have any issue or suggestion while using Memozy, please email us.</p>
+
+            <h3>📩 Contact</h3>
+            <p><a href="mailto:pecos6246@gmail.com">pecos6246@gmail.com</a></p>
+            <p>Please include the following so we can help quickly:</p>
+            <ul>
+                <li>OS and version (e.g. iOS 18.2 / Android 14)</li>
+                <li>Device model</li>
+                <li>App version</li>
+                <li>What happened, and how to reproduce</li>
+                <li>(Optional) Screenshot or screen recording</li>
+            </ul>
+
+            <h3>❓ FAQ</h3>
+
+            <p><strong>Q. AI summary doesn't work.</strong></p>
+            <ul>
+                <li>Check your internet connection.</li>
+                <li>Free tier has a daily summary limit. Watch an ad or upgrade to Memozy Pro for more.</li>
+                <li>YouTube videos without transcripts cannot be summarised.</li>
+            </ul>
+
+            <p><strong>Q. How does cloud backup work?</strong></p>
+            <ul>
+                <li>Sign in with Apple or Google to back up notes automatically.</li>
+                <li>Sign in on another device to restore.</li>
+                <li>Local notes remain after sign-out.</li>
+            </ul>
+
+            <p><strong>Q. How do I cancel Memozy Pro?</strong></p>
+            <ul>
+                <li>iOS: Settings → Apple ID → Subscriptions → Memozy → Cancel</li>
+                <li>Android: Google Play → Menu → Subscriptions → Memozy → Cancel</li>
+                <li>Pro features remain until the paid period ends.</li>
+            </ul>
+
+            <p><strong>Q. Can I get a refund?</strong></p>
+            <ul>
+                <li>Refunds follow Apple App Store / Google Play policy.</li>
+                <li>Request refunds directly from each store's purchase history.</li>
+            </ul>
+
+            <p><strong>Q. How do I delete my account and all data?</strong></p>
+            <ul>
+                <li>App → Settings → Account → Delete account</li>
+                <li>Or email <a href="mailto:pecos6246@gmail.com">pecos6246@gmail.com</a>.</li>
+            </ul>
+
+            <p><strong>Q. Voice recognition isn't accurate.</strong></p>
+            <ul>
+                <li>Check microphone permission.</li>
+                <li>iOS additionally requires speech recognition permission.</li>
+                <li>Background noise may reduce accuracy.</li>
+            </ul>
+        </section>
+
+        <footer>© 2026 pecos-lab</footer>
+    </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
App Store Connect 심사 제출에 필요한 **개인정보 처리방침 / 지원 URL** 호스팅.

`develop` 브랜치 + `/docs/site/` 경로로 GitHub Pages 서빙 예정 (PR 머지 후 Settings → Pages 활성화).

## 최종 URL (예정)
- 랜딩: https://pecos-lab.github.io/memozy/site/
- Privacy: https://pecos-lab.github.io/memozy/site/privacy.html
- Support: https://pecos-lab.github.io/memozy/site/support.html

## 추가된 파일
- `docs/site/index.html` — 앱 소개 (한/영)
- `docs/site/privacy.html` — 개인정보 처리방침 (한/영)
  - 시행일: 2026-05-09
  - 수집 항목 8개 (이메일/메모/오디오/구독/광고ID/통계/충돌/마이크)
  - 제3자 처리위탁 10개사 (Supabase / Gemini / AdMob / Firebase / Apple / Google / RevenueCat / Cloudflare / Supadata / 스토어)
  - 보관 기간 명시 (탈퇴까지 / 14개월 / 90일 / 5년)
  - 사용자 권리 (열람·정정·삭제·처리정지·동의철회)
- `docs/site/support.html` — 고객 지원 + FAQ (한/영, 6개 질문)
- `docs/site/style.css` — 다크모드 자동 대응 공통 스타일

## 후속 작업
- [ ] 머지 후 Settings → Pages → develop 브랜치 + `/docs` 경로로 활성화
- [ ] 빌드 완료 후 위 URL 접속 확인
- [ ] App Store Connect 1.0 버전 메타데이터에 두 URL 입력

## 관련
- Epic #324 — iOS App Store 출시 준비

🤖 Generated with [Claude Code](https://claude.com/claude-code)