### PR TITLE
Update: #363 Privacy Policy 제3자 동등 보호 확인 문구 추가

### DIFF
--- a/docs/site/privacy.html
+++ b/docs/site/privacy.html
@@ -65,6 +65,7 @@
                 </tbody>
             </table>
             <p><strong>AI 기능 사전 동의:</strong> 요약 / 받아쓰기 / 이미지 인식 기능은 입력 텍스트·오디오·이미지를 위 AI 서비스 (Google Gemini, Cloudflare Workers, Supadata) 로 전송합니다. 앱 최초 실행 시 동의 모달에서 사용자의 명시적 동의를 받으며, 동의하지 않으면 AI 기능이 비활성화됩니다. 일반 메모 작성 / 저장은 그대로 사용할 수 있습니다.</p>
+            <p><strong>제3자 보호 수준:</strong> 당사는 위에 명시된 모든 제3자 처리위탁사가 본 방침과 <strong>동등한 수준의 개인정보 보호 조치</strong>를 제공함을 확인하였습니다. 각 위탁사는 자체 개인정보 처리방침과 데이터 처리 약관(Data Processing Agreement), 그리고 국외 이전 시 표준계약조항(SCC) 등 적법한 보호 장치를 통해 사용자 데이터를 보호합니다. 사용자 데이터는 위 명시된 목적 외 광고 프로파일링 또는 모델 학습 등에 재사용되지 않으며, AI 처리위탁사(Google Gemini, Cloudflare Workers, Supadata)는 입력 데이터를 학습 목적으로 보관하지 않습니다.</p>
 
             <h3>4. 보관 기간</h3>
             <ul>
@@ -145,6 +146,7 @@
                 </tbody>
             </table>
             <p><strong>Prior consent for AI features:</strong> Summarisation, transcription, and image recognition features send your text, audio, and images to the AI processors above (Google Gemini, Cloudflare Workers, Supadata). On first launch the app shows an explicit consent modal; if you decline, AI features are disabled while regular memo creation and storage remain available.</p>
+            <p><strong>Equivalent third-party protection:</strong> We confirm that every third-party processor listed above provides <strong>data protection equivalent to this policy</strong>. Each processor is bound by its own privacy policy and a Data Processing Agreement, and any cross-border transfer is governed by Standard Contractual Clauses (SCC) or equivalent safeguards. User data is not reused for advertising profiling or model training beyond the stated purposes, and the AI processors (Google Gemini, Cloudflare Workers, Supadata) do not retain submitted data for training.</p>
 
             <h3>4. Retention</h3>
             <ul>
@@ -227,6 +229,7 @@
                 </tbody>
             </table>
             <p><strong>AI 機能の事前同意:</strong> 要約 / 文字起こし / 画像認識機能は、入力されたテキスト・音声・画像を上記 AI サービス(Google Gemini、Cloudflare Workers、Supadata)に送信します。アプリの初回起動時に同意モーダルでユーザーの明示的な同意を得ており、同意しない場合は AI 機能が無効化されます。通常のメモ作成 / 保存はそのままご利用いただけます。</p>
+            <p><strong>第三者の保護水準:</strong> 当社は上記すべての第三者委託先が本ポリシーと<strong>同等の個人情報保護措置</strong>を提供することを確認しています。各委託先は自社のプライバシーポリシーおよびデータ処理契約(DPA)に拘束され、国外移転時は標準契約条項(SCC)等の適法な保護措置が適用されます。ユーザーデータは記載された目的を超えて広告プロファイリングやモデル学習に再利用されることはなく、AI 委託先(Google Gemini、Cloudflare Workers、Supadata)は学習目的での入力データの保持を行いません。</p>
 
             <h3>4. 保存期間</h3>
             <ul>


### PR DESCRIPTION
## Summary

App Store Guideline **5.1.1(i) / 5.1.2(i)** 가 명시한 *"confirm any third party the app shares data with provides the same or equal protection"* 요구를 만족하기 위해 Privacy Policy 의 ko / en / ja 3개 섹션에 동등 보호 확인 문구를 추가.

이전 #365 / #366 머지에서 누락된 마지막 보강. 이 PR 머지 후 1.0(9) 빌드 업로드 → 재심사 진행.

## Changes

- `docs/site/privacy.html` 3개 섹션 (한국어 / English / 日本語) 모두 "AI 기능 사전 동의" 단락 바로 뒤에 **"제3자 보호 수준 / Equivalent third-party protection / 第三者の保護水準"** 문단 추가
  - 동등한 수준의 개인정보 보호 조치 제공 명시
  - 각 위탁사 DPA(Data Processing Agreement) + 국외 이전 시 SCC 등 적법한 보호 장치 적용
  - 사용자 데이터를 광고 프로파일링 / 모델 학습에 재사용 안 함
  - AI 위탁사(Gemini / Cloudflare Workers / Supadata) 입력 데이터 학습 목적 비보유

## Test Plan

- [ ] GitHub Pages 배포 후 `https://pecos.me/memozy/site/privacy.html` 에서 3개 언어 섹션 모두 새 문단 표시 확인
- [ ] 모바일 화면에서 줄바꿈 / 굵은 글씨 정상 렌더 확인
- [ ] App Store Connect 의 Privacy Policy URL 이 동일 URL 가리키는지 확인

## Related

- Refs #363
- 후속 작업: 1.0(9) iOS 빌드 업로드 (별도 이슈로 트래킹)

🤖 Generated with [Claude Code](https://claude.com/claude-code)