### PR TITLE
Fix: #363 CMP outputDir .convention() 교체 — iPad launch crash

### DIFF
--- a/shared/umbrella/build.gradle.kts
+++ b/shared/umbrella/build.gradle.kts
@@ -133,8 +133,14 @@ kotlin {
 
 // CMP 1.10.3 + Gradle 9.3.1 호환 — SyncComposeResourcesForIosTask 의 outputDir 가
 // Xcode env 미감지 시 wiring 안 되어 Gradle strict validation 에 걸리는 회귀 우회.
-// 클래스가 internal 이라 reflection 으로 outputDir 프로퍼티 접근 + default 주입.
-// Xcode 빌드 시에는 plugin 이 실제 BUILT_PRODUCTS_DIR 로 덮어쓰므로 default 만 제공.
+// 클래스가 internal 이라 reflection 으로 outputDir 프로퍼티 접근 + fallback 주입.
+//
+// .convention() 사용 — Xcode 빌드 시 plugin 이 BUILT_PRODUCTS_DIR 로 .set() 하면
+// convention 은 무시되고 plugin 값이 우선. 일반 gradle 호출 (Xcode env 부재)
+// 에서만 convention 이 적용돼 strict validation 통과.
+// 과거에 .set() 으로 했을 때 plugin 의 BUILT_PRODUCTS_DIR 세팅까지 덮어써
+// app bundle 에 compose-resources 가 누락 → 첫 stringResource() 호출 시
+// MissingResourceException → SIGABRT (iPad 심사 build 10 launch crash 원인).
 //
 // TODO(#363): 임시 workaround. 다음 조건 충족 시 블록 전체 제거:
 //   1) CMP > 1.10.3 (outputDir 가 default value 를 갖도록 plugin 수정 시), 또는
@@ -162,10 +168,10 @@ afterEvaluate {
                 logger.warn("CMP outputDir 반환 타입 mismatch — CMP API 변경 가능, ${task.name} skip")
                 return@forEach
             }
-            outputDirProp.set(
+            outputDirProp.convention(
                 layout.buildDirectory.dir("compose/cmp-ios-resources/${task.name}")
             )
-            logger.lifecycle("CMP outputDir wired for ${task.name} → ${outputDirProp.orNull?.asFile?.path}")
+            logger.lifecycle("CMP outputDir convention wired for ${task.name}")
         } catch (e: Throwable) {
             logger.warn("Failed to set outputDir on ${task.name}: ${e.message}")
         }


### PR DESCRIPTION
## Summary
- `.set()` → `.convention()` 교체. 이전 `.set()` 이 CMP plugin 의 `BUILT_PRODUCTS_DIR` 세팅을 덮어써서 app bundle 에 `compose-resources/` 가 통째로 누락 → 첫 `stringResource()` 호출에서 `MissingResourceException` → SIGABRT.
- 이게 **App Store build 10 iPad 심사 거절** (`EXC_CRASH/SIGABRT` at `BaseComposeScene#setContent`) 의 진짜 원인.
- `.convention()` 은 plugin 의 `.set(BUILT_PRODUCTS_DIR)` 이 호출되면 양보하므로 Xcode 빌드 정상화. 동시에 Xcode env 부재인 plain gradle 호출에서는 fallback 으로 적용되어 **#363 strict validation 회귀 재발 없음**.

## 재현 / 검증
- 재현: iPad Air 11-inch (M3) 시뮬레이터, iPadOS 26.5 — 애플 심사기와 동일 기기. launch 즉시 SIGABRT 재현.
- 원인 트레이스: `kfun:org.jetbrains.compose.resources.DefaultIOsResourceReader.readData` → `MissingResourceException: .../values-en/strings.commonMain.cvr`
- bundle 검증: 수정 전 `find iosApp.app -name '*.cvr'` → 0개 / 수정 후 → 3개 (`values-en`, `values-ja`, `values` strings.commonMain.cvr).
- 수정 후 시뮬에서 `AiConsentGate` 다이얼로그 정상 표시 (스택 트레이스에서 죽었던 컴포저블).
- #363 회귀: `./gradlew :shared:umbrella:embedAndSignAppleFrameworkForXcode` Xcode env 없이 호출 시 `outputDir` 관련 strict validation 에러 안 남 (다른 `xcodeTargetArchs` 에러는 무관한 정상 동작).

## iPhone 통과 / iPad 거절 가설
- 동일 root cause 였으나 system locale 차이 (영어 `en_001` iPad 심사기 vs 다른 locale iPhone) 또는 build 10 에서 `AiConsentGate` 가 첫 진입 경로에 들어오게 바뀐 시점 변화로 iPad 에서만 노출.

## Test plan
- [x] iPad Air 11-inch (M3) 시뮬, iPadOS 26.5 — 정상 부팅 + 첫 화면 표시
- [ ] iPhone 16 Pro 시뮬 - 정상 부팅 확인 (회귀 체크)
- [ ] 실기기 (iPhone/iPad) launch 확인
- [ ] Archive 빌드 통과 확인 (#363 원래 잡으려던 회귀)
- [ ] App Store Connect 에 build 11 제출 (versionCode/CURRENT_PROJECT_VERSION bump 별도 PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)