### PR TITLE
Fix: #363 iOS 심사 4번 대응 — 계정 삭제 + Supabase RPC

### DIFF
--- a/data/repository/user/api/src/commonMain/kotlin/me/pecos/memozy/data/repository/user/AuthRepository.kt
+++ b/data/repository/user/api/src/commonMain/kotlin/me/pecos/memozy/data/repository/user/AuthRepository.kt
@@ -11,5 +11,6 @@ interface AuthRepository {
     suspend fun signInWithGoogle(idToken: String): Result<AuthUser>
     suspend fun signInWithApple(idToken: String, rawNonce: String): Result<AuthUser>
     suspend fun signOut()
+    suspend fun deleteAccount(): Result<Unit>
     fun getAccessToken(): String?
 }

--- a/data/repository/user/impl/src/commonMain/kotlin/me/pecos/memozy/data/repository/user/AuthRepositoryImpl.kt
+++ b/data/repository/user/impl/src/commonMain/kotlin/me/pecos/memozy/data/repository/user/AuthRepositoryImpl.kt
@@ -25,5 +25,7 @@ class AuthRepositoryImpl(
 
     override suspend fun signOut() = authService.signOut()
 
+    override suspend fun deleteAccount(): Result<Unit> = authService.deleteAccount()
+
     override fun getAccessToken(): String? = authService.getAccessToken()
 }

--- a/datasource/remote/auth/api/src/commonMain/kotlin/me/pecos/memozy/data/datasource/remote/auth/AuthService.kt
+++ b/datasource/remote/auth/api/src/commonMain/kotlin/me/pecos/memozy/data/datasource/remote/auth/AuthService.kt
@@ -21,5 +21,14 @@ interface AuthService {
     suspend fun signInWithGoogle(idToken: String): Result<AuthUser>
     suspend fun signInWithApple(idToken: String, rawNonce: String): Result<AuthUser>
     suspend fun signOut()
+
+    /**
+     * App Store Guideline 5.1.1(v) — 사용자 계정 + 관련 데이터 영구 삭제.
+     * Supabase RPC `delete_user_account` (SECURITY DEFINER) 를 호출해
+     * `auth.users` 본인 행을 지운다. 모든 public.* 테이블이
+     * ON DELETE CASCADE 라 같이 정리된다.
+     */
+    suspend fun deleteAccount(): Result<Unit>
+
     fun getAccessToken(): String?
 }

--- a/datasource/remote/auth/impl/build.gradle.kts
+++ b/datasource/remote/auth/impl/build.gradle.kts
@@ -11,6 +11,7 @@ kotlin {
         commonMain.dependencies {
             implementation(projects.datasource.remote.auth.api)
             implementation(libs.supabase.auth)
+            implementation(libs.supabase.postgrest)
             implementation(libs.kotlinx.coroutines.core)
         }
     }

--- a/datasource/remote/auth/impl/src/commonMain/kotlin/me/pecos/memozy/data/datasource/remote/auth/AuthServiceImpl.kt
+++ b/datasource/remote/auth/impl/src/commonMain/kotlin/me/pecos/memozy/data/datasource/remote/auth/AuthServiceImpl.kt
@@ -6,6 +6,7 @@ import io.github.jan.supabase.auth.providers.Apple
 import io.github.jan.supabase.auth.providers.Google
 import io.github.jan.supabase.auth.providers.builtin.IDToken
 import io.github.jan.supabase.auth.status.SessionStatus
