### PR TITLE
Fix: #363 iOS 심사 거부 1·2·3번 대응 (Info.plist + 페이월 링크)

### DIFF
--- a/docs/site/privacy.html
+++ b/docs/site/privacy.html
@@ -177,6 +177,87 @@
             <p><a href="mailto:pecos6246@gmail.com">pecos6246@gmail.com</a></p>
         </section>
 
+        <!-- ============= 日本語 ============= -->
+        <section class="locale" lang="ja">
+            <h2>プライバシーポリシー</h2>
+            <p class="meta">施行日: 2026年5月9日 · 最終更新: 2026年5月9日</p>
+
+            <p>Memozy(以下「本サービス」)は、ユーザーのプライバシーを尊重し、関連法令を遵守します。本ポリシーでは、Memozy iOS / Android アプリが収集・利用するデータ、利用目的、第三者への委託、保存期間、ユーザーの権利について説明します。</p>
+
+            <h3>1. 運営者</h3>
+            <ul>
+                <li>運営者: pecos-lab(個人開発者)</li>
+                <li>メール: <a href="mailto:pecos6246@gmail.com">pecos6246@gmail.com</a></li>
+            </ul>
+
+            <h3>2. 収集するデータ</h3>
+            <table>
+                <thead>
+                    <tr><th>項目</th><th>収集タイミング</th><th>利用目的</th></tr>
+                </thead>
+                <tbody>
+                    <tr><td>メールアドレス、氏名</td><td>Apple / Google ログイン</td><td>アカウント識別、クラウドバックアップ</td></tr>
+                    <tr><td>メモ本文、添付画像、音声ファイル</td><td>ユーザー入力</td><td>ローカル保存 + ログイン時のクラウドバックアップ</td></tr>
+                    <tr><td>要約リクエストのテキスト / URL</td><td>要約機能の利用時</td><td>AI 要約処理</td></tr>
+                    <tr><td>サブスクリプション状態、購入履歴</td><td>有料プラン利用時</td><td>サブスクリプションの検証、返金 / 復元</td></tr>
+                    <tr><td>広告識別子(IDFA / AAID)</td><td>無料プラン利用時</td><td>広告配信</td></tr>
+                    <tr><td>イベントログ、画面遷移、機能利用</td><td>アプリ利用中に自動取得</td><td>サービス改善(匿名統計)</td></tr>
+                    <tr><td>クラッシュレポート(スタックトレース、デバイス機種)</td><td>クラッシュ発生時に自動取得</td><td>不具合修正</td></tr>
+                    <tr><td>マイク音声</td><td>録音 / 文字起こし時</td><td>オンデバイス処理。テキスト変換以外には保存しません。</td></tr>
+                </tbody>
+            </table>
+
+            <h3>3. 第三者への委託</h3>
+            <p>以下のサービスに一部データの処理を委託しています。各社のプライバシーポリシーが適用されます。</p>
+            <table>
+                <thead><tr><th>委託先</th><th>処理内容</th></tr></thead>
+                <tbody>
+                    <tr><td>Supabase</td><td>認証、メモのクラウドバックアップ、サブスクリプションキャッシュ</td></tr>
+                    <tr><td>Google Cloud(Gemini API)</td><td>AI 要約処理(リクエストテキスト)</td></tr>
+                    <tr><td>Google AdMob</td><td>無料プランの広告配信(広告 ID)</td></tr>
+                    <tr><td>Google Firebase</td><td>匿名利用統計(Analytics)、クラッシュレポート(Crashlytics)</td></tr>
+                    <tr><td>Apple Sign-In</td><td>アカウント識別(氏名 / リレーメール)</td></tr>
+                    <tr><td>Google Sign-In</td><td>アカウント識別(氏名 / メール)</td></tr>
+                    <tr><td>RevenueCat</td><td>サブスクリプション状態の同期</td></tr>
+                    <tr><td>Cloudflare Workers</td><td>Web ページ本文抽出のプロキシ</td></tr>
+                    <tr><td>Supadata</td><td>YouTube 字幕の抽出</td></tr>
+                    <tr><td>Apple App Store / Google Play</td><td>サブスクリプション課金処理</td></tr>
+                </tbody>
+            </table>
+
+            <h3>4. 保存期間</h3>
+            <ul>
+                <li>アカウント情報 / メモ: 退会または削除リクエストまで</li>
+                <li>匿名利用統計: 最大 14 か月</li>
+                <li>クラッシュログ: 90 日</li>
+                <li>サブスクリプション課金記録: 関連法令に基づき 5 年以上(電子商取引法、税法)</li>
+            </ul>
+
+            <h3>5. ユーザーの権利</h3>
+            <p>ユーザーはいつでも以下の権利を行使できます:</p>
+            <ul>
+                <li>本人情報の閲覧 / 訂正 / 削除請求</li>
+                <li>処理停止の請求</li>
+                <li>同意の撤回(アプリ内ログアウト / アカウント削除 / サブスクリプション解約)</li>
+            </ul>
+            <p>上記の権利行使は <a href="mailto:pecos6246@gmail.com">pecos6246@gmail.com</a> までご連絡ください。本人確認後、速やかに対応します。</p>
+
+            <h3>6. 国外移転</h3>
+            <p>上記の第三者サービスの一部は米国などの海外にサーバーを運用しています。標準契約条項(SCC)等を通じて適切な保護措置を講じます。</p>
+
+            <h3>7. 児童に関する情報</h3>
+            <p>本サービスは 13 歳未満(または居住国の法定年齢未満)のユーザーを対象としておらず、当該ユーザーの情報を意図的に収集しません。</p>
+
+            <h3>8. セキュリティ</h3>
+            <p>通信区間は TLS で暗号化し、クラウド保存時は Supabase Row Level Security により本人データのみアクセス可能となるように分離します。</p>
+
+            <h3>9. 変更の告知</h3>
+            <p>重要な変更は、アプリ内または本ページにおいて少なくとも 7 日前に告知します。</p>
+
+            <h3>10. お問い合わせ</h3>
+            <p><a href="mailto:pecos6246@gmail.com">pecos6246@gmail.com</a></p>
+        </section>
+
         <footer>© 2026 pecos-lab</footer>
     </main>
 </body>

