### PR TITLE
Fix: #357 정지 버튼 회귀 + 녹음 STT 인프라 재작성 (AudioRecord + Gemini Live)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -88,6 +88,7 @@ android {
             buildConfigField("String", "ADMOB_REWARD_AD_UNIT_ID", "\"${localProperties.getProperty("admob.reward.ad.unit.id", testRewardAdUnitId)}\"")
             buildConfigField("String", "ADMOB_TEST_DEVICE_IDS", "\"${localProperties.getProperty("admob.test.device.ids", "")}\"")
             buildConfigField("String", "REVENUECAT_API_KEY", "\"${localProperties.getProperty("revenuecat.android.api.key", "")}\"")
+            buildConfigField("String", "VOSK_MODEL_URL", "\"${localProperties.getProperty("vosk.model.url", "")}\"")
         }
         release {
             isMinifyEnabled = true
@@ -104,6 +105,7 @@ android {
             buildConfigField("String", "ADMOB_REWARD_AD_UNIT_ID", "\"${localProperties.getProperty("admob.reward.ad.unit.id", testRewardAdUnitId)}\"")
             buildConfigField("String", "ADMOB_TEST_DEVICE_IDS", "\"${localProperties.getProperty("admob.test.device.ids", "")}\"")
             buildConfigField("String", "REVENUECAT_API_KEY", "\"${localProperties.getProperty("revenuecat.android.prod.api.key", "")}\"")
+            buildConfigField("String", "VOSK_MODEL_URL", "\"${localProperties.getProperty("vosk.model.prod.url", localProperties.getProperty("vosk.model.url", ""))}\"")
         }
     }
 }

--- a/app/src/main/java/me/pecos/memozy/di/TranscriptionPlatformModule.kt
+++ b/app/src/main/java/me/pecos/memozy/di/TranscriptionPlatformModule.kt
@@ -1,10 +1,17 @@
 package me.pecos.memozy.di
 
+import me.pecos.memozy.BuildConfig
 import me.pecos.memozy.platform.transcription.LiveTranscriptionService
 import me.pecos.memozy.platform.transcription.provideLiveTranscriptionService
 import org.koin.android.ext.koin.androidContext
 import org.koin.dsl.module
 
 val transcriptionPlatformModule = module {
-    single<LiveTranscriptionService> { provideLiveTranscriptionService(androidContext()) }
+    single<LiveTranscriptionService> {
+        provideLiveTranscriptionService(
+            context = androidContext(),
+            workerUrl = BuildConfig.WORKER_URL,
+            appKey = BuildConfig.APP_SECRET_KEY,
+        )
+    }
 }

