### PR TITLE
Add: #329 실시간 번역 녹음 — 양방향 번역 (단방향 batch)

### DIFF
--- a/feature/core/resource/src/commonMain/composeResources/values-en/strings.xml
+++ b/feature/core/resource/src/commonMain/composeResources/values-en/strings.xml
@@ -278,4 +278,15 @@
     <string name="ai_input_placeholder">Ask Memozy AI anything</string>
     <string name="ai_insert_to_memo">Add to memo</string>
     <string name="ai_loading">AI is responding…</string>
+
+    <!-- Translation / Recording -->
+    <string name="recording_now">Recording</string>
+    <string name="speak_now_placeholder">Speak now…</string>
+    <string name="realtime_translation">Real-time Translation</string>
+    <string name="my_language">My language</string>
+    <string name="target_language">Target language</string>
+    <string name="select_language">Select a language</string>
+    <string name="translation_same_language_warning">Cannot translate when both languages are the same.</string>
+    <string name="memo_recording_suffix">Recording</string>
+    <string name="memo_translation_suffix">Translation</string>
 </resources>

--- a/feature/core/resource/src/commonMain/composeResources/values-ja/strings.xml
+++ b/feature/core/resource/src/commonMain/composeResources/values-ja/strings.xml
@@ -278,4 +278,15 @@
     <string name="ai_input_placeholder">Memozy AIに何でも聞いてください</string>
     <string name="ai_insert_to_memo">メモに追加</string>
     <string name="ai_loading">AI応答中…</string>
+
+    <!-- Translation / Recording -->
+    <string name="recording_now">録音中</string>
+    <string name="speak_now_placeholder">話してください…</string>
+    <string name="realtime_translation">リアルタイム翻訳</string>
+    <string name="my_language">私の言語</string>
+    <string name="target_language">翻訳先の言語</string>
+    <string name="select_language">言語を選択してください</string>
+    <string name="translation_same_language_warning">同じ言語同士では翻訳できません。</string>
+    <string name="memo_recording_suffix">録音</string>
+    <string name="memo_translation_suffix">翻訳</string>
 </resources>

--- a/feature/core/resource/src/commonMain/composeResources/values/strings.xml
+++ b/feature/core/resource/src/commonMain/composeResources/values/strings.xml
@@ -282,4 +282,15 @@
     <string name="ai_input_placeholder">Memozy AI에게 물어보세요</string>
     <string name="ai_insert_to_memo">메모에 추가</string>
     <string name="ai_loading">AI 응답 중…</string>
+
+    <!-- Translation / Recording -->
+    <string name="recording_now">녹음 중</string>
+    <string name="speak_now_placeholder">말씀해 주세요…</string>
+    <string name="realtime_translation">실시간 번역</string>
+    <string name="my_language">내 언어</string>
+    <string name="target_language">번역할 언어</string>
+    <string name="select_language">언어를 선택하세요</string>
+    <string name="translation_same_language_warning">두 언어가 동일하면 번역할 수 없어요.</string>
+    <string name="memo_recording_suffix">녹음</string>
+    <string name="memo_translation_suffix">번역</string>
 </resources>