--- a/feature/core/resource/src/commonMain/composeResources/values-en/strings.xml
+++ b/feature/core/resource/src/commonMain/composeResources/values-en/strings.xml
@@ -265,6 +265,8 @@
     <string name="subscription_current_plan">Current plan</string>
     <string name="subscription_manage">Manage subscription</string>
     <string name="subscription_restore">Restore purchases</string>
+    <string name="subscription_terms_of_use">Terms of Use (EULA)</string>
+    <string name="subscription_privacy_policy">Privacy Policy</string>
     <string name="subscription_status_renews_at">Renews on %s</string>
     <string name="subscription_status_expires_at">Expires on %s</string>
     <string name="subscription_status_grace_period">Billing issue — please resolve by %s</string>

--- a/feature/core/resource/src/commonMain/composeResources/values-ja/strings.xml
+++ b/feature/core/resource/src/commonMain/composeResources/values-ja/strings.xml
@@ -265,6 +265,8 @@
     <string name="subscription_current_plan">現在のプラン</string>
     <string name="subscription_manage">サブスクリプション管理</string>
     <string name="subscription_restore">購入を復元</string>
+    <string name="subscription_terms_of_use">利用規約 (EULA)</string>
+    <string name="subscription_privacy_policy">プライバシーポリシー</string>
     <string name="subscription_status_renews_at">%sに自動更新</string>
     <string name="subscription_status_expires_at">%sに期限切れ</string>
     <string name="subscription_status_grace_period">決済の問題 — %sまでに解決してください</string>

--- a/feature/core/resource/src/commonMain/composeResources/values/strings.xml
+++ b/feature/core/resource/src/commonMain/composeResources/values/strings.xml
@@ -265,6 +265,8 @@
     <string name="subscription_current_plan">현재 이용 중</string>
     <string name="subscription_manage">구독 관리</string>
     <string name="subscription_restore">구매 복원</string>
