### PR TITLE
Chore: 출시 준비 — AI 한도 복원 + versionCode 122 bump

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -51,8 +51,8 @@ android {
     }
 
     defaultConfig {
-        versionCode = 14
-        versionName = "1.2605.9"
+        versionCode = 122
+        versionName = "1.2605.10"
 
         val admobAppId = localProperties.getProperty(
             "admob.app.id",

--- a/feature/core/resource/src/commonMain/kotlin/me/pecos/memozy/presentation/theme/SubscriptionTier.kt
+++ b/feature/core/resource/src/commonMain/kotlin/me/pecos/memozy/presentation/theme/SubscriptionTier.kt
@@ -5,9 +5,8 @@ enum class SubscriptionTier {
 
     val dailyAiLimit: Int
         get() = when (this) {
-            // TEMP: 출시 전 테스트 기간 임시 한도. 출시 시 FREE=3 / PRO=30 으로 복원.
-            FREE -> 100
-            PRO -> 1000
+            FREE -> 3
+            PRO -> 30
         }
 
     val isPro: Boolean get() = this == PRO


### PR DESCRIPTION
## Summary
- Play Store nota 트랙 출시(1.2605.10 / versionCode 122) 를 위한 release prep
- 테스트용 임시 AI 한도(FREE=100 / PRO=1000) → 출시값(FREE=3 / PRO=30) 복원
- versionCode 14 → 122 (nota 트랙 마지막 121 다음), versionName 1.2605.9 → 1.2605.10

## Changes
- `feature/core/resource/.../SubscriptionTier.kt`
  - `dailyAiLimit` FREE=3, PRO=30 으로 복원 + TEMP 주석 제거 (#190)
- `app/build.gradle.kts`
  - `defaultConfig.versionCode` 14 → 122
  - `defaultConfig.versionName` "1.2605.9" → "1.2605.10"

## Test Plan
- [ ] AAB 빌드 성공: `.\gradlew.bat clean :app:bundleNotaRelease`
- [ ] 산출물 `app/build/outputs/bundle/notaRelease/app-nota-release.aab` 생성 확인
- [ ] Play Console nota 내부 테스트 트랙 업로드 — versionCode 122 정상 수락
- [ ] internal testing 다운로드 빌드로 디바이스 검증:
  - [ ] 무료 사용자 AI 호출 3회 후 한도 초과 모달 노출
  - [ ] PRO 사용자 30회 한도 동작
  - [ ] #375 자동 포커스 회귀 없음 (기존 메모 진입 시 키보드 자동 X)
  - [ ] 구글 로그인, 결제, 녹음/STT, 유튜브 요약 정상

## Note
- 이 PR 머지 후 `release/1.2605.0` 브랜치를 develop 기준으로 cut 해서 출시 빌드 보관/태그용으로 사용
- 출시 patch (긴급 fix) 는 해당 release 브랜치에서 cherry-pick / hotfix 흐름으로 관리

Closes #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)