### PR TITLE
Update: 사이트 홍보 문구 정리 — Gemini AI · 카테고리 제거

### DIFF
--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -23,10 +23,9 @@
 
             <h3>주요 기능</h3>
             <ul>
-                <li>🎬 YouTube 영상 요약 (Gemini AI)</li>
+                <li>🎬 YouTube 영상 요약</li>
                 <li>🌐 웹페이지 요약</li>
                 <li>🎙 음성 녹음 + 실시간 받아쓰기</li>
-                <li>📂 11 가지 카테고리 분류</li>
                 <li>✏ 리치 텍스트 편집</li>
                 <li>🌙 다크 / 라이트 모드</li>
                 <li>🌐 한국어 · English · 日本語</li>
@@ -40,10 +39,9 @@
 
             <h3>Highlights</h3>
             <ul>
-                <li>YouTube video summaries (Gemini AI)</li>
+                <li>YouTube video summaries</li>
                 <li>Web article summaries</li>
                 <li>Voice memos with live transcription</li>
-                <li>11 categories</li>
                 <li>Rich text editing</li>
                 <li>Light / Dark mode</li>
                 <li>한국어 · English · 日本語</li>


### PR DESCRIPTION
## Summary
- `docs/site/index.html` 한/영 홍보 문구에서 `Gemini AI` 표기 제거
- 단종된 카테고리 분류 기능 항목 제거 (`11 가지 카테고리 분류` / `11 categories`)

## Why
- 라이브 사이트(`https://pecos.me/memozy/site/`)에 사용 모델명을 노출할 필요 없음
- 카테고리 기능은 이미 제거됐는데 홍보 문구에만 남아 있어 불일치

## Scope
- 개인정보처리방침(`privacy.html`)의 `Google Cloud (Gemini API)` 처리위탁 표기는 **법적 고지 의무**라 그대로 유지

## Test plan
- [ ] 머지 후 GitHub Pages 재빌드 확인 (1~3분)
- [ ] `https://pecos.me/memozy/site/index.html` 캐시 새로고침 후 Gemini · 카테고리 문구 사라진 것 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)