+    <string name="subscription_terms_of_use">이용약관 (EULA)</string>
+    <string name="subscription_privacy_policy">개인정보처리방침</string>
     <string name="subscription_status_renews_at">%s에 자동 갱신</string>
     <string name="subscription_status_expires_at">%s에 만료</string>
     <string name="subscription_status_grace_period">결제 문제 발생 — %s까지 해결 필요</string>

--- a/feature/home/impl/src/commonMain/kotlin/me/pecos/memozy/presentation/screen/subscription/SubscriptionScreen.kt
+++ b/feature/home/impl/src/commonMain/kotlin/me/pecos/memozy/presentation/screen/subscription/SubscriptionScreen.kt
@@ -51,7 +51,9 @@ import me.pecos.memozy.feature.core.resource.generated.resources.subscription_fe
 import me.pecos.memozy.feature.core.resource.generated.resources.subscription_feature_youtube
 import me.pecos.memozy.feature.core.resource.generated.resources.subscription_manage
 import me.pecos.memozy.feature.core.resource.generated.resources.subscription_monthly
+import me.pecos.memozy.feature.core.resource.generated.resources.subscription_privacy_policy
 import me.pecos.memozy.feature.core.resource.generated.resources.subscription_restore
+import me.pecos.memozy.feature.core.resource.generated.resources.subscription_terms_of_use
 import me.pecos.memozy.feature.core.resource.generated.resources.subscription_status_expires_at
 import me.pecos.memozy.feature.core.resource.generated.resources.subscription_status_grace_period
 import me.pecos.memozy.feature.core.resource.generated.resources.subscription_status_renews_at
@@ -390,10 +392,49 @@ fun SubscriptionScreen(
                     .padding(12.dp)
             )
 
+            // App Store Review Guideline 3.1.2(c): 결제 화면 내부에 EULA + Privacy Policy 노출 필수.
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 20.dp),
+                horizontalArrangement = Arrangement.Center,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = stringResource(Res.string.subscription_terms_of_use),
+                    fontSize = fontSettings.scaled(12),
+                    color = colors.textSecondary,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier
+                        .clickable { urlLauncher.open(LEGAL_TERMS_OF_USE_URL) }
+                        .padding(8.dp)
+                )
+                Text(
+                    text = "·",
+                    fontSize = fontSettings.scaled(12),
+                    color = colors.textSecondary,
+                    modifier = Modifier.padding(horizontal = 4.dp)
+                )
+                Text(
+                    text = stringResource(Res.string.subscription_privacy_policy),
+                    fontSize = fontSettings.scaled(12),
+                    color = colors.textSecondary,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier
+                        .clickable { urlLauncher.open(LEGAL_PRIVACY_POLICY_URL) }
+                        .padding(8.dp)
+                )
+            }
+
             Spacer(modifier = Modifier.height(24.dp))
         }
     }
 }
