### PR TITLE
Fix: #375 메모 내용 존재 시 자동 커서 포커싱 비활성화

### DIFF
--- a/feature/memo-plain/impl/src/commonMain/kotlin/me/pecos/memozy/presentation/screen/memo/MemoScreen.kt
+++ b/feature/memo-plain/impl/src/commonMain/kotlin/me/pecos/memozy/presentation/screen/memo/MemoScreen.kt
@@ -662,10 +662,14 @@ fun MemoScreen(
                     .verticalScroll(scrollState)
                     .padding(horizontal = 32.dp, vertical = 16.dp)
             ) {
-                // 메모 진입 시 본문에 자동 포커스 + 키보드 표시 (노션 스타일) — 신규/편집 모두
+                // 메모 진입 시 본문 자동 포커스 + 키보드 표시 — 신규/빈 메모만 (#375).
+                // 기존 내용이 있으면 사용자가 본문을 먼저 읽을 수 있도록 자동 포커스 스킵.
                 LaunchedEffect(Unit) {
-                    kotlinx.coroutines.delay(100) // 컴포지션 안정화 대기
-                    try { bodyFocusRequester.requestFocus() } catch (_: Throwable) {}
+                    val hasExistingContent = existingMemo.content.isNotBlank() || existingMemo.name.isNotBlank()
+                    if (!hasExistingContent) {
+                        kotlinx.coroutines.delay(100) // 컴포지션 안정화 대기
+                        try { bodyFocusRequester.requestFocus() } catch (_: Throwable) {}
+                    }
                 }
 
                 BasicTextField(


### PR DESCRIPTION
## Summary
- 기존 내용이 있는 메모 진입 시 자동 키보드/커서 포커싱을 막아 사용자가 본문을 먼저 읽을 수 있도록 함
- 신규 또는 빈 메모는 기존 동작 유지 (노션 스타일 자동 포커스)

## Changes
- `feature/memo-plain/impl/.../MemoScreen.kt` 진입 `LaunchedEffect(Unit)` 안에 가드 추가
  - `existingMemo.content.isNotBlank() || existingMemo.name.isNotBlank()` 이면 `bodyFocusRequester.requestFocus()` 스킵
- 그 외 사용자 액션 기반 `requestFocus()` 호출(녹음 시작, 제목→본문 개행 이동, 빈 영역 탭, AI 채팅)은 그대로 유지

## Note
- 수정 대상이 `commonMain` Compose Multiplatform 코드라 Android/iOS 양쪽에 동시 적용됩니다 (이슈 체크박스 양쪽 모두 사실상 해결)
- 안드로이드 출시 임박 대응이며, iOS 는 별도 빌드/심사 진행 시 함께 반영됨

## Test Plan
- [ ] 기존 내용 있는 메모 진입 → 키보드 자동으로 안 올라옴, 본문 탭하면 그때 포커스/키보드 표시
- [ ] 신규 메모 작성 진입 → 키보드 자동 표시, 제목 또는 본문에 바로 입력 가능
- [ ] 빈 메모(제목/본문 모두 비어있는 기존 메모) 진입 → 자동 포커스 유지
- [ ] 녹음 시작/정지, 제목에서 Enter, AI 채팅 등 기존 포커스 이동 흐름 정상 동작 확인

Closes #375

🤖 Generated with [Claude Code](https://claude.com/claude-code)