### PR TITLE
Update: #354 AI 기능 정비 — 한도/동시실행/녹음카드/요술봉 UX/액션 명령

### DIFF
--- a/feature/core/resource/src/commonMain/kotlin/me/pecos/memozy/presentation/theme/SubscriptionTier.kt
+++ b/feature/core/resource/src/commonMain/kotlin/me/pecos/memozy/presentation/theme/SubscriptionTier.kt
@@ -6,7 +6,7 @@ enum class SubscriptionTier {
     val dailyAiLimit: Int
         get() = when (this) {
             FREE -> 3
-            PRO -> 50
+            PRO -> 30
         }
 
     val isPro: Boolean get() = this == PRO

--- a/feature/memo-plain/impl/src/commonMain/kotlin/me/pecos/memozy/feature/memoplain/impl/MemoPlainNavigationImpl.kt
+++ b/feature/memo-plain/impl/src/commonMain/kotlin/me/pecos/memozy/feature/memoplain/impl/MemoPlainNavigationImpl.kt
@@ -68,6 +68,7 @@ import me.pecos.memozy.platform.intent.AppPermission
 import me.pecos.memozy.platform.intent.PermissionService
 import me.pecos.memozy.platform.intent.PermissionStatus
 import me.pecos.memozy.platform.intent.SharedContentReader
+import me.pecos.memozy.platform.intent.ToastPresenter
 import me.pecos.memozy.platform.intent.percentDecodeUtf8
 import me.pecos.memozy.platform.media.AudioFileStore
 import me.pecos.memozy.platform.media.AudioRecorder
@@ -109,8 +110,36 @@ class MemoPlainNavigationImpl(
         private const val FEATURE_AI_ASSIST = "ai_assist"
         private const val MAX_DAILY_AD_VIEWS = 3
         private const val MAX_MEMO_CONTEXT_CHARS = 3000
-        private const val MEMOZY_AI_SYSTEM_ROLE = "너는 Memozy AI야. 메모지 앱의 AI 어시스턴트로, 사용자의 메모 작성을 돕는 게 너의 역할이야. 너의 이름은 'Memozy AI'이고, 다른 AI 서비스의 이름으로 자신을 소개하면 안 돼. 사용자가 '너 누구야?' 등 정체를 물어볼 때만 'Memozy AI입니다! 메모 작성을 도와드릴게요' 라고 답해. 그 외에는 자기소개 없이 바로 답변해. 인사말, 도입부('도와드릴게요', '해결책을 찾아볼게요', '물론이죠', '네!' 등) 없이 핵심 내용부터 바로 시작해."
+        private const val MEMOZY_AI_SYSTEM_ROLE = "너는 Memozy AI야. 메모지 앱의 AI 어시스턴트로, 사용자의 메모 작성을 돕는 게 너의 역할이야. 너의 이름은 'Memozy AI'이고, 다른 AI 서비스의 이름으로 자신을 소개하면 안 돼. 사용자가 '너 누구야?' 등 정체를 물어볼 때만 'Memozy AI입니다! 메모 작성을 도와드릴게요' 라고 답해. 그 외에는 자기소개 없이 바로 답변해. 도입부 인사('도와드릴게요', '물론이죠', '네!' 등)는 생략하고 본문부터 시작하되, 톤은 친근하고 다정하게(반말은 쓰지 마). 단답으로 끊지 말고 충분히 살을 붙여 꼼꼼하게 설명해 — 정의 → 배경/원리 → 예시 → 관련 맥락 순으로 자연스럽게 풀어줘. 사용자가 더 깊이 알고 싶을 만한 포인트가 있으면 슬쩍 짚어주는 것도 좋아."
         private const val NO_MARKDOWN_RULE = "마크다운 문법(**, ##, - 등)을 절대 사용하지 마. 순수 텍스트로만 답해."
+
+        // 메모 자체 조작 요청 시 AI 가 출력해야 하는 액션 명령 사양.
+        // 일반 질문 (정보/설명/의견) 은 평소처럼 텍스트로 답하고, 메모를 직접 수정하라는
+        // 요청에만 액션 명령을 단독으로 출력한다.
+        private val MEMOZY_AI_ACTION_RULES = """
+사용자가 메모 자체를 수정/조작하라고 요청하면 일반 텍스트 답변 대신 아래 액션 명령 중 하나만 정확한 형식으로, 다른 부가 텍스트 없이 출력해.
+
+지원 액션:
+[ACTION:CLEAR]                    — 본문 비우기
+[ACTION:BOLD_ALL]                 — 본문 전체 굵게
+[ACTION:ITALIC_ALL]               — 본문 전체 이탤릭
+[ACTION:UNDERLINE_ALL]            — 본문 전체 밑줄
+[ACTION:REPLACE]
+새 본문 내용 (여러 줄 가능)
+[/ACTION]                         — 본문을 통째로 교체 (번역/다듬기/정리 등)
+[ACTION:APPEND]
+끝에 추가할 내용
+[/ACTION]                         — 본문 끝에 새 내용 덧붙이기
+
+요청 → 액션 매핑 예시:
+"메모 지워줘" → [ACTION:CLEAR]
+"전체 볼드로 만들어줘" → [ACTION:BOLD_ALL]
+"이거 영어로 번역해서 본문 바꿔줘" → [ACTION:REPLACE] + (번역된 영어 본문) + [/ACTION]
+"오타 다듬어줘" → [ACTION:REPLACE] + (다듬은 본문) + [/ACTION]
+"맨 끝에 '내일 회의' 한 줄 추가" → [ACTION:APPEND] + 내일 회의 + [/ACTION]
+
+단, 일반 질문/설명/의견 요청에는 액션 명령을 쓰지 말고 평소처럼 친근한 텍스트로 답해.
+            """.trimIndent()
 
         private fun stripMarkdown(text: String): String = text
             .replace(Regex("""^\s*#{1,6}\s+""", RegexOption.MULTILINE), "")  // ### 제목
@@ -442,6 +471,12 @@ class MemoPlainNavigationImpl(
                 )
             }
 
+            // AI 사용 1회 차감. 화면 재진입 전까지 카운터 sync 를 위해 in-memory 도 같이 +1.
+            val consumeAiQuota: (String) -> Unit = { feature ->
+                dailyUsageCount++
+                scope.launch { aiUsageDao.insert(AiUsage(feature = feature)) }
+            }
+
             // 이미지 OCR 처리
             var imageOcrState by remember { mutableStateOf<SummaryState>(SummaryState.Idle) }
             val sharedContentReader: SharedContentReader = koinInject()
@@ -558,6 +593,22 @@ class MemoPlainNavigationImpl(
             var transcriptionResult by remember { mutableStateOf<String?>(null) }
             var transcriptionError by remember { mutableStateOf<String?>(null) }
             var savedAudioPath by remember { mutableStateOf<String?>(null) }
+            // 녹음 끝난 직후 사용자에게 "저장/닫기" 결정 받기 위한 pending state.
+            // 파일은 이미 permanent 로 옮겨져 안전 — 닫기 시에만 삭제.
+            var pendingAudioPath by remember { mutableStateOf<String?>(null) }
+            var pendingAudioDurationSeconds by remember { mutableStateOf(0L) }
+            // Web summary busy — 가드 검사용으로 다른 busy state 와 같은 위치에 선언
+            var isWebSummarizing by remember { mutableStateOf(false) }
+
+            val toastPresenter: ToastPresenter = koinInject()
+            // AI 기능 중복 실행 가드 — 어느 하나라도 진행 중이면 다른 entry point 차단
+            val isAnyAiBusy = isRecording || isTranscribing || isWebSummarizing ||
+                inlineSummaryState is SummaryState.Loading ||
+                inlineSummaryState is SummaryState.Streaming ||
+                isAiAssistLoading
+            val notifyAiBusy: () -> Unit = {
+                toastPresenter.show("다른 AI 작업이 진행 중이에요. 잠시 후 다시 시도해주세요.")
+            }
             // 에러/결과 메시지 3초 후 자동 해제
             LaunchedEffect(transcriptionError) {
                 if (transcriptionError != null) {
@@ -605,6 +656,14 @@ class MemoPlainNavigationImpl(
             }
 
             fun startRecording() {
+                if (isAnyAiBusy) {
+                    notifyAiBusy()
+                    return
+                }
+                if (!canUseAi) {
+                    notifyAiBlocked()
+                    return
+                }
                 transcriptionResult = null
                 if (permissionService.status(AppPermission.RECORD_AUDIO) == PermissionStatus.GRANTED) {
                     beginRecording()
@@ -623,6 +682,14 @@ class MemoPlainNavigationImpl(
                 audioRecorder = null
                 isRecording = false
 
+                // 녹음 도중 다른 AI 사용으로 한도 초과되면 transcription 차단.
+                // 녹음 캐시는 폐기 — 결과 보존 시 사용자가 잘못 이해할 수 있음.
+                if (!canUseAi) {
+                    audioFileStore.delete(audioCachePath)
+                    notifyAiBlocked()
+                    return
+                }
+
                 // Live STT 결과를 최종 — Gemini polish 제거 (Gemini 가 WAV 포맷 이슈로 hallucinate 발생)
                 // Live STT 텍스트가 있으면 그대로 본문에 남기고 종료. 파일은 audio playback 용으로 영구 저장.
                 val liveTextFinal = liveTranscriptionService.confirmedText.value.ifBlank {
@@ -640,9 +707,11 @@ class MemoPlainNavigationImpl(
                             audioFileStore.copy(audioCachePath, permanentPath)
                             audioFileStore.delete(audioCachePath)
                             savedAudioPath = permanentPath
+                            pendingAudioPath = permanentPath
+                            pendingAudioDurationSeconds = durationSeconds
                         }
                     }
-                    scope.launch { aiUsageDao.insert(AiUsage(feature = FEATURE_TRANSCRIPTION)) }
+                    consumeAiQuota(FEATURE_TRANSCRIPTION)
                     return
                 }
 
@@ -676,10 +745,12 @@ class MemoPlainNavigationImpl(
                             audioFileStore.copy(audioCachePath, permanentPath)
                             audioFileStore.delete(audioCachePath)
                             savedAudioPath = permanentPath
+                            pendingAudioPath = permanentPath
+                            pendingAudioDurationSeconds = durationSeconds
 
                             transcriptionResult = result
                             transcriptionError = null
-                            aiUsageDao.insert(AiUsage(feature = FEATURE_TRANSCRIPTION))
+                            consumeAiQuota(FEATURE_TRANSCRIPTION)
                         }
                     } catch (e: Exception) {
                         transcriptionError = "음성 변환에 실패했어요."
@@ -690,8 +761,7 @@ class MemoPlainNavigationImpl(
                 }
             }
 
-            // 웹 요약 상태
-            var isWebSummarizing by remember { mutableStateOf(false) }
+            // 웹 요약 상태 (isWebSummarizing 은 위쪽에 선언됨 — 가드용)
             var webSummaryResult by remember { mutableStateOf<String?>(null) }
             var webSummaryError by remember { mutableStateOf<String?>(null) }
             var webPageTitle by remember { mutableStateOf<String?>(null) }
@@ -751,6 +821,19 @@ class MemoPlainNavigationImpl(
                 transcriptionResult = transcriptionResult,
                 transcriptionError = transcriptionError,
                 audioPath = savedAudioPath,
+                pendingAudioPath = pendingAudioPath,
+                pendingAudioDurationSeconds = pendingAudioDurationSeconds,
+                onSaveRecording = {
+                    pendingAudioPath = null
+                },
+                onDiscardRecording = {
+                    val path = pendingAudioPath
+                    if (path != null) {
+                        scope.launch { audioFileStore.delete(path) }
+                    }
+                    savedAudioPath = null
+                    pendingAudioPath = null
+                },
                 onCancelSummarize = {
                     currentSummarizeJob?.cancel()
                     currentSummarizeJob = null
@@ -759,6 +842,10 @@ class MemoPlainNavigationImpl(
                     isTranscribing = false
                 },
                 onWebSummarize = { url, mode ->
+                    if (isAnyAiBusy) {
+                        notifyAiBusy()
+                        return@MemoScreen
+                    }
                     if (!canUseAi) {
                         notifyAiBlocked()
                         return@MemoScreen
@@ -779,7 +866,7 @@ class MemoPlainNavigationImpl(
                                     )
                                 }
                                 webSummaryResult = summary
-                                aiUsageDao.insert(AiUsage(feature = FEATURE_WEB_SUMMARY))
+                                consumeAiQuota(FEATURE_WEB_SUMMARY)
                             }
                         } catch (e: Exception) {
                             webSummaryError = when {
@@ -799,6 +886,10 @@ class MemoPlainNavigationImpl(
                 webSummaryError = webSummaryError,
                 webPageTitle = webPageTitle,
                 onWebSummaryStyleSelected = { style, url ->
+                    if (isAnyAiBusy) {
+                        notifyAiBusy()
+                        return@MemoScreen
+                    }
                     if (!canUseAi) {
                         notifyAiBlocked()
                         return@MemoScreen
@@ -824,7 +915,7 @@ class MemoPlainNavigationImpl(
                                     )
                                 }
                                 webSummaryResult = summary
-                                aiUsageDao.insert(AiUsage(feature = FEATURE_WEB_SUMMARY))
+                                consumeAiQuota(FEATURE_WEB_SUMMARY)
                             }
                         } catch (e: Exception) {
                             webSummaryError = when {
@@ -848,8 +939,12 @@ class MemoPlainNavigationImpl(
                     // 바텀시트에서 양식 선택 시 즉시 요약 실행
                     currentSummarizeJob?.cancel()
                     currentSummarizeJob = scope.launch {
+                        if (isAnyAiBusy) {
+                            notifyAiBusy()
+                            return@launch
+                        }
                         if (!canUseAi) {
-                            showLimitBottomSheet = true
+                            notifyAiBlocked()
                             return@launch
                         }
                         val videoId = extractVideoId(url)
@@ -886,8 +981,7 @@ class MemoPlainNavigationImpl(
                                 ))
                             }
                             inlineSummaryState = SummaryState.Success(summary)
-                            aiUsageDao.insert(AiUsage(feature = FEATURE_YOUTUBE_SUMMARY))
-                            dailyUsageCount++
+                            consumeAiQuota(FEATURE_YOUTUBE_SUMMARY)
                         } catch (e: Exception) {
                             inlineSummaryState = SummaryState.Error(e.message ?: "요약 실패")
                         }
@@ -909,8 +1003,12 @@ class MemoPlainNavigationImpl(
                     }
                     activeSummaryStyle = style
                     currentSummarizeJob = scope.launch {
+                        if (isAnyAiBusy) {
+                            notifyAiBusy()
+                            return@launch
+                        }
                         if (!canUseAi) {
-                            showLimitBottomSheet = true
+                            notifyAiBlocked()
                             return@launch
                         }
                         val videoId = extractVideoId(url)
@@ -951,8 +1049,7 @@ class MemoPlainNavigationImpl(
                             }
                             inlineSummaryState = SummaryState.Success(summary)
                             // 성공 시 사용 횟수 증가
-                            aiUsageDao.insert(AiUsage(feature = FEATURE_YOUTUBE_SUMMARY))
-                            dailyUsageCount++
+                            consumeAiQuota(FEATURE_YOUTUBE_SUMMARY)
                         } catch (e: Exception) {
                             val errorMsg = when {
                                 e.message?.contains("token count exceeds") == true ||
@@ -998,7 +1095,6 @@ class MemoPlainNavigationImpl(
                         onNavigateToHome()
                     }
                 } else null,
-                // Memozy AI
                 aiAssistStreamingText = aiAssistStreamingText,
                 isAiAssistLoading = isAiAssistLoading,
                 isAiCancelled = isAiCancelled,
@@ -1009,6 +1105,10 @@ class MemoPlainNavigationImpl(
                     isAiAssistLoading = false
                 },
                 onAiCustomSend = { userMessage, currentTitle, currentBody ->
+                    if (isAnyAiBusy) {
+                        notifyAiBusy()
+                        return@MemoScreen
+                    }
                     if (!canUseAi) {
                         notifyAiBlocked()
                         return@MemoScreen
@@ -1023,13 +1123,12 @@ class MemoPlainNavigationImpl(
                             val memoBody = if (plainBody.length > MAX_MEMO_CONTEXT_CHARS) {
                                 plainBody.take(2000) + "\n...(중략)...\n" + plainBody.takeLast(1000)
                             } else plainBody
-                            val systemRole = MEMOZY_AI_SYSTEM_ROLE
-                            val noMarkdownRule = NO_MARKDOWN_RULE
                             val prompt = buildString {
-                                appendLine(systemRole)
-                                appendLine("답변은 간결하고 핵심적으로.")
-                                appendLine("사용자가 현재 메모를 작성 중이니, 메모 내용이 있으면 참고해서 답해줘.")
-                                appendLine("메모와 관련 없는 질문이어도 자유롭게 답변해. 답변은 간결하게. $noMarkdownRule")
+                                appendLine(MEMOZY_AI_SYSTEM_ROLE)
+                                appendLine("사용자가 현재 메모를 작성 중이니, 메모 내용이 있으면 자연스럽게 참고해서 답해줘.")
+                                appendLine("메모와 관련 없는 질문이어도 자유롭게 답변하고, 살을 충분히 붙여 친근하게 풀어줘. $NO_MARKDOWN_RULE")
+                                appendLine()
+                                appendLine(MEMOZY_AI_ACTION_RULES)
                                 appendLine()
                                 if (memoBody.isNotBlank()) {
                                     appendLine("=== 현재 메모 ===")
@@ -1045,82 +1144,10 @@ class MemoPlainNavigationImpl(
                                 sb.append(delta)
                                 aiAssistStreamingText = stripMarkdown(sb.toString())
                             }
-                            // UI가 마지막 스트리밍 텍스트를 반영할 시간 확보
                             kotlinx.coroutines.yield()
                             kotlinx.coroutines.delay(50)
                             aiAssistStreamingText = null
-                            aiUsageDao.insert(AiUsage(feature = FEATURE_AI_ASSIST))
-                            dailyUsageCount++
-                        } catch (e: Exception) {
-                            aiAssistStreamingText = null
-                            if (e is kotlinx.coroutines.CancellationException) return@launch
-                        } finally {
-                            isAiAssistLoading = false
-                        }
-                    }
-                },
-                onAiPresetAction = { actionName, currentTitle, currentBody ->
-                    if (!canUseAi) {
-                        notifyAiBlocked()
-                        return@MemoScreen
-                    }
-                    aiAssistJob?.cancel()
-                    aiAssistJob = scope.launch {
-                        isAiAssistLoading = true
-                        isAiCancelled = false
-                        aiAssistStreamingText = ""
-                        try {
-                            val plainBody = currentBody.replace(Regex("<[^>]*>"), "").trim()
-                            val memoBody = if (plainBody.length > MAX_MEMO_CONTEXT_CHARS) {
-                                plainBody.take(2000) + "\n...(중략)...\n" + plainBody.takeLast(1000)
-                            } else plainBody
-                            if (memoBody.isBlank()) {
-                                aiAssistStreamingText = null
-                                return@launch
-                            }
-                            val systemRole = MEMOZY_AI_SYSTEM_ROLE
-                            val noMarkdownRule = NO_MARKDOWN_RULE
-                            val prompt = when (actionName) {
-                                "EXPLAIN" -> buildString {
-                                    appendLine(systemRole)
-                                    appendLine("아래 메모 내용을 이해하기 쉽게 풀어서 설명해줘. 어려운 용어가 있으면 쉬운 말로 바꿔줘.")
-                                    appendLine("설명문만 출력해. $noMarkdownRule")
-                                    appendLine()
-                                    appendLine("=== 메모 ===")
-                                    appendLine("제목: $currentTitle")
-                                    appendLine(memoBody)
-                                }
-                                "ORGANIZE" -> buildString {
-                                    appendLine(systemRole)
-                                    appendLine("아래 메모 내용을 깔끔하게 정리해줘. 구조화하고 가독성을 높여줘.")
-                                    appendLine("정리된 텍스트만 출력해. $noMarkdownRule")
-                                    appendLine()
-                                    appendLine("=== 메모 ===")
-                                    appendLine("제목: $currentTitle")
-                                    appendLine(memoBody)
-                                }
-                                "SUMMARIZE" -> buildString {
-                                    appendLine(systemRole)
-                                    appendLine("아래 메모 내용의 핵심만 간결하게 요약해줘. 원문의 1/3 이하로 줄여줘.")
-                                    appendLine("요약문만 출력해. $noMarkdownRule")
-                                    appendLine()
-                                    appendLine("=== 메모 ===")
-                                    appendLine("제목: $currentTitle")
-                                    appendLine(memoBody)
-                                }
-                                else -> return@launch
-                            }
-                            val sb = StringBuilder()
-                            aiApiService.generateContentStream(prompt).collect { delta ->
-                                sb.append(delta)
-                                aiAssistStreamingText = stripMarkdown(sb.toString())
-                            }
-                            // UI가 마지막 스트리밍 텍스트를 반영할 시간 확보
-                            kotlinx.coroutines.yield()
-                            kotlinx.coroutines.delay(50)
-                            aiAssistStreamingText = null
-                            aiUsageDao.insert(AiUsage(feature = FEATURE_AI_ASSIST))
-                            dailyUsageCount++
+                            consumeAiQuota(FEATURE_AI_ASSIST)
                         } catch (e: Exception) {
                             aiAssistStreamingText = null
                             if (e is kotlinx.coroutines.CancellationException) return@launch

--- a/feature/memo-plain/impl/src/commonMain/kotlin/me/pecos/memozy/presentation/screen/memo/MemoScreen.kt
+++ b/feature/memo-plain/impl/src/commonMain/kotlin/me/pecos/memozy/presentation/screen/memo/MemoScreen.kt
@@ -145,8 +145,6 @@ import me.pecos.memozy.presentation.screen.memo.components.SummaryStyleBottomShe
 import me.pecos.memozy.presentation.screen.memo.components.YouTubeSummaryInlineCard
 import me.pecos.memozy.presentation.screen.memo.components.YouTubeLinkBottomSheet
 import me.pecos.memozy.presentation.screen.memo.components.YouTubeUrlDialog
-import me.pecos.memozy.presentation.screen.memo.components.AiActionMenu
-import me.pecos.memozy.presentation.screen.memo.components.AiPresetAction
 import me.pecos.memozy.presentation.screen.memo.components.MemoActionBar
 import me.pecos.memozy.presentation.theme.LocalAppColors
 import me.pecos.memozy.presentation.theme.LocalFontSettings
@@ -243,6 +241,10 @@ fun MemoScreen(
     transcriptionResult: String? = null,
     transcriptionError: String? = null,
     audioPath: String? = null,
+    pendingAudioPath: String? = null,
+    pendingAudioDurationSeconds: Long = 0L,
+    onSaveRecording: (() -> Unit)? = null,
+    onDiscardRecording: (() -> Unit)? = null,
     onWebSummarize: ((url: String, mode: SummaryMode) -> Unit)? = null,
     onCancelSummarize: (() -> Unit)? = null,
     isWebSummarizing: Boolean = false,
@@ -252,7 +254,6 @@ fun MemoScreen(
     onSummaryStyleSelected: ((SummaryStyle, String) -> Unit)? = null,
     onWebSummaryStyleSelected: ((SummaryStyle, String) -> Unit)? = null,
     // Memozy AI — (actionName, currentTitle, currentBody)
-    onAiPresetAction: ((String, String, String) -> Unit)? = null,
     onAiCustomSend: ((String, String, String) -> Unit)? = null,
     onAiCancel: (() -> Unit)? = null,
     isAiCancelled: Boolean = false,
@@ -362,44 +363,98 @@ fun MemoScreen(
         }
     }
 
-    // Memozy AI 스트리밍 → 본문 끝에 실시간 반영
+    // Memozy AI 스트리밍 → 본문 끝에 실시간 반영 (단, 액션 명령은 제외)
     var aiInsertAnchorHtml by remember { mutableStateOf("") }
     var aiInsertAnchorPlain by remember { mutableStateOf("") }
     var lastStreamedText by remember { mutableStateOf("") }
 
-    // aiAssistStreamingText 변경될 때마다 직접 반응
+    fun escHtml(s: String) = s
+        .replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace("\n", "<br>")
+
+    // 액션 명령 파싱: 단일형 ([ACTION:CLEAR] 등) 과 페이로드형 ([ACTION:REPLACE]\n...\n[/ACTION])
+    val singleActionRegex = Regex("""\A\s*\[ACTION:(CLEAR|BOLD_ALL|ITALIC_ALL|UNDERLINE_ALL)]\s*\z""")
+    val payloadActionRegex = Regex("""\A\s*\[ACTION:(REPLACE|APPEND)]\s*\n([\s\S]*?)\n\s*\[/ACTION]\s*\z""")
+
+    fun looksLikeAction(s: String): Boolean = s.trimStart().startsWith("[ACTION:")
+
+    fun executeAiAction(type: String, payload: String?) {
+        when (type) {
+            "CLEAR" -> {
+                richTextState.setHtml("")
+                bodyText = ""
+            }
+            "BOLD_ALL", "ITALIC_ALL", "UNDERLINE_ALL" -> {
+                val plain = richTextState.annotatedString.text
+                if (plain.isNotEmpty()) {
+                    val tag = when (type) {
+                        "BOLD_ALL" -> "strong"; "ITALIC_ALL" -> "em"; else -> "u"
+                    }
+                    richTextState.setHtml("<p><$tag>${escHtml(plain)}</$tag></p>")
+                    bodyText = richTextState.annotatedString.text
+                }
+            }
+            "REPLACE" -> {
+                val text = payload.orEmpty()
+                richTextState.setHtml("<p>${escHtml(text)}</p>")
+                bodyText = text
+            }
+            "APPEND" -> {
+                val text = payload.orEmpty()
+                val current = richTextState.annotatedString.text
+                val joined = if (current.isBlank()) text else "$current\n\n$text"
+                richTextState.setHtml("<p>${escHtml(joined)}</p>")
+                bodyText = joined
+            }
+        }
+    }
+
     LaunchedEffect(aiAssistStreamingText) {
         val streaming = aiAssistStreamingText
         if (streaming != null) {
             if (aiInsertAnchorHtml.isEmpty()) {
-                // 스트리밍 시작 — 앵커 저장 (1회)
                 aiInsertAnchorHtml = richTextState.toHtml()
                 aiInsertAnchorPlain = richTextState.annotatedString.text
                 lastStreamedText = ""
             }
-            // 스트리밍 중 — bodyText 업데이트
             if (streaming.isNotBlank()) {
                 lastStreamedText = streaming
-                val separator = if (aiInsertAnchorPlain.isBlank()) "" else "\n\n"
-                bodyText = aiInsertAnchorPlain + separator + streaming
+                // 액션 명령 진행 중이면 본문에 노출하지 않음 — 완료 시 일괄 실행
+                if (!looksLikeAction(streaming)) {
+                    val separator = if (aiInsertAnchorPlain.isBlank()) "" else "\n\n"
+                    bodyText = aiInsertAnchorPlain + separator + streaming
+                }
             }
         } else if (aiInsertAnchorHtml.isNotEmpty()) {
-            // 스트리밍 완료 또는 취소
             if (isAiCancelled) {
-                // 취소 — 본문 원복
                 richTextState.setHtml(aiInsertAnchorHtml)
                 bodyText = richTextState.annotatedString.text
             } else if (lastStreamedText.isNotBlank()) {
-                // 완료 — richTextState에 최종 결과 반영
-                val escapedAi = lastStreamedText.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace("\n", "<br>")
-                val anchorHtml = aiInsertAnchorHtml.trimEnd()
-                val finalHtml = if (anchorHtml.isBlank() || anchorHtml == "<p><br></p>") {
-                    "<p>$escapedAi</p>"
-                } else {
-                    "$anchorHtml<p><br></p><p>$escapedAi</p>"
+                val singleMatch = singleActionRegex.matchEntire(lastStreamedText)
+                val payloadMatch = payloadActionRegex.matchEntire(lastStreamedText)
+                when {
+                    singleMatch != null -> {
+                        // 액션 — 본문 그대로 두고 명령만 실행
+                        executeAiAction(singleMatch.groupValues[1], null)
+                    }
+                    payloadMatch != null -> {
+                        executeAiAction(payloadMatch.groupValues[1], payloadMatch.groupValues[2])
+                    }
+                    else -> {
+                        // 일반 텍스트 응답 — 본문 끝에 삽입 (기존 동작)
+                        val escapedAi = escHtml(lastStreamedText)
+                        val anchorHtml = aiInsertAnchorHtml.trimEnd()
+                        val finalHtml = if (anchorHtml.isBlank() || anchorHtml == "<p><br></p>") {
+                            "<p>$escapedAi</p>"
+                        } else {
+                            "$anchorHtml<p><br></p><p>$escapedAi</p>"
+                        }
+                        richTextState.setHtml(finalHtml)
+                        bodyText = richTextState.annotatedString.text
+                    }
                 }
-                richTextState.setHtml(finalHtml)
-                bodyText = richTextState.annotatedString.text
             }
             aiInsertAnchorHtml = ""
             aiInsertAnchorPlain = ""
@@ -468,11 +523,11 @@ fun MemoScreen(
     val colors = LocalAppColors.current  // ← CompositionLocal에서 현재 테마 색상 가져옴
     val fontSettings = LocalFontSettings.current
 
-    var showAiActionMenu by remember { mutableStateOf(false) }
     var showAiCustomInput by remember { mutableStateOf(false) }
-    // AI 액션 메뉴 / 기타 바텀시트 띄울 때 키보드 먼저 내리기 — IME 와 ModalBottomSheet 가 충돌해서
-    // 시트가 가려지거나 위치가 어긋나 보이는 문제 방지.
+    // AI 채팅 툴바 띄울 때 키보드 먼저 내리기 — IME 와 입력 툴바 위치 충돌 방지.
     val focusManager = androidx.compose.ui.platform.LocalFocusManager.current
+    // 본문 포커스 — AI 채팅 닫을 때 복원해서 키보드/툴바 유지
+    val bodyFocusRequester = remember { FocusRequester() }
 
     // containerColor 명시 → MaterialTheme.colorScheme.surface 무시
     Scaffold(
@@ -580,9 +635,6 @@ fun MemoScreen(
                     .verticalScroll(scrollState)
                     .padding(horizontal = 32.dp, vertical = 16.dp)
             ) {
-                // 제목 — 개행 시 내용으로 포커스 이동
-                val bodyFocusRequester = remember { FocusRequester() }
-
                 // 메모 진입 시 본문에 자동 포커스 + 키보드 표시 (노션 스타일) — 신규/편집 모두
                 LaunchedEffect(Unit) {
                     kotlinx.coroutines.delay(100) // 컴포지션 안정화 대기
@@ -805,6 +857,34 @@ fun MemoScreen(
                         }
                     }
                 )
+
+                // 녹음 후 저장 여부 확인 카드 — pendingAudioPath 가 있는 동안만 노출
+                if (pendingAudioPath != null && onSaveRecording != null && onDiscardRecording != null) {
+                    Spacer(modifier = Modifier.height(12.dp))
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clip(RoundedCornerShape(12.dp))
+                            .background(colors.chipBackground.copy(alpha = 0.5f))
+                            .padding(horizontal = 14.dp, vertical = 10.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        val mm = pendingAudioDurationSeconds / 60
+                        val ss = pendingAudioDurationSeconds % 60
+                        Text(
+                            text = "🎙 녹음 (${mm}:${ss.toString().padStart(2, '0')})",
+                            fontSize = fontSettings.scaled(14),
+                            color = colors.textBody,
+                            modifier = Modifier.weight(1f),
+                        )
+                        TextButton(onClick = onSaveRecording) {
+                            Text("저장", fontSize = fontSettings.scaled(13), color = colors.chipText)
+                        }
+                        TextButton(onClick = onDiscardRecording) {
+                            Text("닫기", fontSize = fontSettings.scaled(13), color = colors.textBody.copy(alpha = 0.6f))
+                        }
+                    }
+                }
 
                 // 본문 아래 빈 공간도 탭하면 본문에 포커스
                 Spacer(
@@ -1086,7 +1166,10 @@ fun MemoScreen(
                                 tint = colors.textBody.copy(alpha = 0.5f),
                                 modifier = Modifier
                                     .size(18.dp)
-                                    .clickable { showAiCustomInput = false }
+                                    .clickable {
+                                        try { bodyFocusRequester.requestFocus() } catch (_: Throwable) {}
+                                        showAiCustomInput = false
+                                    }
                             )
                         }
                     }
@@ -1120,10 +1203,13 @@ fun MemoScreen(
                                     onYoutubeDialogOpen = { showYoutubeDialog = true },
                                     onWebSummarize = onWebSummarize,
                                     onWebDialogOpen = { showWebDialog = true },
-                                    onAiAssistClick = if (onAiPresetAction != null) {
+                                    onAiAssistClick = if (onAiCustomSend != null) {
                                         {
-                                            focusManager.clearFocus()
-                                            showAiActionMenu = true
+                                            if (showAiCustomInput) {
+                                                // 닫을 때 본문 포커스 복원 — 키보드/툴바 유지
+                                                try { bodyFocusRequester.requestFocus() } catch (_: Throwable) {}
+                                            }
+                                            showAiCustomInput = !showAiCustomInput
                                         }
                                     } else null
                                 )
@@ -1136,22 +1222,7 @@ fun MemoScreen(
             }
         } // outer Column
 
-    // AI 액션 메뉴 팝업 — AnimatedVisibility 바깥에 배치 (���보드 내려가도 유지)
-    if (showAiActionMenu && onAiPresetAction != null) {
-        AiActionMenu(
-            onPresetSelected = { action ->
-                showAiActionMenu = false
-                if (action == AiPresetAction.CUSTOM) {
-                    showAiCustomInput = true
-                } else {
-                    onAiPresetAction(action.name, nameText, bodyText)
-                }
-            },
-            onDismiss = { showAiActionMenu = false }
-        )
-    }
-
-    // 웹 URL 입력 다이얼로그
+// 웹 URL 입력 다이얼로그
     if (showWebDialog && onWebSummarize != null) {
         WebUrlDialog(
             onDismiss = { showWebDialog = false },


### PR DESCRIPTION
## Summary
iOS 출시 직전 AI 기능 전반 정비. 비용 안전망 + 동시실행 가드 + 녹음 UX 개선 + 메모지AI(요술봉) 톤·액션 개편. 모두 commonMain 변경이라 Android 에도 자동 적용.

## 1. PRO 일일 한도 50 → 30
- `SubscriptionTier.kt`
- 사유: 헤비유저 API 비용 보수적 책정. 카피 "사용량 증가" 약속은 여전히 충족 (FREE 3 → PRO 30 = 10배)

## 2. 카운팅/가드 통합 + 버그 픽스 2건
- 새 헬퍼 `consumeAiQuota(feature)` — DB insert + in-memory 카운터 +1 한 쌍으로 묶음
- 🐞 **카운터 sync 버그 픽스**: Web 요약 / Transcription 경로가 in-memory 카운터를 증가시키지 않아 같은 화면에서 한도 우회 가능했음
- 🐞 **YouTube 가드 우회 픽스**: `showLimitBottomSheet = true` 직접 설정 → `notifyAiBlocked()` 통일 (analytics 일관 + 비로그인 fallback 동작)
- 녹음 사전/사후 가드 추가 (한도 race 대응)

## 3. AI 기능 동시실행 차단 (mutex)
- `isAnyAiBusy` derived state (녹음/transcription/web/youtube/AI assist)
- 6개 entry point 가드: \"다른 AI 작업이 진행 중이에요. 잠시 후 다시 시도해주세요.\" toast
- ToastPresenter Koin 주입 추가

## 4. 녹음 후 저장/닫기 카드
- 새 state: `pendingAudioPath`, `pendingAudioDurationSeconds`
- 본문 editor 아래 inline 카드: \`🎙 녹음 (m:ss) [저장] [닫기]\`
- **저장**: 카드만 사라짐 (파일은 이미 permanent 저장됨)
- **닫기**: 파일 삭제 + savedAudioPath 해제

## 5. 요술봉 (Memozy AI) UX 개편
- ❌ 바텀시트 preset 메뉴 (EXPLAIN/ORGANIZE/SUMMARIZE) 제거
- ✅ 요술봉 한 번 = 채팅 툴바 노출, 두 번 = 채팅창만 닫힘
- 닫을 때 본문 포커스 복원 → 키보드/포맷팅 툴바 그대로 유지
- `bodyFocusRequester` outer scope 로 hoist
- 사용 안 하는 import 정리 (`AiActionMenu`, `AiPresetAction`)

## 6. AI 응답 톤 + 메모 조작 액션 명령
**톤**: 친근/다정 + 도입부 인사 자제 + 단답 금지 + 정의 → 배경 → 예시 → 맥락 순으로 살붙여 설명. 사용자 프롬프트의 \"간결하게\" 제거.

**메모 조작 액션** (AI 가 메모 직접 수정):
| 액션 | 효과 | 페이로드 |
|---|---|---|
| `[ACTION:CLEAR]` | 본문 비우기 | — |
| `[ACTION:BOLD_ALL]` / `ITALIC_ALL` / `UNDERLINE_ALL` | 본문 전체 서식 | — |
| `[ACTION:REPLACE]\\n...\\n[/ACTION]` | 본문 통째로 교체 (번역/다듬기) | text |
| `[ACTION:APPEND]\\n...\\n[/ACTION]` | 본문 끝에 추가 | text |

- MemoScreen: 정규식 파싱 + `executeAiAction()` 함수
- 스트리밍 중 \`[ACTION:\` 감지 시 본문 노출 억제 (사용자가 명령 텍스트 안 봄)
- 일반 질문/설명은 평소처럼 친근한 텍스트로 응답

## Test plan
- [x] iOS 시뮬레이터 컴파일 통과 (`compileKotlinIosSimulatorArm64`)
- [ ] iOS 디바이스 검증 (사용자 진행 중)
  - [ ] AI 한도 초과 시 차단 토스트
  - [ ] 동시 사용 차단 (녹음 중 YouTube 시도 등)
  - [ ] 녹음 카드 [저장]/[닫기]
  - [ ] 요술봉 토글 (키보드 유지)
  - [ ] AI 액션: \"메모 지워줘\" / \"전체 볼드\" / \"영어로 번역\" / \"맨 끝에 한 줄 추가\"
  - [ ] AI 일반 응답 톤 (살붙여 설명)
- [ ] Android 검증 — #354 에서 별도 트래킹 (내일 작업)

## 관련
- Android 1.0 출시 트래킹: #354
- iOS 출시 PR: #352
- 양 플랫폼 동등성 Epic: #330

🤖 Generated with [Claude Code](https://claude.com/claude-code)