+
+private const val LEGAL_TERMS_OF_USE_URL =
+    "https://www.apple.com/legal/internet-services/itunes/dev/stdeula/"
+private const val LEGAL_PRIVACY_POLICY_URL =
+    "https://pecos.me/memozy/site/privacy.html"
 
 @Composable
 private fun SubscriptionLifecycleStatus(

--- a/feature/home/impl/src/commonMain/kotlin/me/pecos/memozy/presentation/screen/subscription/SubscriptionScreen.kt
+++ b/feature/home/impl/src/commonMain/kotlin/me/pecos/memozy/presentation/screen/subscription/SubscriptionScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import me.pecos.memozy.feature.core.resource.generated.resources.Res
 import me.pecos.memozy.feature.core.resource.generated.resources.close
@@ -405,9 +406,11 @@ fun SubscriptionScreen(
                     fontSize = fontSettings.scaled(12),
                     color = colors.textSecondary,
                     textAlign = TextAlign.Center,
+                    textDecoration = TextDecoration.Underline,
                     modifier = Modifier
+                        .clip(RoundedCornerShape(6.dp))
                         .clickable { urlLauncher.open(LEGAL_TERMS_OF_USE_URL) }
-                        .padding(8.dp)
+                        .padding(horizontal = 12.dp, vertical = 10.dp)
                 )
                 Text(
                     text = "·",
@@ -420,9 +423,11 @@ fun SubscriptionScreen(
                     fontSize = fontSettings.scaled(12),
                     color = colors.textSecondary,
                     textAlign = TextAlign.Center,
+                    textDecoration = TextDecoration.Underline,
                     modifier = Modifier
+                        .clip(RoundedCornerShape(6.dp))
                         .clickable { urlLauncher.open(LEGAL_PRIVACY_POLICY_URL) }
-                        .padding(8.dp)
+                        .padding(horizontal = 12.dp, vertical = 10.dp)
                 )
             }
 

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -16,6 +16,8 @@
 	<string>6.0</string>
 	<key>CFBundleName</key>
 	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundleDisplayName</key>
+	<string>Memozy AI</string>
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
@@ -24,10 +26,6 @@
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
-	<key>UIBackgroundModes</key>
-	<array>
-		<string>audio</string>
-	</array>
 	<!-- privacy usage descriptions: iOS 는 키 누락 시 즉시 크래시.
 	     녹음 PR 진행 중 마이크 누락으로 첫 크래시 발생 → 인접 권한들도 함께 추가 (사진 / 카메라는 메모 이미지 첨부 흐름 대비). -->
 	<key>NSMicrophoneUsageDescription</key>


### PR DESCRIPTION
## Summary

App Store Submission `4d1c85af` 거부 사유 6건 중 **즉시·중간 작업 3건** 처리.
계정 삭제(#4)와 AI 동의 모달(#5)은 후속 PR 로 분리.

| Guideline | 조치 |
|---|---|
| 2.3 / 2.3.8 — 앱 이름 불일치 | `Info.plist` 에 `CFBundleDisplayName = Memozy AI` 추가 |
| 2.5.4 — 백그라운드 오디오 오남용 | `Info.plist` 에서 `UIBackgroundModes(audio)` 제거 |
| 3.1.2(c) — 페이월 EULA/Privacy 링크 누락 | `SubscriptionScreen` 하단에 Terms of Use(Apple Standard EULA) + Privacy Policy 링크 노출, ko/en/ja 리소스 동시 추가 |

EULA URL 은 우선 Apple Standard EULA (`https://www.apple.com/legal/internet-services/itunes/dev/stdeula/`) 사용.
자체 terms 페이지를 만들면 상수만 교체.
Privacy URL 은 기존 사이트 (`https://pecos.me/memozy/site/privacy.html`).

## 남은 작업 (#363 후속 PR)

- [ ] Guideline 5.1.1(v) — 계정 삭제 기능 + Supabase RPC
- [ ] Guideline 5.1.1(i) / 5.1.2(i) — AI 데이터 전송 동의 모달
- [ ] App Store Connect 메타데이터에 EULA/Privacy URL 등록
- [ ] (선택) 자체 terms.html 작성 후 Apple Standard EULA URL 교체

## Test plan

- [ ] Mac 환경에서 iOS 빌드 → 홈 화면 앱 이름이 `Memozy AI` 로 표시되는지 확인
- [ ] Xcode → Signing & Capabilities 에서 Background Modes 비활성 상태 유지 확인
- [ ] 페이월 화면 진입 → Restore 아래에 "Terms of Use (EULA) · Privacy Policy" 두 링크 노출 확인
- [ ] 각 링크 탭 → 외부 브라우저에서 정상 오픈
- [ ] Android `./gradlew assembleDebug` 통과 (commonMain 리소스 변경)
- [ ] ko/en/ja 로케일에서 라벨이 각 언어로 노출

Closes (부분 해결): #363

🤖 Generated with [Claude Code](https://claude.com/claude-code)