--- a/feature/memo-plain/impl/src/commonMain/kotlin/me/pecos/memozy/feature/memoplain/impl/MemoPlainNavigationImpl.kt
+++ b/feature/memo-plain/impl/src/commonMain/kotlin/me/pecos/memozy/feature/memoplain/impl/MemoPlainNavigationImpl.kt
@@ -629,7 +629,8 @@ class MemoPlainNavigationImpl(
             val permissionService: PermissionService = koinInject()
             var audioRecorder by remember { mutableStateOf<AudioRecorder?>(null) }
             var recordingStartTime by remember { mutableStateOf(0L) }
-            val audioCachePath = remember { audioFileStore.cachePath("recording.m4a") }
+            // RecordingService 가 PCM 16-bit/16kHz/mono WAV 로 저장.
+            val audioCachePath = remember { audioFileStore.cachePath("recording.wav") }
 
             fun beginRecording() {
                 try {
@@ -732,7 +733,8 @@ class MemoPlainNavigationImpl(
                         val audioBytes = audioFileStore.readBytes(audioCachePath)
                         @OptIn(ExperimentalEncodingApi::class)
                         val base64 = Base64.Default.encode(audioBytes)
-                        val result = aiApiService.transcribeAudio(base64, "audio/mp4", durationSeconds)
+                        // RecordingService 가 WAV(PCM 16-bit/16kHz/mono) 로 저장하므로 MIME 도 audio/wav.
+                        val result = aiApiService.transcribeAudio(base64, "audio/wav", durationSeconds)
                         // Gemini가 프롬프트를 그대로 반환하는 경우 필터링
                         if (result.contains("받아쓰기") || result.contains("텍스트만 출력") || result.isBlank()) {
                             transcriptionError = "음성이 감지되지 않았어요. 다시 시도해주세요."

--- a/feature/memo-plain/impl/src/commonMain/kotlin/me/pecos/memozy/presentation/screen/memo/MemoScreen.kt
+++ b/feature/memo-plain/impl/src/commonMain/kotlin/me/pecos/memozy/presentation/screen/memo/MemoScreen.kt
@@ -155,8 +155,9 @@ import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.ime
-import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.ui.platform.LocalDensity
 import dev.chrisbanes.haze.HazeStyle
 import dev.chrisbanes.haze.HazeTint
@@ -563,6 +564,11 @@ fun MemoScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(innerPadding)
+                // IME 가 dismiss 되어도 nav bar 영역까지 padding 유지 → 녹음 정지 버튼(툴바)이
+                // 시스템 nav bar 제스처 영역으로 미끄러져 클릭이 가로채이는 #357 회귀 차단.
+                // navigationBarsPadding → imePadding 순서로 체이닝하면 inset consumption 으로
+                // IME up 시 (nav + (ime-nav)) = ime, IME down 시 nav 만 적용되어 중복 padding 없음.
+                .navigationBarsPadding()
                 .imePadding()
         ) {
             // 상단 바

--- a/feature/memo-plain/impl/src/commonMain/kotlin/me/pecos/memozy/presentation/screen/memo/components/AudioPlayerBar.kt
+++ b/feature/memo-plain/impl/src/commonMain/kotlin/me/pecos/memozy/presentation/screen/memo/components/AudioPlayerBar.kt
@@ -84,7 +84,7 @@ fun AudioPlayerBar(
             ) { Icon(if (isPlaying) Icons.Default.Pause else Icons.Default.PlayArrow, contentDescription = null, tint = Color.White, modifier = Modifier.size(20.dp)) }
             Spacer(modifier = Modifier.width(10.dp))
             Text("🎙️ ${memoTitle.ifBlank { stringResource(Res.string.recording_file) }}", fontSize = fontSettings.scaled(14), color = colors.textBody, fontWeight = FontWeight.SemiBold, modifier = Modifier.weight(1f), maxLines = 1)
-            val downloadsTarget = audioFileStore.downloadsPath("memozy_${Clock.System.now().toEpochMilliseconds()}.m4a")
+            val downloadsTarget = audioFileStore.downloadsPath("memozy_${Clock.System.now().toEpochMilliseconds()}.wav")
             if (downloadsTarget != null) {
                 Icon(Icons.Default.Download, contentDescription = null, tint = colors.textSecondary,
                     modifier = Modifier.size(20.dp).clickable {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -100,6 +100,7 @@ ktor-client-darwin = { group = "io.ktor", name = "ktor-client-darwin", version.r
 ktor-client-content-negotiation = { group = "io.ktor", name = "ktor-client-content-negotiation", version.ref = "ktor" }
 ktor-serialization-kotlinx-json = { group = "io.ktor", name = "ktor-serialization-kotlinx-json", version.ref = "ktor" }
 ktor-client-logging = { group = "io.ktor", name = "ktor-client-logging", version.ref = "ktor" }
+ktor-client-websockets = { group = "io.ktor", name = "ktor-client-websockets", version.ref = "ktor" }
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
 koin-core = { group = "io.insert-koin", name = "koin-core", version.ref = "koin" }
 koin-compose = { group = "io.insert-koin", name = "koin-compose", version.ref = "koin" }

--- a/platform/media/impl/src/androidMain/kotlin/me/pecos/memozy/platform/media/AndroidAudioFileStore.kt
+++ b/platform/media/impl/src/androidMain/kotlin/me/pecos/memozy/platform/media/AndroidAudioFileStore.kt
@@ -46,6 +46,6 @@ class AndroidAudioFileStore(
 
     private companion object {
         const val AUDIO_SUBDIR = "audio"
-        const val AUDIO_EXT = "m4a"
+        const val AUDIO_EXT = "wav"
     }
 }

--- a/platform/media/impl/src/androidMain/kotlin/me/pecos/memozy/platform/media/RecordingService.kt
+++ b/platform/media/impl/src/androidMain/kotlin/me/pecos/memozy/platform/media/RecordingService.kt
@@ -1,5 +1,6 @@
 package me.pecos.memozy.platform.media
 
+import android.Manifest
 import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
@@ -7,24 +8,41 @@ import android.app.PendingIntent
 import android.app.Service
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.content.pm.ServiceInfo
+import android.media.AudioFormat
+import android.media.AudioRecord
 import android.media.MediaRecorder
 import android.os.Build
 import android.os.IBinder
+import android.util.Log
 import androidx.core.app.NotificationCompat
+import androidx.core.content.ContextCompat
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.concurrent.thread
 
 /**
- * 녹음용 Foreground Service.
+ * 녹음 + 실시간 받아쓰기 통합 Foreground Service.
  *
- * 화면이 꺼지거나 앱이 백그라운드로 가도 녹음이 끊기지 않도록 MediaRecorder 를 별도 서비스에서 보유.
- * 알림바에 녹음 상태 + 정지 버튼 노출 (Android 13+ 의 `microphone` foregroundServiceType 사용).
+ * iOS 의 AVAudioEngine input tap 패턴을 흉내 — mic 1개 클라이언트(AudioRecord)에서 PCM 을 받아
+ * (1) WAV 파일에 그대로 쓰기 + (2) 등록된 PcmListener 들에 broadcast.
+ *
+ * 기존 MediaRecorder + SpeechRecognizer 동시 사용 시 mic 자원 경합으로
+ * SpeechRecognizer 가 NO_SPEECH_DETECTED 만 뱉던 회귀를 차단.
+ *
+ * 실시간 STT 는 외부 구현 (GeminiLiveTranscriptionService 등) 이 PcmListener 로 PCM 을
+ * 받아 자체적으로 처리하고, [publishPartial] / [publishConfirmed] 로 결과를 push 한다.
  */
-internal class RecordingService : Service() {
+class RecordingService : Service() {
 
-    private var recorder: MediaRecorder? = null
+    private val running = AtomicBoolean(false)
+    private var audioRecord: AudioRecord? = null
+    private var captureThread: Thread? = null
     private var outputPath: String? = null
+    private var wavSink: WavFileSink? = null
 
     override fun onBind(intent: Intent?): IBinder? = null
 
@@ -32,58 +50,144 @@ internal class RecordingService : Service() {
         when (intent?.action) {
             ACTION_START -> {
                 val path = intent.getStringExtra(EXTRA_OUTPUT_PATH)
-                if (path != null) {
-                    startRecording(path)
+                if (path != null && !running.get()) {
+                    startCapture(path)
                 }
             }
-            ACTION_STOP -> {
-                if (recorder == null) {
-                    android.util.Log.i(TAG, "STOP received but recorder is null — already stopped or never started")
-                }
-                stopRecordingAndService()
-            }
+            ACTION_STOP -> stopCapture()
         }
-        // START_NOT_STICKY: 프로세스 종료 시 Service 자동 재시작 안 함.
-        // 이유: companion object 의 _state StateFlow 는 재시작 후 부정확하므로 상태 일관성 유지를 위해 명시적 재시작만 허용.
         return START_NOT_STICKY
     }
 
-    private fun startRecording(path: String) {
-        if (recorder != null) return // 이미 녹음 중
+    private fun startCapture(path: String) {
         outputPath = path
+        _partial.value = ""
+        _confirmed.value = ""
 
         startForegroundCompat()
 
-        recorder = createRecorder().apply {
-            setAudioSource(MediaRecorder.AudioSource.MIC)
-            setOutputFormat(MediaRecorder.OutputFormat.MPEG_4)
-            setAudioEncoder(MediaRecorder.AudioEncoder.AAC)
-            setAudioSamplingRate(16000)
-            setAudioEncodingBitRate(64000)
-            setOutputFile(path)
-            try {
-                prepare()
-                start()
-                _state.value = RecordingState.Recording(path)
-            } catch (e: Exception) {
-                _state.value = RecordingState.Idle
-                stopRecordingAndService()
+        if (ContextCompat.checkSelfPermission(
+                this, Manifest.permission.RECORD_AUDIO
+            ) != PackageManager.PERMISSION_GRANTED
+        ) {
+            Log.w(TAG, "RECORD_AUDIO permission not granted")
+            _state.value = RecordingState.Idle
+            stopForeground(STOP_FOREGROUND_REMOVE)
+            stopSelf()
+            return
+        }
+
+        val sink = WavFileSink(path, SAMPLE_RATE, 1, 16).also { it.open() }
+        wavSink = sink
+
+        val minBuf = AudioRecord.getMinBufferSize(
+            SAMPLE_RATE, AudioFormat.CHANNEL_IN_MONO, AudioFormat.ENCODING_PCM_16BIT
+        )
+        if (minBuf <= 0) {
+            Log.e(TAG, "AudioRecord.getMinBufferSize failed ($minBuf)")
+            stopCapture()
+            return
+        }
+        val bufSize = minBuf * 2
+
+        val rec = try {
+            AudioRecord(
+                MediaRecorder.AudioSource.MIC,
+                SAMPLE_RATE,
+                AudioFormat.CHANNEL_IN_MONO,
+                AudioFormat.ENCODING_PCM_16BIT,
+                bufSize,
+            )
+        } catch (e: Throwable) {
+            Log.e(TAG, "AudioRecord ctor failed", e)
+            stopCapture()
+            return
+        }
+
+        if (rec.state != AudioRecord.STATE_INITIALIZED) {
+            Log.e(TAG, "AudioRecord not initialized (state=${rec.state})")
+            try { rec.release() } catch (_: Throwable) {}
+            stopCapture()
+            return
+        }
+
+        try {
+            rec.startRecording()
+        } catch (e: Throwable) {
+            Log.e(TAG, "AudioRecord startRecording failed", e)
+            try { rec.release() } catch (_: Throwable) {}
+            stopCapture()
+            return
+        }
+
+        audioRecord = rec
+        running.set(true)
+        _state.value = RecordingState.Recording(path)
+
+        captureThread = thread(name = "MemozyPcmCapture", isDaemon = false) {
+            val buffer = ByteArray(bufSize)
+            while (running.get()) {
+                val n = try {
+                    rec.read(buffer, 0, buffer.size)
+                } catch (e: Throwable) {
+                    Log.w(TAG, "AudioRecord.read threw: ${e.message}")
+                    break
+                }
+                if (n > 0) {
+                    try { sink.write(buffer, n) } catch (e: Throwable) {
+                        Log.w(TAG, "WAV write failed: ${e.message}")
+                    }
+                    // Listener broadcast — listener 측에서 자체적으로 throttle/network IO 분리
+                    val listeners = pcmListeners
+                    if (listeners.isNotEmpty()) {
+                        // copy buffer slice to avoid mutation race
+                        val chunk = ByteArray(n)
+                        System.arraycopy(buffer, 0, chunk, 0, n)
+                        for (l in listeners) {
+                            try { l.onPcmChunk(chunk, n) } catch (e: Throwable) {
+                                Log.w(TAG, "pcm listener failed: ${e.message}")
+                            }
+                        }
+                    }
+                } else if (n < 0) {
+                    Log.w(TAG, "AudioRecord.read returned $n")
+                    break
+                }
             }
         }
     }
 
-    private fun stopRecordingAndService() {
-        try {
-            recorder?.apply {
-                try { stop() } catch (_: Throwable) {}
-                release()
-            }
-        } finally {
-            recorder = null
+    private fun stopCapture() {
+        if (!running.compareAndSet(true, false)) {
             _state.value = RecordingState.Idle
             stopForeground(STOP_FOREGROUND_REMOVE)
             stopSelf()
+            return
         }
+
+        try { captureThread?.join(800) } catch (_: Throwable) {}
+        captureThread = null
+
+        audioRecord?.let { rec ->
+            try { rec.stop() } catch (_: Throwable) {}
+            try { rec.release() } catch (_: Throwable) {}
+        }
+        audioRecord = null
+
+        // partial 잔여 → confirmed 로 흡수
+        val tail = _partial.value
+        if (tail.isNotBlank()) {
+            val cur = _confirmed.value
+            _confirmed.value = if (cur.isEmpty()) tail else "$cur $tail"
+            _partial.value = ""
+        }
+
+        wavSink?.close()
+        wavSink = null
+
+        _state.value = RecordingState.Idle
+        stopForeground(STOP_FOREGROUND_REMOVE)
+        stopSelf()
     }
 
     private fun startForegroundCompat() {
@@ -102,7 +206,6 @@ internal class RecordingService : Service() {
     private fun buildNotification(): Notification {
         val nm = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            // 채널이 없을 때만 생성 — 매번 createNotificationChannel 호출 비용 회피
             if (nm.getNotificationChannel(CHANNEL_ID) == null) {
                 val channel = NotificationChannel(
                     CHANNEL_ID,
@@ -141,23 +244,21 @@ internal class RecordingService : Service() {
             .build()
     }
 
-    @Suppress("DEPRECATION")
-    private fun createRecorder(): MediaRecorder =
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            MediaRecorder(this)
-        } else {
-            MediaRecorder()
-        }
-
     override fun onDestroy() {
         super.onDestroy()
-        stopRecordingAndService()
+        if (running.get()) stopCapture()
+    }
+
+    interface PcmListener {
+        /** 16kHz mono 16-bit PCM little-endian. buf[0..len) 만 유효. buf 는 호출자가 소유. */
+        fun onPcmChunk(buf: ByteArray, len: Int)
     }
 
     companion object {
         const val ACTION_START = "me.pecos.memozy.recording.START"
         const val ACTION_STOP = "me.pecos.memozy.recording.STOP"
         const val EXTRA_OUTPUT_PATH = "output_path"
+        const val SAMPLE_RATE = 16000
 
         private const val CHANNEL_ID = "memozy.recording"
         private const val NOTIFICATION_ID = 8801
@@ -166,6 +267,29 @@ internal class RecordingService : Service() {
 
         private val _state = MutableStateFlow<RecordingState>(RecordingState.Idle)
         val state: StateFlow<RecordingState> = _state
+
+        private val _partial = MutableStateFlow("")
+        private val _confirmed = MutableStateFlow("")
+        val partial: StateFlow<String> = _partial
+        val confirmed: StateFlow<String> = _confirmed
+
+        private val pcmListeners = CopyOnWriteArrayList<PcmListener>()
+
+        fun addPcmListener(l: PcmListener) { pcmListeners.addIfAbsent(l) }
+        fun removePcmListener(l: PcmListener) { pcmListeners.remove(l) }
+
+        /** 외부 STT 구현이 partial 결과를 발행. */
+        fun publishPartial(text: String) {
+            _partial.value = text
+        }
+
+        /** 외부 STT 구현이 확정 결과(문장 단위)를 누적 발행. */
+        fun publishConfirmed(text: String) {
+            if (text.isBlank()) return
+            val cur = _confirmed.value
+            _confirmed.value = if (cur.isEmpty()) text else "$cur $text"
+            _partial.value = ""
+        }
 
         fun start(context: Context, outputPath: String) {
             val intent = Intent(context, RecordingService::class.java).apply {
@@ -188,7 +312,7 @@ internal class RecordingService : Service() {
     }
 }
 
-internal sealed class RecordingState {
+sealed class RecordingState {
     data object Idle : RecordingState()
     data class Recording(val outputPath: String) : RecordingState()
 }

--- a/platform/media/impl/src/androidMain/kotlin/me/pecos/memozy/platform/media/WavFileSink.kt
+++ b/platform/media/impl/src/androidMain/kotlin/me/pecos/memozy/platform/media/WavFileSink.kt
@@ -1,0 +1,64 @@
+package me.pecos.memozy.platform.media
+
+import java.io.File
+import java.io.RandomAccessFile
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+internal class WavFileSink(
+    private val path: String,
+    private val sampleRate: Int,
+    private val channels: Int,
+    private val bitsPerSample: Int,
+) {
+    private var raf: RandomAccessFile? = null
+    private var dataSize: Long = 0
+
+    fun open() {
+        val f = File(path)
+        f.parentFile?.mkdirs()
+        if (f.exists()) f.delete()
+        raf = RandomAccessFile(f, "rw").apply {
+            setLength(0)
+            write(buildHeader(0))
+        }
+        dataSize = 0
+    }
+
+    fun write(buf: ByteArray, len: Int) {
+        val r = raf ?: return
+        r.write(buf, 0, len)
+        dataSize += len
+    }
+
+    fun close() {
+        val r = raf ?: return
+        try {
+            r.seek(0)
+            r.write(buildHeader(dataSize.toInt()))
+        } finally {
+            try { r.close() } catch (_: Throwable) {}
+            raf = null
+        }
+    }
+
+    private fun buildHeader(dataLen: Int): ByteArray {
+        val byteRate = sampleRate * channels * bitsPerSample / 8
+        val blockAlign = channels * bitsPerSample / 8
+        return ByteBuffer.allocate(44).order(ByteOrder.LITTLE_ENDIAN).apply {
+            put("RIFF".toByteArray(Charsets.US_ASCII))
+            putInt(36 + dataLen)
+            put("WAVE".toByteArray(Charsets.US_ASCII))
+            put("fmt ".toByteArray(Charsets.US_ASCII))
+            putInt(16)
+            putShort(1.toShort())
+            putShort(channels.toShort())
+            putInt(sampleRate)
+            putInt(byteRate)
+            putShort(blockAlign.toShort())
+            putShort(bitsPerSample.toShort())
+            put("data".toByteArray(Charsets.US_ASCII))
+            putInt(dataLen)
+        }.array()
+    }
+}

--- a/platform/transcription/impl/build.gradle.kts
+++ b/platform/transcription/impl/build.gradle.kts
@@ -11,9 +11,15 @@ kotlin {
         commonMain.dependencies {
             api(projects.platform.transcription.api)
             implementation(libs.kotlinx.coroutines.core)
+            implementation(libs.ktor.client.core)
+            implementation(libs.ktor.client.websockets)
+            implementation(libs.kotlinx.serialization.json)
         }
         androidMain.dependencies {
             implementation(libs.androidx.core.ktx)
+            implementation(libs.ktor.client.okhttp)
+            // RecordingService 의 PCM listener / state 노출에 의존
+            implementation(projects.platform.media.impl)
         }
     }
 }

--- a/platform/transcription/impl/src/androidMain/kotlin/me/pecos/memozy/platform/transcription/AndroidLiveTranscriptionService.kt
+++ b/platform/transcription/impl/src/androidMain/kotlin/me/pecos/memozy/platform/transcription/AndroidLiveTranscriptionService.kt
@@ -1,119 +1,79 @@
 package me.pecos.memozy.platform.transcription
 
 import android.content.Context
-import android.content.Intent
-import android.os.Bundle
-import android.os.Handler
-import android.os.Looper
-import android.speech.RecognitionListener
-import android.speech.RecognizerIntent
-import android.speech.SpeechRecognizer
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import me.pecos.memozy.platform.media.RecordingService
+import me.pecos.memozy.platform.media.RecordingState
 
-fun provideLiveTranscriptionService(context: Context): LiveTranscriptionService =
-    AndroidLiveTranscriptionService(context.applicationContext)
+fun provideLiveTranscriptionService(
+    context: Context,
+    workerUrl: String,
+    appKey: String,
+): LiveTranscriptionService =
+    AndroidLiveTranscriptionService(context.applicationContext, workerUrl, appKey)
 
+/**
+ * iOS 의 SFSpeechRecognizer + AVAudioEngine 패턴을 Android 에 맞춰 구현.
+ *
+ * 실제 음성 캡처는 [RecordingService] 가 mic 1개 클라이언트(AudioRecord)로 통합 수행.
+ * 실시간 STT 는 [GeminiLiveSession] 이 PCM 청크를 WebSocket 으로 Gemini Live API 에 stream.
+ *
+ * 결과(partial/confirmed) 는 RecordingService 의 companion StateFlow 를 그대로 노출.
+ */
 internal class AndroidLiveTranscriptionService(
-    private val context: Context,
+    @Suppress("UNUSED_PARAMETER") private val context: Context,
+    private val workerUrl: String,
+    private val appKey: String,
 ) : LiveTranscriptionService {
 
-    private val mainHandler = Handler(Looper.getMainLooper())
-    private var recognizer: SpeechRecognizer? = null
-    private var languageCode: String = "ko"
-    private var stillListening = false
+    private val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+    private var session: GeminiLiveSession? = null
 
-    private val _partial = MutableStateFlow("")
-    private val _confirmed = MutableStateFlow("")
+    override val partialText: StateFlow<String> = RecordingService.partial
+    override val confirmedText: StateFlow<String> = RecordingService.confirmed
+
     private val _state = MutableStateFlow<TranscriptionState>(TranscriptionState.Idle)
-
-    override val partialText: StateFlow<String> = _partial
-    override val confirmedText: StateFlow<String> = _confirmed
     override val state: StateFlow<TranscriptionState> = _state
 
+    init {
+        scope.launch {
+            RecordingService.state.collect { rec ->
+                _state.value = when (rec) {
+                    is RecordingState.Idle -> TranscriptionState.Idle
+                    is RecordingState.Recording -> TranscriptionState.Listening
+                }
+            }
+        }
+    }
+
     override suspend fun start(languageCode: String, outputPath: String?) {
-        // Android 는 별도 MediaRecorder (RecordingService) 가 파일 캡처 담당. outputPath 무시.
-        this.languageCode = languageCode
-        _partial.value = ""
-        _confirmed.value = ""
-        stillListening = true
-        mainHandler.post { startSession() }
+        if (workerUrl.isBlank() || appKey.isBlank()) {
+            _state.value = TranscriptionState.Error("Worker URL / app key 미설정")
+            return
+        }
+        // 새 세션 — 기존 세션이 남아있으면 정리
+        session?.stop()
+        val prompt = buildSystemPrompt(languageCode)
+        session = GeminiLiveSession(workerUrl, appKey).apply { start(prompt) }
     }
 
     override fun stop() {
-        stillListening = false
-        mainHandler.post {
-            recognizer?.stopListening()
-            recognizer?.destroy()
-            recognizer = null
-            // partial 에 남아있는 텍스트도 confirmed 로 이관
-            if (_partial.value.isNotEmpty()) {
-                _confirmed.value = (_confirmed.value + " " + _partial.value).trim()
-                _partial.value = ""
-            }
-            _state.value = TranscriptionState.Idle
-        }
+        session?.stop()
+        session = null
     }
 
-    private fun startSession() {
-        recognizer?.destroy()
-        val rec = SpeechRecognizer.createSpeechRecognizer(context)
-        rec.setRecognitionListener(buildListener())
-        val intent = Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH).apply {
-            putExtra(RecognizerIntent.EXTRA_LANGUAGE_MODEL, RecognizerIntent.LANGUAGE_MODEL_FREE_FORM)
-            putExtra(RecognizerIntent.EXTRA_LANGUAGE, mapLocale(languageCode))
-            putExtra(RecognizerIntent.EXTRA_PARTIAL_RESULTS, true)
-            putExtra(RecognizerIntent.EXTRA_PREFER_OFFLINE, false)
+    private fun buildSystemPrompt(languageCode: String): String {
+        val langName = when (languageCode) {
+            "ko" -> "한국어"
+            "en" -> "영어"
+            "ja" -> "일본어"
+            else -> languageCode
         }
-        rec.startListening(intent)
-        recognizer = rec
-        _state.value = TranscriptionState.Listening
-    }
-
-    private fun buildListener() = object : RecognitionListener {
-        override fun onReadyForSpeech(params: Bundle?) {}
-        override fun onBeginningOfSpeech() {}
-        override fun onRmsChanged(rmsdB: Float) {}
-        override fun onBufferReceived(buffer: ByteArray?) {}
-        override fun onEndOfSpeech() {}
-
-        override fun onPartialResults(partialResults: Bundle?) {
-            val text = partialResults
-                ?.getStringArrayList(SpeechRecognizer.RESULTS_RECOGNITION)
-                ?.firstOrNull().orEmpty()
-            if (text.isNotEmpty()) _partial.value = text
-        }
-
-        override fun onResults(results: Bundle?) {
-            val text = results
-                ?.getStringArrayList(SpeechRecognizer.RESULTS_RECOGNITION)
-                ?.firstOrNull().orEmpty()
-            if (text.isNotEmpty()) {
-                _confirmed.value = (_confirmed.value + " " + text).trim()
-                _partial.value = ""
-            }
-            // 사용자가 아직 정지 안 했으면 자동 재시작
-            if (stillListening) {
-                mainHandler.post { startSession() }
-            }
-        }
-
-        override fun onError(error: Int) {
-            // 음성 무음 / 네트워크 등 — 단순히 재시작 시도
-            if (stillListening && error != SpeechRecognizer.ERROR_CLIENT) {
-                mainHandler.postDelayed({ if (stillListening) startSession() }, 100)
-            } else {
-                _state.value = TranscriptionState.Error("error_code=$error")
-            }
-        }
-
-        override fun onEvent(eventType: Int, params: Bundle?) {}
-    }
-
-    private fun mapLocale(code: String): String = when (code) {
-        "ko" -> "ko-KR"
-        "en" -> "en-US"
-        "ja" -> "ja-JP"
-        else -> code
+        return "사용자가 발화한 $langName 음성을 정확히 받아쓰기만 하세요. 별도 응답이나 추가 텍스트는 출력하지 마세요."
     }
 }

--- a/platform/transcription/impl/src/androidMain/kotlin/me/pecos/memozy/platform/transcription/GeminiLiveSession.kt
+++ b/platform/transcription/impl/src/androidMain/kotlin/me/pecos/memozy/platform/transcription/GeminiLiveSession.kt
@@ -1,0 +1,159 @@
+package me.pecos.memozy.platform.transcription
+
+import android.util.Base64
+import android.util.Log
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.okhttp.OkHttp
+import io.ktor.client.plugins.websocket.WebSockets
+import io.ktor.client.plugins.websocket.webSocket
+import io.ktor.client.request.header
+import io.ktor.websocket.Frame
+import io.ktor.websocket.readText
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import me.pecos.memozy.platform.media.RecordingService
+
+/**
+ * Gemini Live API WebSocket 세션 — Worker `/gemini-live` proxy 를 거쳐 양방향 audio stream.
+ *
+ * - 시작: WebSocket open → setup 메시지(model + inputAudioTranscription) 전송 →
+ *   [RecordingService] 에 PcmListener 등록.
+ * - PCM 청크가 들어올 때마다 base64 인코딩 + realtimeInput 메시지로 송신.
+ * - 서버 응답에서 inputTranscription.text 를 추출 → [RecordingService.publishPartial] 로 발행.
+ * - 종료: WebSocket close + listener 해제.
+ *
+ * Worker URL 은 `https://...workers.dev` 형태로 들어오면 `wss://...workers.dev/gemini-live` 로 변환.
+ */
+internal class GeminiLiveSession(
+    private val workerUrl: String,
+    private val appKey: String,
+) {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private var job: Job? = null
+
+    private val httpClient: HttpClient by lazy {
+        HttpClient(OkHttp) {
+            install(WebSockets)
+        }
+    }
+
+    fun start(systemPrompt: String) {
+        if (job?.isActive == true) return
+        val wssUrl = buildWssUrl() + "?k=" + encodeUrlComponent(appKey)
+        Log.i(TAG, "starting Gemini Live session → ${buildWssUrl()} (auth via query)")
+
+        val chunkChannel = Channel<ByteArray>(capacity = Channel.UNLIMITED)
+
+        val pcmListener = object : RecordingService.PcmListener {
+            override fun onPcmChunk(buf: ByteArray, len: Int) {
+                val chunk = if (len == buf.size) buf else buf.copyOf(len)
+                chunkChannel.trySend(chunk)
+            }
+        }
+
+        job = scope.launch {
+            try {
+                httpClient.webSocket(
+                    urlString = wssUrl,
+                    request = { header("x-app-key", appKey) },
+                ) {
+                    val setupJson = buildSetupMessage(systemPrompt)
+                    send(Frame.Text(setupJson))
+                    Log.i(TAG, "setup sent")
+
+                    RecordingService.addPcmListener(pcmListener)
+
+                    // PCM chunk → WebSocket 송신 코루틴
+                    val sendJob = launch {
+                        try {
+                            for (chunk in chunkChannel) {
+                                if (!isActive) break
+                                val b64 = Base64.encodeToString(chunk, Base64.NO_WRAP)
+                                val msg = """{"realtimeInput":{"audio":{"data":"$b64","mimeType":"audio/pcm;rate=16000"}}}"""
+                                try {
+                                    send(Frame.Text(msg))
+                                } catch (e: Throwable) {
+                                    Log.w(TAG, "send failed: ${e.message}")
+                                    break
+                                }
+                            }
+                        } catch (e: Throwable) {
+                            Log.w(TAG, "send loop error: ${e.message}")
+                        }
+                    }
+
+                    try {
+                        for (frame in incoming) {
+                            if (frame is Frame.Text) {
+                                handleServerMessage(frame.readText())
+                            }
+                        }
+                    } finally {
+                        sendJob.cancel()
+                        chunkChannel.close()
+                        RecordingService.removePcmListener(pcmListener)
+                    }
+                }
+            } catch (e: Throwable) {
+                Log.w(TAG, "websocket error: ${e.javaClass.simpleName}: ${e.message}", e)
+                RecordingService.removePcmListener(pcmListener)
+                chunkChannel.close()
+            }
+        }
+    }
+
+    fun stop() {
+        Log.i(TAG, "stopping Gemini Live session")
+        job?.cancel()
+        job = null
+    }
+
+    private fun buildWssUrl(): String {
+        val base = workerUrl
+            .replace("http://", "ws://")
+            .replace("https://", "wss://")
+            .trimEnd('/')
+        return "$base/gemini-live"
+    }
+
+    private fun encodeUrlComponent(s: String): String =
+        java.net.URLEncoder.encode(s, "UTF-8")
+
+    private fun buildSetupMessage(systemPrompt: String): String {
+        // JSON 직접 조립 — Live API 의 가장 기본 setup. 추후 inputAudioTranscription +
+        // systemInstruction 활성화 시 systemPrompt 사용.
+        val safePrompt = systemPrompt.replace("\\", "\\\\").replace("\"", "\\\"")
+        return """
+            {"setup":{"model":"models/gemini-3.1-flash-live-preview","generationConfig":{"responseModalities":["TEXT"]},"inputAudioTranscription":{},"systemInstruction":{"parts":[{"text":"$safePrompt"}]}}}
+        """.trimIndent()
+    }
+
+    /**
+     * 단순 정규식 파서 — Live API 의 inputTranscription.text 만 추출.
+     * Live API 응답에는 setupComplete, modelTurn, turnComplete 등 다양한 메시지가 섞여있으나
+     * 우리는 사용자 발화 텍스트만 필요.
+     */
+    private fun handleServerMessage(json: String) {
+        val text = extractInputTranscription(json)
+        if (text != null && text.isNotBlank()) {
+            RecordingService.publishPartial(text)
+        }
+        // turnComplete 등 별도 신호는 현재 무시. partial 누적이 그대로 최종 텍스트.
+    }
+
+    private fun extractInputTranscription(json: String): String? {
+        // "inputTranscription":{"text":"..."} 형태 매칭
+        val regex = "\"inputTranscription\"\\s*:\\s*\\{[^}]*\"text\"\\s*:\\s*\"([^\"]*)\"".toRegex()
+        return regex.find(json)?.groupValues?.get(1)
+    }
+
+    companion object {
+        private const val TAG = "GeminiLiveSession"
+    }
+}

--- a/workers/src/index.ts
+++ b/workers/src/index.ts
@@ -16,7 +16,7 @@ const FALLBACK_MODELS = ["gemini-2.5-flash-lite", "gemini-1.5-flash"];
 
 function verifyAppAuth(req: Request, env: Env): Response | null {
   const apiKey = req.headers.get("x-app-key");
-  if (!apiKey || apiKey !== env.APP_SECRET_KEY) {
+  if (!apiKey || apiKey !== normalizeSecret(env.APP_SECRET_KEY)) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }
   return null;
@@ -74,12 +74,19 @@ async function supabaseRest(
 
 // --- Gemini helpers ---
 
+// Secret 들이 wrangler secret put 시 PowerShell 인코딩으로 BOM(U+FEFF)/공백을 포함하는 경우가
+// 있어 Gemini 가 "Invalid API key" 응답하는 회귀를 흡수.
+function normalizeSecret(s: string | undefined): string {
+  return (s ?? "").replace(/^﻿/, "").trim();
+}
+
 async function callGemini(
   env: Env,
   model: string,
   body: unknown
 ): Promise<Response> {
-  const url = `${GEMINI_BASE_URL}/models/${model}:generateContent?key=${env.GEMINI_API_KEY}`;
+  const apiKey = normalizeSecret(env.GEMINI_API_KEY);
+  const url = `${GEMINI_BASE_URL}/models/${model}:generateContent?key=${apiKey}`;
   return await fetch(url, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -92,7 +99,8 @@ async function callGeminiStream(
   model: string,
   body: unknown
 ): Promise<Response> {
-  const url = `${GEMINI_BASE_URL}/models/${model}:streamGenerateContent?alt=sse&key=${env.GEMINI_API_KEY}`;
+  const apiKey = normalizeSecret(env.GEMINI_API_KEY);
+  const url = `${GEMINI_BASE_URL}/models/${model}:streamGenerateContent?alt=sse&key=${apiKey}`;
   return await fetch(url, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -151,6 +159,105 @@ async function handleGeminiStream(req: Request, env: Env): Promise<Response> {
       "Cache-Control": "no-cache",
       "Connection": "keep-alive",
     },
+  });
+}
+
+// --- Gemini Live (bidirectional WebSocket proxy) ---
+
+// Cloudflare Worker `fetch` 는 wss:// 스킴 직접 못 받음 — https:// + Upgrade 헤더로 호출하면
+// Cloudflare 가 자동으로 WebSocket 으로 변환.
+const GEMINI_LIVE_WS_URL =
+  "https://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent";
+
+/**
+ * 실시간 음성 인식/통역용 Gemini Live API proxy.
+ *
+ * 클라이언트(앱) ← WebSocket → Worker ← WebSocket → Gemini Live API
+ *
+ * 인증은 표준 REST 핸들러와 동일하게 x-app-key 헤더 검사. 외부 Gemini wss 는
+ * GEMINI_API_KEY 를 query param 으로 주입 (Live API 사양).
+ *
+ * 양방향 raw passthrough — setup/realtimeInput/response 메시지 구조는 클라이언트에서 결정.
+ */
+async function handleGeminiLive(req: Request, env: Env): Promise<Response> {
+  const upgradeHeader = req.headers.get("Upgrade");
+  if (!upgradeHeader || upgradeHeader.toLowerCase() !== "websocket") {
+    return new Response("Expected Upgrade: websocket", { status: 426 });
+  }
+
+  // WebSocket handshake — 일부 client(특히 Ktor/OkHttp)가 custom header를 흘리는 경우가 있어
+  // query param `?k=` 도 인증 대안으로 허용.
+  const urlObj = new URL(req.url);
+  const queryKey = urlObj.searchParams.get("k");
+  const headerKey = req.headers.get("x-app-key");
+  const expected = normalizeSecret(env.APP_SECRET_KEY);
+  if (
+    (!queryKey || queryKey !== expected) &&
+    (!headerKey || headerKey !== expected)
+  ) {
+    return new Response("Unauthorized", { status: 401 });
+  }
+
+  // 외부 Gemini Live wss 연결 먼저 시도
+  const geminiUrl = `${GEMINI_LIVE_WS_URL}?key=${normalizeSecret(env.GEMINI_API_KEY)}`;
+  let geminiResp: Response;
+  try {
+    geminiResp = await fetch(geminiUrl, {
+      headers: { Upgrade: "websocket" },
+    });
+  } catch (e) {
+    return new Response(`Gemini Live connect failed: ${(e as Error).message}`, { status: 502 });
+  }
+
+  const externalWs = geminiResp.webSocket;
+  if (!externalWs) {
+    const body = await geminiResp.text().catch(() => "");
+    return new Response(`Gemini Live did not accept WebSocket (status=${geminiResp.status}): ${body}`, {
+      status: 502,
+    });
+  }
+
+  externalWs.accept();
+
+  // 클라이언트 측 WebSocketPair
+  const pair = new WebSocketPair();
+  const clientSide = pair[0];
+  const serverSide = pair[1];
+  serverSide.accept();
+
+  // app → Gemini
+  serverSide.addEventListener("message", (event) => {
+    try {
+      externalWs.send(event.data as ArrayBuffer | string);
+    } catch (e) {
+      try { serverSide.close(1011, "upstream send failed"); } catch {}
+    }
+  });
+  serverSide.addEventListener("close", (ev) => {
+    try { externalWs.close(ev.code, ev.reason); } catch {}
+  });
+  serverSide.addEventListener("error", () => {
+    try { externalWs.close(1011, "client error"); } catch {}
+  });
+
+  // Gemini → app
+  externalWs.addEventListener("message", (event) => {
+    try {
+      serverSide.send(event.data as ArrayBuffer | string);
+    } catch (e) {
+      try { externalWs.close(1011, "downstream send failed"); } catch {}
+    }
+  });
+  externalWs.addEventListener("close", (ev) => {
+    try { serverSide.close(ev.code, ev.reason); } catch {}
+  });
+  externalWs.addEventListener("error", () => {
+    try { serverSide.close(1011, "upstream error"); } catch {}
+  });
+
+  return new Response(null, {
+    status: 101,
+    webSocket: clientSide,
   });
 }
 
@@ -648,6 +755,12 @@ export default {
   async fetch(req: Request, env: Env): Promise<Response> {
     const url = new URL(req.url);
     const pathname = url.pathname;
+
+    // Gemini Live WebSocket — 일반 routes 와 응답 형태가 달라 별도 분기.
+    // 인증은 handleGeminiLive 내부에서 query param + header 둘 다 허용.
+    if (pathname === "/gemini-live") {
+      return await handleGeminiLive(req, env);
+    }
 
     // Handle /backup/:id routes
     const backupIdMatch = pathname.match(/^\/backup\/([0-9a-f-]+)$/);


### PR DESCRIPTION
## Summary

- **#357 fix**: 녹음 정지 버튼(툴바)이 IME dismiss 후 nav bar 제스처 영역으로 미끄러져 클릭이 가로채이던 회귀. `MemoScreen` outer Column에 `navigationBarsPadding() + imePadding()` 체인 적용해 IME 유무와 무관하게 nav inset 보장.
- **녹음 STT 인프라 통합 재작성**: 기존 `MediaRecorder` + `SpeechRecognizer` 동시 mic 사용으로 Android 14+ 에서 SpeechRecognizer가 빈 결과만 뱉던 회귀 → iOS의 AVAudioEngine input tap 패턴 흉내, **`AudioRecord` 단일 mic 클라이언트로 PCM 캡처 + WAV 저장 + 외부 STT feed** 통합으로 변경.
- **Gemini Live API streaming 인프라** 1차 완성. Cloudflare Worker WebSocket proxy + Ktor 클라이언트 + AudioRecord PCM stream. 단 Google AI Studio 한국 region 미지원(1007 `User location is not supported`)이라 활성화는 Vertex AI 마이그레이션 시점으로 보류. 코드는 보존 — region 정책 변경 또는 GCP key 교체 시 즉시 가동.
- **Vosk 라이브러리 제거**: PoC로 추가했으나 정확도 한계 + `libvosk.so`가 16KB 페이지 미정렬이라 Android 15+ Play Store 호환 경고를 유발. 의존성 완전 삭제.

## 주요 변경

### Android
- `RecordingService`: `MediaRecorder` → `AudioRecord` (16kHz mono 16-bit PCM) + `WavFileSink` 직접 캡처 + `PcmListener` bus + `partial/confirmed StateFlow` 노출
- `AndroidLiveTranscriptionService`: SpeechRecognizer 제거 → `GeminiLiveSession` 위임하는 얇은 wrapper. `partialText/confirmedText` 는 `RecordingService` companion StateFlow 그대로 노출
- `GeminiLiveSession`: Ktor `webSocket{}` + setup 메시지 + PCM chunk → base64 `realtimeInput` 송신 + `inputTranscription.text` 수신
- `TranscriptionPlatformModule`: `BuildConfig.WORKER_URL/APP_SECRET_KEY` 주입
- 녹음 파일 확장자 `m4a → wav` (AndroidAudioFileStore, MemoPlain audio cache path, AudioPlayerBar 다운로드 이름, transcribe MIME 모두 일치)
- `MemoScreen` outer Column inset 체인 수정 (#357)

### Worker (`workers/src/index.ts`)
- `/gemini-live` WebSocket proxy 추가 — `fetch` + `Upgrade: websocket` 로 `generativelanguage.googleapis.com` 양방향 bridge
- `normalizeSecret`: 모든 secret 호출 경로(`verifyAppAuth`, `callGemini`, Live API key) 에 BOM(U+FEFF)/whitespace trim — `wrangler secret put` PowerShell 경유 시 hidden 문자 흡수
- `/gemini-live` 인증: query `?k=` + header `x-app-key` 둘 다 허용 (Ktor WebSocket custom header가 일부 환경에서 흘림)

## Known issue / Follow-up

- **Gemini Live API region**: 한국 region 에서 1007 `User location is not supported`. Vertex AI Live API (`asia-northeast3`) 마이그레이션 시점에 활성화 예정. 현재 빌드는 Live API 시작 실패 시 종료 시점의 Gemini REST `transcribeAudio` fallback 으로 자동 흡수되어 음성 → 텍스트 자체는 정상 동작.
- 통역 기능 추가 시점에 Vertex Live 또는 Gemini Live (US 라우팅) 로 활성화하면서 `inputAudioTranscription` partial 실시간 타이핑 복원 가능.

## Test plan

- [x] `:app:assembleNotaDebug` 빌드 성공
- [x] 실기기 (Android 13, `me.pecos.nota`) install 후 녹음 → 정지 시 음성 파일(.wav) 저장 + Gemini REST transcribe 텍스트 반영 확인
- [x] #357 정지 버튼: 키보드 dismiss 후에도 nav bar 제스처에 안 가려짐
- [x] Worker `/gemini-generate` REST 200 (BOM-strip 후 정상)
- [x] Worker `/gemini-live` WebSocket 핸드셰이크 성공, setup 송신 OK (Gemini 측 1007 close — region 이슈로 expected)
- [ ] 출시 빌드(`:app:bundleNotaRelease`) sanity 빌드
- [ ] Live API region 해결 후 실시간 타이핑 재검증 (별도 PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)