--- a/feature/core/resource/src/commonMain/kotlin/me/pecos/memozy/presentation/components/AppPopup.kt
+++ b/feature/core/resource/src/commonMain/kotlin/me/pecos/memozy/presentation/components/AppPopup.kt
@@ -101,7 +101,8 @@ fun AppPopup(
                 .fillMaxWidth()
                 .padding(horizontal = 24.dp)
                 .clip(RoundedCornerShape(20.dp))
-                .background(colors.cardBackground)
+                // Wanted Popup 가이드 — 일관된 흰색 배경 (light/dark 동일).
+                .background(Color.White)
                 .padding(innerPadding)
         ) {
             // ── Navigation ────────────────────────────────────────────────────

--- a/feature/home/impl/src/androidMain/kotlin/me/pecos/memozy/MainActivity.kt
+++ b/feature/home/impl/src/androidMain/kotlin/me/pecos/memozy/MainActivity.kt
@@ -192,7 +192,8 @@ class MainActivity : ComponentActivity() {
             ) {
             OverrideNightMode(isDarkTheme = isDarkTheme) {
                 CompositionLocalProvider(
-                    LocalFontSettings provides fontSettings
+                    LocalFontSettings provides fontSettings,
+                    me.pecos.memozy.presentation.theme.LocalLanguageCode provides selectedLanguage.code,
                 ) {
                     AppThemeShell(isDarkTheme = isDarkTheme) {
                     val currentTypography = MaterialTheme.typography

--- a/feature/home/impl/src/commonMain/kotlin/me/pecos/memozy/presentation/screen/home/components/MemoCard.kt
+++ b/feature/home/impl/src/commonMain/kotlin/me/pecos/memozy/presentation/screen/home/components/MemoCard.kt
@@ -97,7 +97,8 @@ fun MemoCardItem(
             Spacer(modifier = Modifier.height(8.dp))
             Text(
                 text = memo.content.htmlToPlainText()
-                    .ifBlank { parseSummaryEntries(memo.summaryContent).firstOrNull()?.content?.take(200) ?: "" },
+                    .ifBlank { parseSummaryEntries(memo.summaryContent).firstOrNull()?.content?.take(200).orEmpty() }
+                    .ifBlank { memo.recordingTranscript?.take(200).orEmpty() },
                 color = colors.textBody,
                 fontFamily = fontSettings.fontFamily,
                 fontSize = fontSettings.bodySize,

--- a/feature/memo-plain/impl/src/commonMain/kotlin/me/pecos/memozy/feature/memoplain/impl/MemoPlainNavigationImpl.kt
+++ b/feature/memo-plain/impl/src/commonMain/kotlin/me/pecos/memozy/feature/memoplain/impl/MemoPlainNavigationImpl.kt
@@ -556,7 +556,8 @@ class MemoPlainNavigationImpl(
                             youtubeUrl = it.youtubeUrl,
                             summaryContent = it.summaryContent,
                             isSummaryExpanded = it.isSummaryExpanded,
-                            webUrl = it.webUrl
+                            webUrl = it.webUrl,
+                            recordingTranscript = it.recordingTranscript
                         )
                     }
                     memoLoaded = true
@@ -601,6 +602,14 @@ class MemoPlainNavigationImpl(
             // 녹음 정지 후에도 라이브 카드를 카드 형태로 유지 — 헤더가 제목, 본문이 녹음 텍스트.
             var recordedCardTitle by remember { mutableStateOf<String?>(null) }
             var recordedCardText by remember { mutableStateOf<String?>(null) }
+            // 번역 녹음 — 소스/타겟 언어 선택. null 이면 일반 녹음.
+            var showTranslationDialog by remember { mutableStateOf(false) }
+            var translationSourceLang by remember { mutableStateOf<String?>(null) }
+            var translationTargetLang by remember { mutableStateOf<String?>(null) }
+            // 녹음 시작 시 사용할 언어 — 번역 녹음이면 소스 언어, 아니면 앱 언어.
+            // beginRecording 안에서 매번 갱신해서 일반/번역 흐름 분기.
+            var activeRecordingSourceLang by remember { mutableStateOf<String?>(null) }
+            var activeRecordingTargetLang by remember { mutableStateOf<String?>(null) }
             // 메모 다시 열 때 entity 의 recordingTranscript 가 있으면 카드 복원.
             // 제목은 메모의 createdAt 으로 stamp 생성 (별도 필드 없이 자연스럽게).
             LaunchedEffect(finalMemo.id, finalMemo.recordingTranscript) {
@@ -673,8 +682,9 @@ class MemoPlainNavigationImpl(
                     // 새 녹음 시작 시 이전 녹음 카드 초기화
                     recordedCardTitle = null
                     recordedCardText = null
+                    val effectiveLang = activeRecordingSourceLang ?: languageCode
                     scope.launch {
-                        liveTranscriptionService.start(languageCode, audioCachePath)
+                        liveTranscriptionService.start(effectiveLang, audioCachePath)
                     }
                 } catch (e: Exception) {
                     transcriptionError = "녹음을 시작할 수 없어요."
@@ -749,7 +759,28 @@ class MemoPlainNavigationImpl(
 
                         if (liveText.isNotBlank()) {
                             // iOS / API 33+ Android — Live STT 결과 그대로 사용. Gemini fabrication 회피.
-                            val result = liveText
+                            // 번역 모드면 STT 결과를 Gemini 로 번역해서 [원문 \n\n 번역] 합쳐서 표시.
+                            val sourceLangSnap = activeRecordingSourceLang
+                            val targetLangSnap = activeRecordingTargetLang
+                            val isTranslation = sourceLangSnap != null && targetLangSnap != null && sourceLangSnap != targetLangSnap
+                            val result = if (isTranslation) {
+                                try {
+                                    val targetName = languageDisplayName(targetLangSnap!!)
+                                    val translation = retryOn503 {
+                                        aiApiService.generateContent(
+                                            "Translate the following text to $targetName. " +
+                                                "Output ONLY the translation as plain text — no quotes, no explanations, no language tags.\n\n" +
+                                                "Text:\n$liveText"
+                                        )
+                                    }.trim().trim('"', '\'', '`').trim()
+                                    if (translation.isNotBlank()) {
+                                        "$liveText\n\n[${languageDisplayName(targetLangSnap)}]\n$translation"
+                                    } else liveText
+                                } catch (e: Throwable) {
+                                    transcriptionError = "번역 실패: ${e.message ?: e::class.simpleName}"
+                                    liveText
+                                }
+                            } else liveText
 
                             val nowLocal = Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault())
                             fun Int.pad2(): String = toString().padStart(2, '0')
@@ -766,8 +797,9 @@ class MemoPlainNavigationImpl(
                                 pendingAudioDurationSeconds = durationSeconds
                             }
 
-                            // 카드 영구 표시: 헤더 = "{stamp} 녹음", 본문 = 녹음 텍스트
-                            recordedCardTitle = "$stamp 녹음"
+                            // 카드 영구 표시: 헤더는 번역 모드면 "번역", 일반이면 "녹음".
+                            val typeLabel = if (isTranslation) "번역" else "녹음"
+                            recordedCardTitle = "$stamp $typeLabel"
                             recordedCardText = result
 
                             transcriptionResult = result
@@ -780,7 +812,13 @@ class MemoPlainNavigationImpl(
                             val base64 = Base64.Default.encode(audioBytes)
                             val resultRaw = aiApiService.transcribeAudio(base64, "audio/mp4", durationSeconds)
                             val result = resultRaw.trim().trim('"', '\'', '`').trim()
-                            val looksLikePromptEcho = result.contains("받아쓰기해줘") || result.contains("받아쓰기 텍스트만")
+                            // Gemini 가 빈/짧은 오디오 받으면 transcribe prompt 를 그대로 echo 하는 케이스가 있어
+                            // 카드에 prompt 문구가 노출되던 버그 차단. 한국어 prompt 의 흔한 토큰을 폭넓게 검사.
+                            val looksLikePromptEcho = result.contains("받아쓰기")
+                                || result.contains("텍스트만 출력")
+                                || result.contains("다른 설명은 하지")
+                                || result.contains("다른설명은 하지")
+                                || result.contains("오디오를")
                             if (looksLikePromptEcho || result.isBlank()) {
                                 transcriptionError = "음성이 감지되지 않았어요. 다시 시도해주세요."
                                 transcriptionResult = null
@@ -851,6 +889,8 @@ class MemoPlainNavigationImpl(
                                 || memoWithAudio.summaryContent != null
                                 || memoWithAudio.youtubeUrl != null
                                 || memoWithAudio.webUrl != null
+                                || !memoWithAudio.recordingTranscript.isNullOrBlank()
+                                || memoWithAudio.audioPath != null
                             ) {
                                 val newId = repository.addMemo(memoWithAudio.toEntity())
                                 savedMemoId = newId.toInt()
@@ -870,10 +910,15 @@ class MemoPlainNavigationImpl(
                     if (!canUseAi) {
                         notifyAiBlocked()
                     } else {
+                        // 일반 녹음: 번역 모드 해제.
+                        activeRecordingSourceLang = null
+                        activeRecordingTargetLang = null
                         startRecording()
                     }
                 },
                 onStopRecording = { stopRecordingAndTranscribe() },
+                // onStartRecording 진입(마이크 버튼) — 일반 녹음이므로 번역 lang 초기화.
+                // 번역 녹음은 별도로 onOpenTranslationDialog → 확인 시 startRecording 직접 호출.
                 isRecording = isRecording,
                 isTranscribing = isTranscribing,
                 transcriptionResult = transcriptionResult,
@@ -882,6 +927,12 @@ class MemoPlainNavigationImpl(
                 liveConfirmedText = liveConfirmedText,
                 recordedCardTitle = recordedCardTitle,
                 recordedCardText = recordedCardText,
+                onOpenTranslationDialog = {
+                    // 기본값: "내 언어" = 앱 설정 언어 (자동), "번역할 언어" = 비어있음 (사용자 선택)
+                    translationSourceLang = languageCode
+                    translationTargetLang = null
+                    showTranslationDialog = true
+                },
                 onDismissRecordedCard = {
                     recordedCardTitle = null
                     recordedCardText = null
@@ -1240,6 +1291,22 @@ class MemoPlainNavigationImpl(
                 )
             }
 
+            if (showTranslationDialog) {
+                me.pecos.memozy.presentation.screen.memo.components.TranslationLanguageDialog(
+                    sourceLang = translationSourceLang,
+                    targetLang = translationTargetLang,
+                    onSourceLangSelected = { translationSourceLang = it },
+                    onTargetLangSelected = { translationTargetLang = it },
+                    onDismiss = { showTranslationDialog = false },
+                    onConfirm = {
+                        activeRecordingSourceLang = translationSourceLang
+                        activeRecordingTargetLang = translationTargetLang
+                        showTranslationDialog = false
+                        if (!canUseAi) notifyAiBlocked() else startRecording()
+                    },
+                )
+            }
+
             if (showLimitBottomSheet) {
                 val isAdPlatformSupported = rewardAdProvider?.isPlatformSupported != false
                 AiLimitBottomSheet(
@@ -1266,6 +1333,14 @@ class MemoPlainNavigationImpl(
                 )
             }
         }
+    }
+
+    private fun languageDisplayName(code: String): String = when (code) {
+        "ko" -> "한국어"
+        "en" -> "영어"
+        "ja" -> "일본어"
+        "zh" -> "중국어"
+        else -> code
     }
 
     private fun MemoUiState.toEntity() = Memo(

--- a/feature/memo-plain/impl/src/commonMain/kotlin/me/pecos/memozy/presentation/screen/memo/MemoScreen.kt
+++ b/feature/memo-plain/impl/src/commonMain/kotlin/me/pecos/memozy/presentation/screen/memo/MemoScreen.kt
@@ -117,6 +117,8 @@ import me.pecos.memozy.feature.core.resource.generated.resources.Res
 import me.pecos.memozy.feature.core.resource.generated.resources.ai_input_placeholder
 import me.pecos.memozy.feature.core.resource.generated.resources.ai_loading
 import me.pecos.memozy.feature.core.resource.generated.resources.cancel
+import me.pecos.memozy.feature.core.resource.generated.resources.recording_now
+import me.pecos.memozy.feature.core.resource.generated.resources.speak_now_placeholder
 import me.pecos.memozy.feature.core.resource.generated.resources.category_budget
 import me.pecos.memozy.feature.core.resource.generated.resources.category_exercise
 import me.pecos.memozy.feature.core.resource.generated.resources.category_general
@@ -241,6 +243,7 @@ fun MemoScreen(
     onStopRecording: (() -> Unit)? = null,
     isRecording: Boolean = false,
     isTranscribing: Boolean = false,
+    onOpenTranslationDialog: (() -> Unit)? = null,
     transcriptionResult: String? = null,
     transcriptionError: String? = null,
     livePartialText: String = "",
@@ -645,7 +648,7 @@ fun MemoScreen(
                     color = colors.chipText,
                     modifier = Modifier
                         .clickable {
-                            onSave(MemoUiState(id = existingMemo.id, name = nameText, categoryId = categoryIndex + 1, content = safeContent(), styles = safeStyles(), youtubeUrl = savedYoutubeUrl, summaryContent = safeSummaryContent(), isSummaryExpanded = if (savedWebUrl != null) isWebSummaryExpanded else isSummaryExpanded, webUrl = savedWebUrl))
+                            onSave(MemoUiState(id = existingMemo.id, name = nameText, categoryId = categoryIndex + 1, content = safeContent(), styles = safeStyles(), youtubeUrl = savedYoutubeUrl, summaryContent = safeSummaryContent(), isSummaryExpanded = if (savedWebUrl != null) isWebSummaryExpanded else isSummaryExpanded, webUrl = savedWebUrl, recordingTranscript = recordedCardText))
                         }
                         .padding(horizontal = 8.dp, vertical = 4.dp)
                 )
@@ -706,8 +709,13 @@ fun MemoScreen(
                     }
                 )
 
-                // 녹음 결과는 본문/제목에 자동 삽입하지 않음 — 카드 내부 표시 + (사용자가) 수정 버튼으로 본문 통합.
-                // (이전엔 LaunchedEffect(transcriptionResult) 가 본문/제목에 삽입했으나 카드 단독 표시 흐름으로 변경)
+                // 녹음 결과는 본문에 자동 삽입하지 않음 — 카드 내부 표시.
+                // 다만 메모 제목이 비어있으면 카드 헤더 stamp ("26.05.13 12:02 번역") 를 제목으로 자동 설정.
+                LaunchedEffect(recordedCardTitle) {
+                    if (!recordedCardTitle.isNullOrBlank() && nameText.isBlank()) {
+                        nameText = recordedCardTitle
+                    }
+                }
 
                 Spacer(modifier = Modifier.height(12.dp))
 
@@ -716,6 +724,14 @@ fun MemoScreen(
                 // 인라인 편집 상태 — 수정 버튼 토글. recordedCardText 가 바뀌면 편집 텍스트도 동기화.
                 var isEditingRecordedCard by remember { mutableStateOf(false) }
                 var editingRecordedText by remember(recordedCardText) { mutableStateOf(recordedCardText.orEmpty()) }
+                // 오디오 — 녹음 카드 안에 통합 또는 단독 표시 결정.
+                var audioChipDismissed by remember { mutableStateOf(false) }
+                val effectiveAudioPath = audioPath ?: existingMemo.audioPath
+                val hasAudio = effectiveAudioPath != null
+                    && audioFileStore.exists(effectiveAudioPath)
+                    && !audioChipDismissed
+                val showAudioInsideCard = !isRecording && showRecordedCard && hasAudio
+                val showAudioStandalone = !isRecording && !showRecordedCard && hasAudio
                 if (isRecording || showRecordedCard) {
                     val hasLive = liveConfirmedText.isNotEmpty() || livePartialText.isNotEmpty()
                     Box(
@@ -738,7 +754,7 @@ fun MemoScreen(
                                     )
                                     Spacer(modifier = Modifier.width(6.dp))
                                     Text(
-                                        "녹음 중",
+                                        stringResource(Res.string.recording_now),
                                         fontSize = fontSettings.scaled(11),
                                         color = colors.textSecondary,
                                         fontWeight = FontWeight.Medium,
@@ -798,7 +814,7 @@ fun MemoScreen(
                                     Text(annotated, fontSize = fontSettings.scaled(14), lineHeight = 20.sp)
                                 } else {
                                     Text(
-                                        "말씀해 주세요…",
+                                        stringResource(Res.string.speak_now_placeholder),
                                         fontSize = fontSettings.scaled(13),
                                         color = colors.textSecondary.copy(alpha = 0.7f),
                                     )
@@ -822,15 +838,25 @@ fun MemoScreen(
                                     color = colors.textBody,
                                 )
                             }
+                            // 오디오 sub-section — 텍스트와 같은 카드 안에. 자체 X 버튼으로 독립 dismiss 가능.
+                            if (showAudioInsideCard && effectiveAudioPath != null) {
+                                Spacer(modifier = Modifier.height(12.dp))
+                                HorizontalDivider(color = colors.textSecondary.copy(alpha = 0.2f))
+                                Spacer(modifier = Modifier.height(8.dp))
+                                AudioPlayerBar(
+                                    audioPath = effectiveAudioPath,
+                                    memoTitle = nameText,
+                                    colors = colors,
+                                    onDismiss = { audioChipDismissed = true }
+                                )
+                            }
                         }
                     }
                     Spacer(modifier = Modifier.height(12.dp))
                 }
 
-                // 오디오 플레이어 카드 (재생 / 다운 / 공유 / 닫기) — 녹음 카드 바로 아래 배치.
-                var audioChipDismissed by remember { mutableStateOf(false) }
-                val effectiveAudioPath = audioPath ?: existingMemo.audioPath
-                if (effectiveAudioPath != null && audioFileStore.exists(effectiveAudioPath) && !audioChipDismissed) {
+                // 텍스트(transcript) 없이 오디오만 있는 케이스 (기존 녹음 메모 재열기) — 단독 표시.
+                if (showAudioStandalone && effectiveAudioPath != null) {
                     AudioPlayerBar(
                         audioPath = effectiveAudioPath,
                         memoTitle = nameText,
@@ -1252,6 +1278,7 @@ fun MemoScreen(
                                     onStopRecording = onStopRecording,
                                     isRecording = isRecording,
                                     isTranscribing = isTranscribing,
+                                    onOpenTranslationDialog = onOpenTranslationDialog,
                                     onYoutubeSummarize = onYoutubeSummarize,
                                     isSummarizing = isSummarizing,
                                     isWebSummarizing = isWebSummarizing,

--- a/feature/memo-plain/impl/src/commonMain/kotlin/me/pecos/memozy/presentation/screen/memo/components/MemoActionBar.kt
+++ b/feature/memo-plain/impl/src/commonMain/kotlin/me/pecos/memozy/presentation/screen/memo/components/MemoActionBar.kt
@@ -16,6 +16,7 @@ import androidx.compose.material.icons.filled.Link
 import androidx.compose.material.icons.filled.Mic
 import androidx.compose.material.icons.filled.SmartDisplay
 import androidx.compose.material.icons.filled.Stop
+import androidx.compose.material.icons.filled.Translate
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -37,6 +38,8 @@ fun MemoActionBar(
     onStopRecording: (() -> Unit)?,
     isRecording: Boolean,
     isTranscribing: Boolean,
+    // 번역 녹음 — 시작 시 언어 선택 팝업 열기
+    onOpenTranslationDialog: (() -> Unit)? = null,
     // 유튜브
     onYoutubeSummarize: ((String, SummaryMode) -> Unit)?,
     isSummarizing: Boolean,
@@ -72,6 +75,26 @@ fun MemoActionBar(
                     imageVector = if (isRecording) Icons.Default.Stop else Icons.Default.Mic,
                     contentDescription = null,
                     tint = if (isRecording) Color.White else colors.chipText,
+                    modifier = Modifier.size(20.dp)
+                )
+            }
+        }
+
+        // 🌐 번역 녹음 — 마이크 옆에 배치. 녹음/전사 중에는 비활성.
+        if (onOpenTranslationDialog != null) {
+            Box(
+                modifier = Modifier.size(36.dp).clip(RoundedCornerShape(8.dp))
+                    .background(
+                        if (isRecording || isTranscribing) colors.chipBackground.copy(alpha = 0.3f)
+                        else colors.chipBackground.copy(alpha = 0.4f)
+                    )
+                    .clickable(enabled = !isRecording && !isTranscribing) { onOpenTranslationDialog() },
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Translate,
+                    contentDescription = "번역 녹음",
+                    tint = colors.chipText,
                     modifier = Modifier.size(20.dp)
                 )
             }

--- a/feature/memo-plain/impl/src/commonMain/kotlin/me/pecos/memozy/presentation/screen/memo/components/TranslationLanguageDialog.kt
+++ b/feature/memo-plain/impl/src/commonMain/kotlin/me/pecos/memozy/presentation/screen/memo/components/TranslationLanguageDialog.kt
@@ -1,0 +1,162 @@
+package me.pecos.memozy.presentation.screen.memo.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import me.pecos.memozy.feature.core.resource.generated.resources.Res
+import me.pecos.memozy.feature.core.resource.generated.resources.cancel
+import me.pecos.memozy.feature.core.resource.generated.resources.confirm
+import me.pecos.memozy.feature.core.resource.generated.resources.my_language
+import me.pecos.memozy.feature.core.resource.generated.resources.realtime_translation
+import me.pecos.memozy.feature.core.resource.generated.resources.select_language
+import me.pecos.memozy.feature.core.resource.generated.resources.target_language
+import me.pecos.memozy.feature.core.resource.generated.resources.translation_same_language_warning
+import me.pecos.memozy.presentation.components.AppPopup
+import me.pecos.memozy.presentation.components.PopupActionArea
+import me.pecos.memozy.presentation.components.PopupNavigation
+import me.pecos.memozy.presentation.components.PopupSize
+import me.pecos.memozy.presentation.theme.LocalAppColors
+import org.jetbrains.compose.resources.stringResource
+
+private val SUPPORTED_LANGS = listOf(
+    "ko" to "한국어",
+    "en" to "English",
+    "ja" to "日本語",
+    "zh" to "中文",
+)
+
+private fun labelOf(code: String?): String =
+    SUPPORTED_LANGS.firstOrNull { it.first == code }?.second ?: ""
+
+/**
+ * Wanted Popup 가이드 — AppPopup (Medium / Emphasized / Compact).
+ * Dropdown 은 popup 과 동일 톤(흰색 + 옅은 border + rounded)으로 통일.
+ */
+@Composable
+fun TranslationLanguageDialog(
+    sourceLang: String?,
+    targetLang: String?,
+    onSourceLangSelected: (String) -> Unit,
+    onTargetLangSelected: (String) -> Unit,
+    onDismiss: () -> Unit,
+    onConfirm: () -> Unit,
+) {
+    val colors = LocalAppColors.current
+    val canConfirm = sourceLang != null && targetLang != null && sourceLang != targetLang
+    val placeholderText = stringResource(Res.string.select_language)
+    AppPopup(
+        onDismissRequest = onDismiss,
+        title = stringResource(Res.string.realtime_translation),
+        navigation = PopupNavigation.EMPHASIZED,
+        size = PopupSize.MEDIUM,
+        actionArea = PopupActionArea.COMPACT,
+        primaryButtonText = stringResource(Res.string.confirm),
+        onPrimaryClick = if (canConfirm) onConfirm else null,
+        secondaryButtonText = stringResource(Res.string.cancel),
+        onSecondaryClick = onDismiss,
+    ) {
+        Text(stringResource(Res.string.my_language), fontWeight = FontWeight.Medium, fontSize = 14.sp, color = colors.textBody)
+        Spacer(modifier = Modifier.height(8.dp))
+        LanguageDropdown(
+            selectedLabel = labelOf(sourceLang),
+            placeholder = placeholderText,
+            onSelected = onSourceLangSelected,
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        Text(stringResource(Res.string.target_language), fontWeight = FontWeight.Medium, fontSize = 14.sp, color = colors.textBody)
+        Spacer(modifier = Modifier.height(8.dp))
+        LanguageDropdown(
+            selectedLabel = labelOf(targetLang),
+            placeholder = placeholderText,
+            onSelected = onTargetLangSelected,
+        )
+        if (sourceLang != null && targetLang != null && sourceLang == targetLang) {
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                stringResource(Res.string.translation_same_language_warning),
+                fontSize = 12.sp,
+                color = Color(0xFFE24B4A),
+            )
+        }
+    }
+}
+
+@Composable
+private fun LanguageDropdown(
+    selectedLabel: String,
+    placeholder: String,
+    onSelected: (String) -> Unit,
+) {
+    val colors = LocalAppColors.current
+    var expanded by remember { mutableStateOf(false) }
+    Box(modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(10.dp))
+                .background(Color.White)
+                .border(
+                    width = 1.dp,
+                    color = colors.cardBorder,
+                    shape = RoundedCornerShape(10.dp),
+                )
+                .clickable { expanded = true }
+                .padding(horizontal = 14.dp, vertical = 14.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = selectedLabel.ifBlank { placeholder },
+                fontSize = 14.sp,
+                color = if (selectedLabel.isBlank()) colors.textSecondary.copy(alpha = 0.7f) else colors.textBody,
+                modifier = Modifier.weight(1f),
+            )
+            Icon(
+                imageVector = Icons.Filled.ArrowDropDown,
+                contentDescription = null,
+                tint = colors.textSecondary,
+                modifier = Modifier.size(20.dp),
+            )
+        }
+        DropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+            modifier = Modifier.background(Color.White),
+        ) {
+            SUPPORTED_LANGS.forEach { (code, label) ->
+                DropdownMenuItem(
+                    text = { Text(label, color = colors.textBody) },
+                    onClick = {
+                        onSelected(code)
+                        expanded = false
+                    },
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- 툴바에 **실시간 번역** 버튼 추가. 누르면 팝업 → "내 언어"(앱 언어 자동) / "번역할 언어"(사용자 선택) 드롭다운
- 기존 Live STT (소스 언어 locale) 그대로 사용 + 정지 후 Gemini 로 batch 번역 호출
- 카드에 `원문 \n\n[타겟 언어]\n번역` 형태로 합쳐 표시, 자동저장으로 영구화
- 다국어 (ko/en/ja) 적용 + `LocalLanguageCode` provide 로 시간/라벨 다국어 정상화

Closes #329

## Changes

### 번역 녹음 흐름
- `MemoActionBar`: 마이크 옆에 Translate 아이콘 버튼 추가
- `MemoPlainNavigationImpl`:
  - `translationSourceLang` / `translationTargetLang` / `activeRecordingSourceLang/TargetLang` state
  - `onOpenTranslationDialog` → 다이얼로그 오픈, 소스=앱 언어 자동, 타겟=null
  - `stopRecordingAndTranscribe` 의 `liveText.isNotBlank()` 분기에 번역 모드 처리:
    - `isTranslation` true 일 때 `aiApiService.generateContent(번역 프롬프트)` 호출
    - 결과 = `liveText \n\n[타겟 언어 이름]\n번역` 형태
    - 실패 시 catch → 원문만 반환 + `transcriptionError` 토스트
  - `beginRecording` 의 STT locale 을 `activeRecordingSourceLang ?: languageCode` 로
- `TranslationLanguageDialog.kt` (신규): `AppPopup` + 자체 LanguageDropdown 사용. Wanted Popup 가이드 — Medium / Emphasized / Compact

### 카드 / 자동저장 / 복원
- 카드 헤더: 번역이면 `"{stamp} 번역"`, 일반이면 `"{stamp} 녹음"`
- 메모 제목 자동 채움: `LaunchedEffect(recordedCardTitle)` → `nameText` 비어있으면 헤더로 세팅
- 자동저장 (`onAutoSave`) 의 새 메모 생성 조건에 `recordingTranscript` / `audioPath` 추가
- 완료 버튼 (`onSave`) 의 `MemoUiState` 에 `recordingTranscript` 누락 fix
- 메모 다시 열기 시 `existingMemo` 매핑에 `recordingTranscript = it.recordingTranscript` 추가 (이게 누락돼서 transcript 가 list 에서 안 보였음)
- `MemoCard` preview text fallback chain 에 `recordingTranscript` 추가

### 다국어
- `MainActivity` 의 CompositionLocalProvider 에 `LocalLanguageCode provides selectedLanguage.code` 추가 — 이전엔 default "ko" 박혀있어 영어/일본어 설정해도 한국어 표시되던 버그 fix
- `recording_now / realtime_translation / my_language / target_language / select_language / translation_same_language_warning / memo_recording_suffix / memo_translation_suffix / speak_now_placeholder` 9개 string 추가 (ko/en/ja)
- `MemoScreen` 의 "녹음 중" / "말씀해 주세요…" 하드코딩 → `stringResource`
- `TranslationLanguageDialog` 의 4개 라벨 + 경고 → `stringResource`

### 디자인 시스템
- `AppPopup` 의 배경을 `Color.White` 로 강제 (light/dark 동일) — 유튜브 URL / 웹 URL / 실시간 번역 팝업 모두 흰색 통일
- LanguageDropdown: OutlinedTextField(disabled) 대신 Row + Border + ArrowDropDown 으로 wanted popup 톤과 통일

### Misc
- Gemini transcribe fallback 의 prompt echo 차단 키워드 확장 (`받아쓰기 / 텍스트만 출력 / 다른 설명은 하지 / 오디오를`)

## Test Plan

### 번역 녹음 흐름
- [ ] 툴바 번역 버튼 → 흰색 팝업 + 좌측 정렬 "실시간 번역" 제목 + 우측 [✕]
- [ ] "내 언어" 가 앱 언어로 자동 (한국어 앱이면 ko), "번역할 언어" 는 placeholder
- [ ] 같은 언어 선택 시 "확인" 비활성 + 경고 텍스트
- [ ] 확인 → 녹음 시작 (소스 언어 locale), 정지 → 1-2초 후 카드에 `원문 + [언어]\n번역`
- [ ] 번역 실패 시 카드는 원문만 + "번역 실패: …" 토스트
- [ ] 카드 헤더 "{yy.MM.dd HH:mm} 번역", 메모 제목도 자동 채움

### 카드 통합
- [ ] 텍스트 카드 + 오디오 플레이어 한 카드 안에 표시 (divider 로 구분)
- [ ] 오디오 X 버튼 → 오디오 sub-section 만 사라짐 (텍스트 유지)
- [ ] 카드 X 버튼 → 카드 전체 사라짐

### 저장 / 복원
- [ ] 새 메모 → 번역 녹음 → 뒤로가기 → 메모 list 에 항목 생김 + preview 에 원문 일부 보임
- [ ] 메모 다시 열기 → 카드 + 오디오 둘 다 복원
- [ ] 완료 버튼으로 저장 후 재진입 시에도 카드 복원

### 다국어
- [ ] 설정 → 영어 → 메모 카드 시간 `AM/PM`, 녹음 카드 "Recording", 팝업 라벨 모두 영어
- [ ] 일본어 변경 → `午前/午後`, "録音中", "リアルタイム翻訳" 등

🤖 Generated with [Claude Code](https://claude.com/claude-code)