+import io.github.jan.supabase.postgrest.postgrest
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
@@ -63,6 +64,15 @@ class AuthServiceImpl(
 
     override suspend fun signOut() {
         supabaseClient.auth.signOut()
+    }
+
+    override suspend fun deleteAccount(): Result<Unit> = runCatching {
+        // SECURITY DEFINER RPC — 본인 계정 + ON DELETE CASCADE 로 묶인 모든 행 삭제.
+        supabaseClient.postgrest.rpc("delete_user_account")
+        // auth.users 가 사라지면 세션도 무효화되지만, 클라이언트 토큰 캐시는 명시적으로 비워야
+        // SessionStatus 가 즉시 NotAuthenticated 로 전환된다.
+        runCatching { supabaseClient.auth.signOut() }
+        Unit
     }
 
     override fun getAccessToken(): String? =

--- a/feature/core/resource/src/commonMain/composeResources/values-en/strings.xml
+++ b/feature/core/resource/src/commonMain/composeResources/values-en/strings.xml
@@ -206,6 +206,16 @@
     <string name="sign_in_error">Sign in failed</string>
     <string name="sign_out_confirm">Are you sure you want to sign out?</string>
     <string name="sign_in_loading">Signing in…</string>
+    <string name="account_delete">Delete account</string>
+    <string name="account_delete_confirm_title">Delete your account?</string>
+    <string name="account_delete_confirm_message">Your account and all cloud data (memos, categories, backups, chat history) will be permanently deleted.\nThis action cannot be undone.</string>
+    <string name="account_delete_final_title">Are you absolutely sure?</string>
+    <string name="account_delete_final_message">This is permanent. You can sign up again with the same email later, but your existing data will be lost forever.\nContinue?</string>
+    <string name="account_delete_in_progress">Deleting your account…</string>
+    <string name="account_delete_success_title">Account deleted</string>
+    <string name="account_delete_success_message">Your account and cloud data have been removed. Thanks for using Memozy.</string>
+    <string name="account_delete_error_title">Deletion failed</string>
+    <string name="account_delete_error_message">Please try again later or contact pecos6246@gmail.com.</string>
     <string name="login_subtitle">Keep your memos safe with cloud backup</string>
     <string name="login_skip">Start without account</string>
 

--- a/feature/core/resource/src/commonMain/composeResources/values-ja/strings.xml
+++ b/feature/core/resource/src/commonMain/composeResources/values-ja/strings.xml
@@ -206,6 +206,16 @@
     <string name="sign_in_error">ログインに失敗しました</string>
     <string name="sign_out_confirm">ログアウトしますか？</string>
     <string name="sign_in_loading">ログイン中…</string>
+    <string name="account_delete">アカウント削除</string>
+    <string name="account_delete_confirm_title">アカウントを削除しますか？</string>
+    <string name="account_delete_confirm_message">アカウントとクラウドに保存されたすべてのデータ（メモ・カテゴリ・バックアップ・チャット履歴など）が完全に削除されます。\nこの操作は取り消せません。</string>
+    <string name="account_delete_final_title">本当に削除しますか？</string>
+    <string name="account_delete_final_message">削除後の復旧はできません。同じメールアドレスで再登録は可能ですが、既存のデータは戻りません。\n続けますか？</string>
+    <string name="account_delete_in_progress">アカウントを削除しています…</string>
+    <string name="account_delete_success_title">アカウントを削除しました</string>
+    <string name="account_delete_success_message">ご利用ありがとうございました。アカウントとクラウドデータは削除されました。</string>
+    <string name="account_delete_error_title">削除に失敗しました</string>
+    <string name="account_delete_error_message">時間をおいて再試行するか、pecos6246@gmail.com までお問い合わせください。</string>
     <string name="login_subtitle">クラウドバックアップでメモを安全に保管</string>
     <string name="login_skip">アカウントなしで始める</string>
 

--- a/feature/core/resource/src/commonMain/composeResources/values/strings.xml
+++ b/feature/core/resource/src/commonMain/composeResources/values/strings.xml
@@ -206,6 +206,16 @@
     <string name="sign_in_error">로그인에 실패했습니다</string>
     <string name="sign_out_confirm">로그아웃하시겠습니까?</string>
     <string name="sign_in_loading">로그인 중…</string>
+    <string name="account_delete">계정 삭제</string>
+    <string name="account_delete_confirm_title">계정을 삭제할까요?</string>
+    <string name="account_delete_confirm_message">계정과 클라우드에 저장된 모든 데이터(메모, 카테고리, 백업, 채팅 기록 등)가 영구 삭제됩니다.\n이 작업은 되돌릴 수 없어요.</string>
+    <string name="account_delete_final_title">정말 삭제하시겠어요?</string>
+    <string name="account_delete_final_message">삭제 후에는 복구할 수 없습니다. 동일한 이메일로 다시 가입할 수는 있지만 기존 데이터는 모두 사라집니다.\n계속하시겠어요?</string>
+    <string name="account_delete_in_progress">계정을 삭제하는 중…</string>
+    <string name="account_delete_success_title">계정이 삭제되었습니다</string>
+    <string name="account_delete_success_message">이용해 주셔서 감사합니다. 계정과 클라우드 데이터가 모두 삭제되었어요.</string>
+    <string name="account_delete_error_title">삭제에 실패했습니다</string>
+    <string name="account_delete_error_message">잠시 후 다시 시도하거나 pecos6246@gmail.com 으로 문의해 주세요.</string>
     <string name="login_subtitle">클라우드 백업으로 메모를 안전하게 보관하세요</string>
     <string name="login_skip">연결 없이 시작</string>
 

--- a/feature/core/viewmodel/src/commonMain/kotlin/me/pecos/memozy/feature/core/viewmodel/SettingsViewModel.kt
+++ b/feature/core/viewmodel/src/commonMain/kotlin/me/pecos/memozy/feature/core/viewmodel/SettingsViewModel.kt
@@ -17,6 +17,7 @@ import me.pecos.memozy.data.datasource.remote.auth.AuthState
 import me.pecos.memozy.data.repository.MemoRepository
 import me.pecos.memozy.data.repository.model.MemoFormat
 import me.pecos.memozy.data.repository.user.AuthRepository
+import me.pecos.memozy.feature.core.viewmodel.settings.AccountDeleteState
 import me.pecos.memozy.feature.core.viewmodel.settings.AppFontFamily
 import me.pecos.memozy.feature.core.viewmodel.settings.BackupResult
 import me.pecos.memozy.feature.core.viewmodel.settings.CloudBackupState
@@ -83,6 +84,13 @@ class SettingsViewModel(
     private val _lastBackupTime = MutableStateFlow<String?>(null)
     val lastBackupTime: StateFlow<String?> = _lastBackupTime
 
+    /**
+     * App Store Guideline 5.1.1(v) — 계정 삭제 진행 상태.
+     * Idle → InProgress → (Success | Error) 후 호출 측에서 [clearAccountDeleteState] 로 리셋.
+     */
+    private val _accountDeleteState = MutableStateFlow<AccountDeleteState>(AccountDeleteState.Idle)
+    val accountDeleteState: StateFlow<AccountDeleteState> = _accountDeleteState
+
     fun selectLanguage(language: Language) {
         _selectedLanguage.value = language
         preferences.putString(KEY_LANGUAGE, language.code)
@@ -133,6 +141,38 @@ class SettingsViewModel(
             analyticsService.setUserId(null)
             analyticsService.logEvent(me.pecos.memozy.platform.analytics.AnalyticsEvents.LOGOUT)
         }
+    }
+
+    /**
+     * App Store Guideline 5.1.1(v) — 계정 + 관련 데이터 영구 삭제.
+     * 1) Supabase RPC `delete_user_account` (SECURITY DEFINER) 로 auth.users 행 삭제
+     *    → public.* 테이블 ON DELETE CASCADE 로 클라우드 데이터 자동 정리
+     * 2) 로컬 메모 DB 도 clear (기기에 남아있던 캐시 / 동기화 잔재 제거)
+     * 3) analytics user id 비우기
+     */
+    fun deleteAccount() {
+        viewModelScope.launch {
+            _accountDeleteState.value = AccountDeleteState.InProgress
+            val result = authRepository.deleteAccount()
+            result.onSuccess {
+                runCatching { repository.clearAllMemos() }
+                analyticsService.setUserId(null)
+                analyticsService.logEvent(me.pecos.memozy.platform.analytics.AnalyticsEvents.ACCOUNT_DELETED)
+                _accountDeleteState.value = AccountDeleteState.Success
+            }.onFailure { e ->
+                analyticsService.logEvent(
+                    me.pecos.memozy.platform.analytics.AnalyticsEvents.ACCOUNT_DELETE_FAILED,
+                    mapOf(
+                        me.pecos.memozy.platform.analytics.AnalyticsParams.ERROR_MESSAGE to (e.message ?: "unknown"),
+                    ),
+                )
+                _accountDeleteState.value = AccountDeleteState.Error(e.message)
+            }
+        }
+    }
+
+    fun clearAccountDeleteState() {
+        _accountDeleteState.value = AccountDeleteState.Idle
     }
 
     private fun logSignInResult(

--- a/feature/core/viewmodel/src/commonMain/kotlin/me/pecos/memozy/feature/core/viewmodel/settings/AccountDeleteState.kt
+++ b/feature/core/viewmodel/src/commonMain/kotlin/me/pecos/memozy/feature/core/viewmodel/settings/AccountDeleteState.kt
@@ -1,0 +1,12 @@
+package me.pecos.memozy.feature.core.viewmodel.settings
+
+/**
+ * App Store Guideline 5.1.1(v) 계정 삭제 진행 상태.
+ * [SettingsViewModel.deleteAccount] 흐름의 단계 전이를 UI 가 관찰해 다이얼로그를 띄운다.
+ */
+sealed class AccountDeleteState {
+    data object Idle : AccountDeleteState()
+    data object InProgress : AccountDeleteState()
+    data object Success : AccountDeleteState()
+    data class Error(val message: String?) : AccountDeleteState()
+}

--- a/feature/home/impl/src/commonMain/kotlin/me/pecos/memozy/presentation/screen/settings/SettingsScreen.kt
+++ b/feature/home/impl/src/commonMain/kotlin/me/pecos/memozy/presentation/screen/settings/SettingsScreen.kt
@@ -826,12 +826,16 @@ fun SettingsScreen(
                                 text = state.user.email ?: "",
                                 fontSize = fontSettings.scaled(13),
                                 color = colors.textBody,
+                                maxLines = 1,
+                                overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
+                                modifier = Modifier.weight(1f, fill = false).padding(end = 8.dp),
                             )
                             Row(verticalAlignment = Alignment.CenterVertically) {
                                 Text(
                                     text = stringResource(Res.string.sign_out),
                                     fontSize = fontSettings.scaled(12),
                                     color = colors.textSecondary,
+                                    softWrap = false,
                                     modifier = Modifier
                                         .clickable { showSignOutDialog = true }
                                         .padding(8.dp)
@@ -846,6 +850,7 @@ fun SettingsScreen(
                                     text = stringResource(Res.string.account_delete),
                                     fontSize = fontSettings.scaled(12),
                                     color = Color(0xFFE24B4A),
+                                    softWrap = false,
                                     modifier = Modifier
                                         .clickable { showAccountDeleteConfirm = true }
                                         .padding(8.dp)

--- a/feature/home/impl/src/commonMain/kotlin/me/pecos/memozy/presentation/screen/settings/SettingsScreen.kt
+++ b/feature/home/impl/src/commonMain/kotlin/me/pecos/memozy/presentation/screen/settings/SettingsScreen.kt
@@ -90,8 +90,20 @@ import me.pecos.memozy.feature.core.resource.generated.resources.sign_in_error
 import me.pecos.memozy.feature.core.resource.generated.resources.sign_in_apple
 import me.pecos.memozy.feature.core.resource.generated.resources.sign_in_google
 import me.pecos.memozy.feature.core.resource.generated.resources.sign_in_loading
+import me.pecos.memozy.feature.core.resource.generated.resources.account_delete
+import me.pecos.memozy.feature.core.resource.generated.resources.account_delete_confirm_message
+import me.pecos.memozy.feature.core.resource.generated.resources.account_delete_confirm_title
+import me.pecos.memozy.feature.core.resource.generated.resources.account_delete_error_message
+import me.pecos.memozy.feature.core.resource.generated.resources.account_delete_error_title
+import me.pecos.memozy.feature.core.resource.generated.resources.account_delete_final_message
+import me.pecos.memozy.feature.core.resource.generated.resources.account_delete_final_title
+import me.pecos.memozy.feature.core.resource.generated.resources.account_delete_in_progress
+import me.pecos.memozy.feature.core.resource.generated.resources.account_delete_success_message
+import me.pecos.memozy.feature.core.resource.generated.resources.account_delete_success_title
+import me.pecos.memozy.feature.core.resource.generated.resources.confirm
 import me.pecos.memozy.feature.core.resource.generated.resources.sign_out
 import me.pecos.memozy.feature.core.resource.generated.resources.sign_out_confirm
+import me.pecos.memozy.feature.core.viewmodel.settings.AccountDeleteState
 import me.pecos.memozy.feature.core.resource.generated.resources.subscription_current_plan
 import me.pecos.memozy.feature.core.resource.generated.resources.subscription_title
 import me.pecos.memozy.feature.core.resource.generated.resources.theme_dark
@@ -157,6 +169,9 @@ fun SettingsScreen(
     var showRestoreDialog by remember { mutableStateOf(false) }
     var showSignOutDialog by remember { mutableStateOf(false) }
     var showCloudRestoreConfirm by remember { mutableStateOf(false) }
+    var showAccountDeleteConfirm by remember { mutableStateOf(false) }
+    var showAccountDeleteFinal by remember { mutableStateOf(false) }
+    val accountDeleteState by settingsViewModel.accountDeleteState.collectAsState()
 
     val selectedLanguage by settingsViewModel.selectedLanguage.collectAsState()
     val selectedTheme by settingsViewModel.selectedTheme.collectAsState()
@@ -497,6 +512,99 @@ fun SettingsScreen(
         }
     }
 
+    // ── 계정 삭제: 1단계 확인 ────────────────────────────────────────
+    if (showAccountDeleteConfirm) {
+        AppPopup(
+            onDismissRequest = { showAccountDeleteConfirm = false },
+            title = stringResource(Res.string.account_delete_confirm_title),
+            navigation = PopupNavigation.EMPHASIZED,
+            size = PopupSize.MEDIUM,
+            actionArea = PopupActionArea.NEUTRAL,
+            primaryButtonText = stringResource(Res.string.account_delete),
+            isPrimaryDestructive = true,
+            onPrimaryClick = {
+                showAccountDeleteConfirm = false
+                showAccountDeleteFinal = true
+            },
+            secondaryButtonText = stringResource(Res.string.cancel),
+            onSecondaryClick = { showAccountDeleteConfirm = false }
+        ) {
+            Text(stringResource(Res.string.account_delete_confirm_message), color = colors.textBody)
+        }
+    }
+
+    // ── 계정 삭제: 2단계 최종 확인 ───────────────────────────────────
+    if (showAccountDeleteFinal) {
+        AppPopup(
+            onDismissRequest = { showAccountDeleteFinal = false },
+            title = stringResource(Res.string.account_delete_final_title),
+            navigation = PopupNavigation.EMPHASIZED,
+            size = PopupSize.MEDIUM,
+            actionArea = PopupActionArea.NEUTRAL,
+            primaryButtonText = stringResource(Res.string.account_delete),
+            isPrimaryDestructive = true,
+            onPrimaryClick = {
+                showAccountDeleteFinal = false
+                settingsViewModel.deleteAccount()
+            },
+            secondaryButtonText = stringResource(Res.string.cancel),
+            onSecondaryClick = { showAccountDeleteFinal = false }
+        ) {
+            Text(stringResource(Res.string.account_delete_final_message), color = colors.textBody)
+        }
+    }
+
+    // ── 계정 삭제: 진행 / 결과 모달 ─────────────────────────────────
+    when (val s = accountDeleteState) {
+        AccountDeleteState.InProgress -> {
+            AppPopup(
+                onDismissRequest = { },
+                title = stringResource(Res.string.account_delete_in_progress),
+                navigation = PopupNavigation.EMPHASIZED,
+                size = PopupSize.MEDIUM,
+                actionArea = PopupActionArea.NONE,
+            ) {
+                Row(
+                    modifier = Modifier.fillMaxWidth().padding(vertical = 12.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.Center,
+                ) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(24.dp),
+                        color = colors.chipText,
+                    )
+                }
+            }
+        }
+        AccountDeleteState.Success -> {
+            AppPopup(
+                onDismissRequest = { settingsViewModel.clearAccountDeleteState() },
+                title = stringResource(Res.string.account_delete_success_title),
+                navigation = PopupNavigation.EMPHASIZED,
+                size = PopupSize.MEDIUM,
+                actionArea = PopupActionArea.CANCEL,
+                primaryButtonText = stringResource(Res.string.confirm),
+                onPrimaryClick = { settingsViewModel.clearAccountDeleteState() },
+            ) {
+                Text(stringResource(Res.string.account_delete_success_message), color = colors.textBody)
+            }
+        }
+        is AccountDeleteState.Error -> {
+            AppPopup(
+                onDismissRequest = { settingsViewModel.clearAccountDeleteState() },
+                title = stringResource(Res.string.account_delete_error_title),
+                navigation = PopupNavigation.EMPHASIZED,
+                size = PopupSize.MEDIUM,
+                actionArea = PopupActionArea.CANCEL,
+                primaryButtonText = stringResource(Res.string.confirm),
+                onPrimaryClick = { settingsViewModel.clearAccountDeleteState() },
+            ) {
+                Text(stringResource(Res.string.account_delete_error_message), color = colors.textBody)
+            }
+        }
+        AccountDeleteState.Idle -> Unit
+    }
+
     if (showClearDialog) {
         AppPopup(
             onDismissRequest = { showClearDialog = false },
@@ -719,14 +827,30 @@ fun SettingsScreen(
                                 fontSize = fontSettings.scaled(13),
                                 color = colors.textBody,
                             )
-                            Text(
-                                text = stringResource(Res.string.sign_out),
-                                fontSize = fontSettings.scaled(12),
-                                color = colors.textSecondary,
-                                modifier = Modifier
-                                    .clickable { showSignOutDialog = true }
-                                    .padding(8.dp)
-                            )
+                            Row(verticalAlignment = Alignment.CenterVertically) {
+                                Text(
+                                    text = stringResource(Res.string.sign_out),
+                                    fontSize = fontSettings.scaled(12),
+                                    color = colors.textSecondary,
+                                    modifier = Modifier
+                                        .clickable { showSignOutDialog = true }
+                                        .padding(8.dp)
+                                )
+                                Text(
+                                    text = "·",
+                                    fontSize = fontSettings.scaled(12),
+                                    color = colors.textSecondary,
+                                )
+                                // App Store Guideline 5.1.1(v) — 계정 삭제 진입점.
+                                Text(
+                                    text = stringResource(Res.string.account_delete),
+                                    fontSize = fontSettings.scaled(12),
+                                    color = Color(0xFFE24B4A),
+                                    modifier = Modifier
+                                        .clickable { showAccountDeleteConfirm = true }
+                                        .padding(8.dp)
+                                )
+                            }
                         }
                         // 마지막 백업 시간 표시 (이메일 아래)
                         lastBackupTime?.let { time ->

--- a/platform/analytics/api/src/commonMain/kotlin/me/pecos/memozy/platform/analytics/AnalyticsService.kt
+++ b/platform/analytics/api/src/commonMain/kotlin/me/pecos/memozy/platform/analytics/AnalyticsService.kt
@@ -18,6 +18,8 @@ object AnalyticsEvents {
     const val LOGIN_SUCCEEDED = "login_succeeded"
     const val LOGIN_FAILED = "login_failed"
     const val LOGOUT = "logout"
+    const val ACCOUNT_DELETED = "account_deleted"
+    const val ACCOUNT_DELETE_FAILED = "account_delete_failed"
 
     const val SUBSCRIPTION_VIEWED = "subscription_viewed"
     const val SUBSCRIPTION_PURCHASED = "subscription_purchased"

--- a/supabase/migrations/20260514_001_delete_user_account.sql
+++ b/supabase/migrations/20260514_001_delete_user_account.sql
@@ -1,0 +1,29 @@
+-- ============================================================
+-- App Store Guideline 5.1.1(v) — 사용자 계정 삭제 RPC
+-- ============================================================
+-- 클라이언트 SDK 는 service_role 권한이 없으므로 auth.users 행을
+-- 직접 지울 수 없다. SECURITY DEFINER 함수로 auth.uid() 본인 행만
+-- 삭제하도록 격상한다. 모든 public.* 테이블이 user_id REFERENCES
+-- auth.users(id) ON DELETE CASCADE 로 묶여 있어 행 하나 삭제로
+-- 메모 / 카테고리 / 채팅 / 요약 / ai_usage / backup_metadata /
+-- user_subscriptions 가 함께 정리된다.
+
+CREATE OR REPLACE FUNCTION public.delete_user_account()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, auth
+AS $$
+DECLARE
+    uid uuid := auth.uid();
+BEGIN
+    IF uid IS NULL THEN
+        RAISE EXCEPTION 'unauthorized' USING ERRCODE = '42501';
+    END IF;
+    DELETE FROM auth.users WHERE id = uid;
+END;
+$$;
+
+-- 인증된 사용자에게만 실행 권한 부여 (anon / public 차단).
+REVOKE ALL ON FUNCTION public.delete_user_account() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.delete_user_account() TO authenticated;


### PR DESCRIPTION
## Summary

App Store Submission \`4d1c85af\` 거부 사유 4번 — **Guideline 5.1.1(v)** 대응.
사용자가 앱 내에서 자신의 계정과 클라우드 데이터를 영구 삭제할 수 있는 흐름 추가.

## UI 흐름

1. 설정 > 계정 섹션의 \"Sign Out\" 옆에 빨간 \"계정 삭제\" 진입점
2. **1단계 확인**: 어떤 데이터가 사라지는지 안내 (메모/카테고리/백업/채팅)
3. **2단계 최종 확인**: 복구 불가 안내 + 재가입 가능 명시
4. 진행 모달 (CircularProgressIndicator)
5. 성공/실패 모달 (확인 버튼으로만 닫힘)

## Supabase

- \`supabase/migrations/20260514_001_delete_user_account.sql\` 신설
- \`public.delete_user_account()\` — \`SECURITY DEFINER\`, \`search_path\` 고정
- \`auth.uid()\` 검증 후 \`auth.users\` 본인 행 삭제
- 기존 모든 user 데이터 테이블이 \`REFERENCES auth.users(id) ON DELETE CASCADE\` 라 추가 SQL 없이 자동 정리:
  category / memo / chat_session / chat_message / youtube_summary / ai_usage / backup_metadata / user_subscriptions
- \`authenticated\` 롤에만 EXECUTE 권한, PUBLIC revoke

## 아키텍처

| 레이어 | 변경 |
|---|---|
| \`auth/api\` | \`AuthService.deleteAccount(): Result<Unit>\` |
| \`auth/impl\` | \`postgrest.rpc(\"delete_user_account\")\` + 캐시 signOut. \`build.gradle.kts\` 에 \`supabase.postgrest\` 의존성 추가 |
| \`user/api\` + \`user/impl\` | \`AuthRepository.deleteAccount()\` 위임 |
| \`feature/core/viewmodel\` | \`SettingsViewModel.deleteAccount()\` + \`AccountDeleteState\` (Idle/InProgress/Success/Error) |
| \`platform/analytics\` | \`ACCOUNT_DELETED\` / \`ACCOUNT_DELETE_FAILED\` 이벤트 |
| \`feature/home/impl\` | SettingsScreen 2단계 확인 다이얼로그 + 진행/결과 모달 |
| 리소스 | ko/en/ja 10종 strings |

## 검증

- \`./gradlew :app:compileMemozyDebugKotlin\` **BUILD SUCCESSFUL**

## 배포 시 필수 절차 ⚠️

1. **Supabase 대시보드** > SQL Editor 에서 \`20260514_001_delete_user_account.sql\` 적용 (또는 \`supabase db push\`)
2. 적용 안 된 상태로 앱 빌드 → \`postgrest.rpc\` 호출이 \"function not found\" 로 실패하므로 반드시 선행
3. iOS 실기기 빌드 후 \"가입 → 메모 작성 → 계정 삭제\" 화면 녹화해서 Resolution Center 회신 (Mac)

## Test plan

- [ ] **Supabase**: 마이그레이션 적용 후 SQL editor 에서 \`select public.delete_user_account();\` 호출 시 권한 없는 anon 은 차단되는지 확인
- [ ] 로그인 → 메모 1~2 개 작성 → 백업 → 계정 삭제 → Supabase 대시보드에서 auth.users 및 모든 public 테이블에 해당 user_id 행 사라졌는지 확인
- [ ] 1단계 확인에서 취소 → 모달 닫힘, 데이터 그대로
- [ ] 2단계 최종 확인에서 취소 → 모달 닫힘, 데이터 그대로
- [ ] 삭제 진행 중 모달 dismiss 시도 → 닫히지 않음
- [ ] 삭제 성공 → 자동으로 SessionStatus.NotAuthenticated 로 전환 + 설정의 로그인 버튼 노출
- [ ] 동일 이메일로 재가입 시도 → 신규 가입 흐름 + 기존 데이터 없음
- [ ] ko/en/ja 로케일 각각 라벨/문구 확인

## 남은 #363 항목 (Mac 작업)

- [ ] App Store Connect 메타데이터 등록 (EULA / Privacy URL)
- [ ] iOS 빌드/Archive/TestFlight 업로드
- [ ] 실기기 화면 녹화 (가입→삭제 전체 흐름) 첨부 후 Resolution Center 회신

Closes (부분 해결): #363

🤖 Generated with [Claude Code](https://claude.com/claude-code)