### PR TITLE
Fix: #363 CMP outputDir wiring (Archive 빌드 회귀)

### DIFF
--- a/shared/umbrella/build.gradle.kts
+++ b/shared/umbrella/build.gradle.kts
@@ -145,13 +145,21 @@ afterEvaluate {
     }
     matched.forEach { task ->
         try {
-            val outputDirProp = task::class.java.methods
+            val getter = task::class.java.methods
                 .firstOrNull { it.name == "getOutputDir" && it.parameterCount == 0 }
-                ?.invoke(task) as? DirectoryProperty
-            outputDirProp?.set(
+            if (getter == null) {
+                logger.warn("CMP getOutputDir 메서드 누락 — CMP API 변경 가능, ${task.name} skip")
+                return@forEach
+            }
+            val outputDirProp = getter.invoke(task) as? DirectoryProperty
+            if (outputDirProp == null) {
+                logger.warn("CMP outputDir 반환 타입 mismatch — CMP API 변경 가능, ${task.name} skip")
+                return@forEach
+            }
+            outputDirProp.set(
                 layout.buildDirectory.dir("compose/cmp-ios-resources/${task.name}")
             )
-            logger.lifecycle("CMP outputDir wired for ${task.name} → ${outputDirProp?.orNull?.asFile?.path}")
+            logger.lifecycle("CMP outputDir wired for ${task.name} → ${outputDirProp.orNull?.asFile?.path}")
         } catch (e: Throwable) {
             logger.warn("Failed to set outputDir on ${task.name}: ${e.message}")
         }

--- a/shared/umbrella/build.gradle.kts
+++ b/shared/umbrella/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.gradle.api.file.DirectoryProperty
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.XCFramework
 import java.util.Properties
@@ -128,4 +129,24 @@ kotlin {
             implementation(libs.supabase.postgrest)
         }
     }
+}
+
+// CMP 1.10.3 + Gradle 9.3.1 호환 — SyncComposeResourcesForIosTask 의 outputDir 가
+// Xcode env 미감지 시 wiring 안 되어 Gradle strict validation 에 걸리는 회귀 우회.
+// 클래스가 internal 이라 reflection 으로 outputDir 프로퍼티 접근 + default 주입.
+// Xcode 빌드 시에는 plugin 이 실제 BUILT_PRODUCTS_DIR 로 덮어쓰므로 default 만 제공.
+afterEvaluate {
+    tasks.findByName("syncComposeResourcesForIos")?.let { task ->
+        try {
+            val outputDirProp = task::class.java.methods
+                .firstOrNull { it.name == "getOutputDir" && it.parameterCount == 0 }
+                ?.invoke(task) as? DirectoryProperty
+            outputDirProp?.set(
+                layout.buildDirectory.dir("compose/cmp-ios-resources/${task.name}")
+            )
+            logger.lifecycle("CMP outputDir wired for ${task.name} → ${outputDirProp?.orNull?.asFile?.path}")
+        } catch (e: Throwable) {
+            logger.warn("Failed to set outputDir on ${task.name}: ${e.message}")
+        }
+    } ?: logger.warn("syncComposeResourcesForIos task not found in afterEvaluate")
 }

--- a/shared/umbrella/build.gradle.kts
+++ b/shared/umbrella/build.gradle.kts
@@ -135,6 +135,12 @@ kotlin {
 // Xcode env 미감지 시 wiring 안 되어 Gradle strict validation 에 걸리는 회귀 우회.
 // 클래스가 internal 이라 reflection 으로 outputDir 프로퍼티 접근 + default 주입.
 // Xcode 빌드 시에는 plugin 이 실제 BUILT_PRODUCTS_DIR 로 덮어쓰므로 default 만 제공.
+//
+// TODO(#363): 임시 workaround. 다음 조건 충족 시 블록 전체 제거:
+//   1) CMP > 1.10.3 (outputDir 가 default value 를 갖도록 plugin 수정 시), 또는
+//   2) Gradle < 9 다운그레이드 (strict property validation 미적용).
+// 업그레이드 시: 본 블록 삭제 후 ./gradlew :shared:umbrella:embedAndSignAppleFrameworkForXcode
+// 가 outputDir 에러 없이 통과하는지 검증.
 afterEvaluate {
     // prefix 매칭 — 단일 syncComposeResourcesForIos 외에 syncComposeResourcesForIosArm64 /
     // syncComposeResourcesForIosX64 / syncComposeResourcesForIosSimulatorArm64 등 per-target

--- a/shared/umbrella/build.gradle.kts
+++ b/shared/umbrella/build.gradle.kts
@@ -136,7 +136,14 @@ kotlin {
 // 클래스가 internal 이라 reflection 으로 outputDir 프로퍼티 접근 + default 주입.
 // Xcode 빌드 시에는 plugin 이 실제 BUILT_PRODUCTS_DIR 로 덮어쓰므로 default 만 제공.
 afterEvaluate {
-    tasks.findByName("syncComposeResourcesForIos")?.let { task ->
+    // prefix 매칭 — 단일 syncComposeResourcesForIos 외에 syncComposeResourcesForIosArm64 /
+    // syncComposeResourcesForIosX64 / syncComposeResourcesForIosSimulatorArm64 등 per-target
+    // variant 가 있어도 모두 처리.
+    val matched = tasks.filter { it.name.startsWith("syncComposeResourcesForIos") }
+    if (matched.isEmpty()) {
+        logger.warn("syncComposeResourcesForIos* task not found in afterEvaluate")
+    }
+    matched.forEach { task ->
         try {
             val outputDirProp = task::class.java.methods
                 .firstOrNull { it.name == "getOutputDir" && it.parameterCount == 0 }
@@ -148,5 +155,5 @@ afterEvaluate {
         } catch (e: Throwable) {
             logger.warn("Failed to set outputDir on ${task.name}: ${e.message}")
         }
-    } ?: logger.warn("syncComposeResourcesForIos task not found in afterEvaluate")
+    }
 }


### PR DESCRIPTION
## Summary
Xcode → Product → Archive 시 \`PhaseScriptExecution failed\` 회귀.

**원인:** \`SyncComposeResourcesForIosTask.outputDir\` 가 CMP plugin 의 lazy provider 로 wiring 되는데, Gradle 9.3.1 의 strict property validation 이 configure time 에 값을 요구. CMP 1.10.3 에서 일부 경로에서 outputDir 가 resolved 되지 않아 검증 실패.

**우회:** \`shared/umbrella/build.gradle.kts\` 에 \`afterEvaluate\` 훅으로 \`outputDir\` 의 default 를 reflection 으로 주입. (internal class 라 직접 import 불가)

Xcode 빌드 시에는 plugin 이 실제 \`BUILT_PRODUCTS_DIR\` 로 덮어쓰므로 fallback 만 제공.

## Test plan
- [x] CLI 시뮬레이션 (\`./gradlew :shared:umbrella:embedAndSignAppleFrameworkForXcode\` + Xcode env) → outputDir 검증 통과
- [ ] Xcode Archive → ASC 업로드